### PR TITLE
[codex] Add install scripts and docs for native CLI delivery (#23)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,16 +13,105 @@ With the client SDKs, you can fetch released prompt specifications and use them 
 ====
 Windows::
 +
-`mvn clean verify`
+[source,powershell]
+----
+$script = irm https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.ps1
+& ([scriptblock]::Create($script))
+----
+
+Install a specific version:
+
+[source,powershell]
+----
+$script = irm https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.ps1
+& ([scriptblock]::Create($script)) -Version v0.1.0
+----
+
+Install to a custom directory:
+
+[source,powershell]
+----
+$script = irm https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.ps1
+& ([scriptblock]::Create($script)) -InstallDir "$HOME\bin"
+----
 
 Mac::
 +
-{empty}
+[source,bash]
+----
+curl -fsSL https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.sh | bash
+----
+
+Install a specific version:
+
+[source,bash]
+----
+curl -fsSL https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.sh | bash -s -- --version v0.1.0
+----
+
+Install to a custom directory:
+
+[source,bash]
+----
+curl -fsSL https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.sh | bash -s -- --install-dir "$HOME/bin"
+----
 
 Linux::
 +
-{empty}
+[source,bash]
+----
+curl -fsSL https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.sh | bash
+----
+
+Install a specific version:
+
+[source,bash]
+----
+curl -fsSL https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.sh | bash -s -- --version v0.1.0
+----
+
+Install to a custom directory:
+
+[source,bash]
+----
+curl -fsSL https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.sh | bash -s -- --install-dir "$HOME/bin"
+----
 ====
+
+Both installers fail fast on unsupported OS/architecture, missing assets, or checksum mismatch.
+
+=== Verify Installation
+
+[source,bash]
+----
+promptlm-cli --version
+----
+
+=== Update
+
+Re-run the installer with no version argument to install the latest release.
+
+=== Uninstall
+
+Unix:
+
+[source,bash]
+----
+rm -f ~/.local/bin/promptlm-cli
+----
+
+Windows:
+
+[source,powershell]
+----
+Remove-Item "$HOME\.local\bin\promptlm-cli.exe" -ErrorAction SilentlyContinue
+----
+
+=== Troubleshooting
+
+* If `promptlm-cli` is not found, add your install directory to `PATH`.
+* If installer download fails, verify the requested release tag exists and includes your platform archive.
+* If checksum validation fails, stop and retry; do not bypass checksum verification.
 
 == Get Started
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,110 @@
+<#
+Copyright 2026 promptLM
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [string]$InstallDir = $(if ($env:PROMPTLM_INSTALL_DIR) { $env:PROMPTLM_INSTALL_DIR } else { Join-Path $HOME ".local\bin" }),
+    [string]$Repository = "promptLM/promptlm-app"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-LatestVersion {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repo
+    )
+
+    $apiUrl = "https://api.github.com/repos/$Repo/releases/latest"
+    $release = Invoke-RestMethod -Uri $apiUrl -Headers @{ "Accept" = "application/vnd.github+json" }
+    if (-not $release.tag_name) {
+        throw "Unable to resolve latest release version from $apiUrl."
+    }
+    return ($release.tag_name -replace '^v', '')
+}
+
+function Resolve-Arch {
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+    switch ($arch) {
+        "X64" { return "x64" }
+        "Arm64" { return "arm64" }
+        default { throw "Unsupported architecture: $arch. Supported: x64, arm64." }
+    }
+}
+
+if (-not [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+    throw "Unsupported operating system. scripts/install.ps1 supports Windows only."
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = Resolve-LatestVersion -Repo $Repository
+}
+$Version = ($Version.Trim() -replace '^v', '')
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    throw "Resolved release version is empty."
+}
+
+$arch = Resolve-Arch
+$tag = "v$Version"
+$assetName = "promptlm-cli-windows-$arch.zip"
+$checksumsName = "SHA256SUMS"
+$baseUrl = "https://github.com/$Repository/releases/download/$tag"
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("promptlm-install-" + [Guid]::NewGuid().ToString("N"))
+$archivePath = Join-Path $tempRoot $assetName
+$checksumsPath = Join-Path $tempRoot $checksumsName
+$extractDir = Join-Path $tempRoot "extract"
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+try {
+    Invoke-WebRequest -Uri "$baseUrl/$assetName" -OutFile $archivePath
+    Invoke-WebRequest -Uri "$baseUrl/$checksumsName" -OutFile $checksumsPath
+
+    $checksumPattern = '^([A-Fa-f0-9]{64})\s+\*?' + [Regex]::Escape($assetName) + '$'
+    $checksumMatch = Select-String -Path $checksumsPath -Pattern $checksumPattern | Select-Object -First 1
+    if (-not $checksumMatch) {
+        throw "No checksum entry found for $assetName in $checksumsName."
+    }
+
+    $expectedHash = $checksumMatch.Matches[0].Groups[1].Value.ToLowerInvariant()
+    $actualHash = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($expectedHash -ne $actualHash) {
+        throw "Checksum mismatch for $assetName. Expected $expectedHash, got $actualHash."
+    }
+
+    Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+    $sourceBinary = Join-Path $extractDir "promptlm-cli.exe"
+    if (-not (Test-Path $sourceBinary)) {
+        throw "Expected binary not found in archive: $sourceBinary"
+    }
+
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    $targetBinary = Join-Path $InstallDir "promptlm-cli.exe"
+    Copy-Item -Path $sourceBinary -Destination $targetBinary -Force
+
+    & $targetBinary --version | Out-Null
+    Write-Host "Installed promptlm-cli $Version to $targetBinary"
+
+    $pathEntries = $env:PATH -split ';'
+    if ($pathEntries -notcontains $InstallDir) {
+        Write-Host "Add $InstallDir to your PATH to run promptlm-cli globally."
+    }
+}
+finally {
+    Remove-Item -Path $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Copyright 2025 promptLM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+REPOSITORY="promptLM/promptlm-app"
+VERSION=""
+INSTALL_DIR="${PROMPTLM_INSTALL_DIR:-$HOME/.local/bin}"
+
+usage() {
+  cat <<'USAGE'
+Install promptlm-cli from GitHub Releases.
+
+Usage:
+  install.sh [--version <version>] [--install-dir <dir>] [--repo <owner/name>]
+
+Options:
+  --version <version>      Release version to install (with or without "v" prefix).
+                           Defaults to latest published release.
+  --install-dir <dir>      Destination directory for promptlm-cli.
+                           Default: $PROMPTLM_INSTALL_DIR or ~/.local/bin
+  --repo <owner/name>      GitHub repository containing release assets.
+                           Default: promptLM/promptlm-app
+  -h, --help               Show this help message.
+USAGE
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+normalize_version() {
+  local raw="$1"
+  echo "${raw#v}"
+}
+
+detect_os() {
+  case "$(uname -s)" in
+    Linux)
+      echo "linux"
+      ;;
+    Darwin)
+      echo "macos"
+      ;;
+    *)
+      fail "Unsupported operating system: $(uname -s). Supported: Linux, macOS."
+      ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64 | amd64)
+      echo "x64"
+      ;;
+    arm64 | aarch64)
+      echo "arm64"
+      ;;
+    *)
+      fail "Unsupported architecture: $(uname -m). Supported: x64, arm64."
+      ;;
+  esac
+}
+
+resolve_latest_version() {
+  local api_url="https://api.github.com/repos/${REPOSITORY}/releases/latest"
+  local tag
+  tag="$(curl -fsSL "${api_url}" | sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n1)"
+  [[ -n "${tag}" ]] || fail "Unable to resolve latest release version from ${api_url}."
+  normalize_version "${tag}"
+}
+
+sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file}" | awk '{print $1}'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${file}" | awk '{print $1}'
+    return
+  fi
+  fail "No SHA-256 checksum command found. Install sha256sum or shasum."
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -gt 1 ]] || fail "Missing value for --version"
+      VERSION="$2"
+      shift 2
+      ;;
+    --install-dir)
+      [[ $# -gt 1 ]] || fail "Missing value for --install-dir"
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --repo)
+      [[ $# -gt 1 ]] || fail "Missing value for --repo"
+      REPOSITORY="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+require_cmd curl
+require_cmd tar
+require_cmd awk
+require_cmd sed
+require_cmd install
+
+OS="$(detect_os)"
+ARCH="$(detect_arch)"
+
+if [[ -z "${VERSION}" ]]; then
+  VERSION="$(resolve_latest_version)"
+else
+  VERSION="$(normalize_version "${VERSION}")"
+fi
+[[ -n "${VERSION}" ]] || fail "Resolved release version is empty."
+
+TAG="v${VERSION}"
+ASSET_NAME="promptlm-cli-${OS}-${ARCH}.tar.gz"
+CHECKSUMS_NAME="SHA256SUMS"
+BASE_URL="https://github.com/${REPOSITORY}/releases/download/${TAG}"
+
+TMP_DIR="$(mktemp -d)"
+ARCHIVE_PATH="${TMP_DIR}/${ASSET_NAME}"
+CHECKSUMS_PATH="${TMP_DIR}/${CHECKSUMS_NAME}"
+EXTRACT_DIR="${TMP_DIR}/extract"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+curl -fsSL --retry 3 --retry-delay 1 "${BASE_URL}/${ASSET_NAME}" -o "${ARCHIVE_PATH}" \
+  || fail "Unable to download ${ASSET_NAME} from ${BASE_URL}."
+curl -fsSL --retry 3 --retry-delay 1 "${BASE_URL}/${CHECKSUMS_NAME}" -o "${CHECKSUMS_PATH}" \
+  || fail "Unable to download ${CHECKSUMS_NAME} from ${BASE_URL}."
+
+EXPECTED_HASH="$(awk -v f="${ASSET_NAME}" '$2 == f {print $1}' "${CHECKSUMS_PATH}" | head -n1)"
+[[ -n "${EXPECTED_HASH}" ]] || fail "No checksum entry found for ${ASSET_NAME} in ${CHECKSUMS_NAME}."
+
+ACTUAL_HASH="$(sha256_file "${ARCHIVE_PATH}")"
+[[ "${EXPECTED_HASH}" == "${ACTUAL_HASH}" ]] \
+  || fail "Checksum mismatch for ${ASSET_NAME}. Expected ${EXPECTED_HASH}, got ${ACTUAL_HASH}."
+
+mkdir -p "${EXTRACT_DIR}"
+tar -xzf "${ARCHIVE_PATH}" -C "${EXTRACT_DIR}"
+
+SOURCE_BINARY="${EXTRACT_DIR}/promptlm-cli/promptlm-cli"
+[[ -f "${SOURCE_BINARY}" ]] || fail "Expected binary not found in archive: ${SOURCE_BINARY}"
+chmod +x "${SOURCE_BINARY}"
+
+mkdir -p "${INSTALL_DIR}"
+install -m 0755 "${SOURCE_BINARY}" "${INSTALL_DIR}/promptlm-cli"
+
+"${INSTALL_DIR}/promptlm-cli" --version >/dev/null \
+  || fail "Installed binary failed to execute: ${INSTALL_DIR}/promptlm-cli --version"
+
+echo "Installed promptlm-cli ${VERSION} to ${INSTALL_DIR}/promptlm-cli"
+case ":$PATH:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    echo "Add ${INSTALL_DIR} to your PATH to run promptlm-cli globally."
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add Unix installer at `scripts/install.sh` for Linux/macOS
- add Windows installer at `scripts/install.ps1`
- implement strict OS/arch detection and asset selection for native release artifacts
- add checksum verification against `SHA256SUMS` before install
- support version pinning (default latest release)
- support configurable install destination (`--install-dir` / `-InstallDir` and `PROMPTLM_INSTALL_DIR`)
- update `README.adoc` installation section with install, verify, update, uninstall, and troubleshooting guidance

## Why
Issue #23 requires installer hooks for native binaries with fail-fast behavior and checksum validation.

## Validation
- `bash -n scripts/install.sh`
- `./scripts/install.sh --help`
- PowerShell parser check could not be executed locally because `pwsh` is not available in this environment

Closes #23