### PR TITLE
feat(release): add two-phase release flow and completion semantics

### DIFF
--- a/apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptCommands.java
+++ b/apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptCommands.java
@@ -20,10 +20,12 @@ package dev.promptlm.cli;
 import dev.promptlm.lifecycle.PromptLifecycleFacade;
 import dev.promptlm.domain.promptspec.ChatCompletionRequest;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.ReleaseMetadata;
 import dev.promptlm.infrastructure.config.SerializingAppContext;
 import dev.promptlm.store.api.PromptStore;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.shell.core.command.annotation.Command;
 import org.springframework.shell.core.command.annotation.Option;
 import org.springframework.shell.core.command.availability.Availability;
@@ -138,7 +140,16 @@ public class PromptCommands {
             @Option(longName = "id", required = true) String id
     ) {
         PromptSpec promptSpec = promptLifecycleFacade.release(id);
-        return promptSpec.getVersion();
+        return renderReleaseResult(promptSpec);
+    }
+
+    @Command(name = "prompt release complete", availabilityProvider = "promptReleaseCompleteAvailabilityProvider")
+    public String completeRelease(
+            @Option(longName = "id", required = true) String id,
+            @Option(longName = "pr", required = true) String pullRequestReference
+    ) {
+        PromptSpec promptSpec = promptLifecycleFacade.completeRelease(id, pullRequestReference);
+        return renderReleaseResult(promptSpec);
     }
 
     private static String readSystemMessage(ChatCompletionRequest request) {
@@ -173,6 +184,26 @@ public class PromptCommands {
         return placeholders;
     }
 
+    private static String renderReleaseResult(PromptSpec promptSpec) {
+        ReleaseMetadata releaseMetadata = promptSpec.getReleaseMetadata();
+        if (releaseMetadata == null) {
+            throw new IllegalStateException("Release response is missing required release metadata");
+        }
+
+        if (releaseMetadata.isRequested()) {
+            StringBuilder builder = new StringBuilder("requested");
+            if (releaseMetadata.version() != null) {
+                builder.append(" ").append(releaseMetadata.version());
+            }
+            if (releaseMetadata.prNumber() != null) {
+                builder.append(" pr#").append(releaseMetadata.prNumber());
+            }
+            return builder.toString();
+        }
+
+        return releaseMetadata.version() != null ? releaseMetadata.version() : promptSpec.getVersion();
+    }
+
     @Component("promptAvailabilityProvider")
     static class PromptAvailabilityProvider implements AvailabilityProvider {
 
@@ -184,6 +215,10 @@ public class PromptCommands {
 
         @Override
         public Availability get() {
+            return resolveContextAvailability(contextProvider);
+        }
+
+        static Availability resolveContextAvailability(ObjectProvider<SerializingAppContext> contextProvider) {
             SerializingAppContext context;
             try {
                 context = contextProvider.getIfAvailable();
@@ -196,6 +231,40 @@ public class PromptCommands {
                     && context.getActiveProject().getRepoDir() != null
                     ? Availability.available()
                     : Availability.unavailable("the CLI is not connected to any store. Create a new or select an existing store");
+        }
+    }
+
+    @Component("promptReleaseCompleteAvailabilityProvider")
+    static class CompleteReleaseAvailabilityProvider implements AvailabilityProvider {
+
+        private static final String PR_TWO_PHASE_MODE = "pr_two_phase";
+
+        private final ObjectProvider<SerializingAppContext> contextProvider;
+        private final String releasePromotionMode;
+
+        CompleteReleaseAvailabilityProvider(
+                ObjectProvider<SerializingAppContext> contextProvider,
+                @Value("${promptlm.release.promotion.mode:direct}") String releasePromotionMode
+        ) {
+            this.contextProvider = contextProvider;
+            this.releasePromotionMode = releasePromotionMode;
+        }
+
+        @Override
+        public Availability get() {
+            Availability contextAvailability = PromptAvailabilityProvider.resolveContextAvailability(contextProvider);
+            if (!contextAvailability.isAvailable()) {
+                return contextAvailability;
+            }
+
+            return isPrTwoPhaseModeEnabled()
+                    ? Availability.available()
+                    : Availability.unavailable(
+                    "prompt release complete is only available when promptlm.release.promotion.mode=pr_two_phase");
+        }
+
+        private boolean isPrTwoPhaseModeEnabled() {
+            return PR_TWO_PHASE_MODE.equalsIgnoreCase(releasePromotionMode == null ? "" : releasePromotionMode.trim());
         }
     }
 

--- a/apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptCommands.java
+++ b/apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptCommands.java
@@ -24,7 +24,6 @@ import dev.promptlm.domain.promptspec.ReleaseMetadata;
 import dev.promptlm.infrastructure.config.SerializingAppContext;
 import dev.promptlm.store.api.PromptStore;
 import org.jspecify.annotations.NonNull;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.shell.core.command.annotation.Command;
 import org.springframework.shell.core.command.annotation.Option;
@@ -207,25 +206,18 @@ public class PromptCommands {
     @Component("promptAvailabilityProvider")
     static class PromptAvailabilityProvider implements AvailabilityProvider {
 
-        private final ObjectProvider<SerializingAppContext> contextProvider;
+        private final SerializingAppContext context;
 
-        PromptAvailabilityProvider(ObjectProvider<SerializingAppContext> contextProvider) {
-            this.contextProvider = contextProvider;
+        PromptAvailabilityProvider(SerializingAppContext context) {
+            this.context = context;
         }
 
         @Override
         public Availability get() {
-            return resolveContextAvailability(contextProvider);
+            return resolveContextAvailability(context);
         }
 
-        static Availability resolveContextAvailability(ObjectProvider<SerializingAppContext> contextProvider) {
-            SerializingAppContext context;
-            try {
-                context = contextProvider.getIfAvailable();
-            }
-            catch (RuntimeException ex) {
-                return Availability.unavailable("the CLI context could not be loaded");
-            }
+        static Availability resolveContextAvailability(SerializingAppContext context) {
             return context != null
                     && context.getActiveProject() != null
                     && context.getActiveProject().getRepoDir() != null
@@ -239,20 +231,20 @@ public class PromptCommands {
 
         private static final String PR_TWO_PHASE_MODE = "pr_two_phase";
 
-        private final ObjectProvider<SerializingAppContext> contextProvider;
+        private final SerializingAppContext context;
         private final String releasePromotionMode;
 
         CompleteReleaseAvailabilityProvider(
-                ObjectProvider<SerializingAppContext> contextProvider,
+                SerializingAppContext context,
                 @Value("${promptlm.release.promotion.mode:direct}") String releasePromotionMode
         ) {
-            this.contextProvider = contextProvider;
+            this.context = context;
             this.releasePromotionMode = releasePromotionMode;
         }
 
         @Override
         public Availability get() {
-            Availability contextAvailability = PromptAvailabilityProvider.resolveContextAvailability(contextProvider);
+            Availability contextAvailability = PromptAvailabilityProvider.resolveContextAvailability(context);
             if (!contextAvailability.isAvailable()) {
                 return contextAvailability;
             }

--- a/apps/promptlm-cli/src/main/resources/application.yml
+++ b/apps/promptlm-cli/src/main/resources/application.yml
@@ -7,6 +7,9 @@ watch:
 debug: false
 
 promptlm:
+  release:
+    promotion:
+      mode: ${PROMPTLM_RELEASE_PROMOTION_MODE:direct}
   store:
     local:
       workspace-root: ${user.home}

--- a/apps/promptlm-cli/src/test/java/dev/promptlm/cli/PromptCommandsTest.java
+++ b/apps/promptlm-cli/src/test/java/dev/promptlm/cli/PromptCommandsTest.java
@@ -26,7 +26,6 @@ import dev.promptlm.infrastructure.config.SerializingAppContext;
 import dev.promptlm.store.api.PromptStore;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.shell.core.command.availability.Availability;
 
 import java.nio.file.Path;
@@ -55,10 +54,7 @@ class PromptCommandsTest {
 
     @Test
     void createUsesBackendTemplateAsDraftSource() {
-        @SuppressWarnings("unchecked")
-        ObjectProvider<PromptLifecycleFacade> lifecycleProvider = mock(ObjectProvider.class);
         PromptLifecycleFacade lifecycleFacade = mock(PromptLifecycleFacade.class);
-        when(lifecycleProvider.getIfAvailable()).thenReturn(lifecycleFacade);
 
         PromptSpec.Placeholders placeholders = new PromptSpec.Placeholders();
         placeholders.setStartPattern("{{");
@@ -123,10 +119,7 @@ class PromptCommandsTest {
 
     @Test
     void createFailsWhenBackendTemplateRequestIsNotChatCompletion() {
-        @SuppressWarnings("unchecked")
-        ObjectProvider<PromptLifecycleFacade> lifecycleProvider = mock(ObjectProvider.class);
         PromptLifecycleFacade lifecycleFacade = mock(PromptLifecycleFacade.class);
-        when(lifecycleProvider.getIfAvailable()).thenReturn(lifecycleFacade);
 
         Request nonChatRequest = mock(Request.class);
         PromptSpec template = PromptSpec.builder()
@@ -155,29 +148,25 @@ class PromptCommandsTest {
     }
 
     @Test
-    void availabilityIsUnavailableWhenContextCannotBeLoaded() {
-        @SuppressWarnings("unchecked")
-        ObjectProvider<SerializingAppContext> contextProvider = mock(ObjectProvider.class);
-        when(contextProvider.getIfAvailable()).thenThrow(new IllegalStateException("boom"));
+    void availabilityIsUnavailableWhenNoActiveProjectIsSelected() {
+        SerializingAppContext context = mock(SerializingAppContext.class);
+        when(context.getActiveProject()).thenReturn(null);
 
-        Availability availability = new PromptCommands.PromptAvailabilityProvider(contextProvider).get();
+        Availability availability = new PromptCommands.PromptAvailabilityProvider(context).get();
 
         assertFalse(availability.isAvailable());
-        assertTrue(availability.reason().contains("could not be loaded"));
+        assertTrue(availability.reason().contains("not connected to any store"));
     }
 
     @Test
     void completeReleaseAvailabilityIsUnavailableOutsidePrTwoPhaseMode() {
-        @SuppressWarnings("unchecked")
-        ObjectProvider<SerializingAppContext> contextProvider = mock(ObjectProvider.class);
         SerializingAppContext context = mock(SerializingAppContext.class);
         ProjectSpec activeProject = new ProjectSpec();
         activeProject.setRepoDir(Path.of("/tmp/repo"));
         when(context.getActiveProject()).thenReturn(activeProject);
-        when(contextProvider.getIfAvailable()).thenReturn(context);
 
         Availability availability = new PromptCommands.CompleteReleaseAvailabilityProvider(
-                contextProvider,
+                context,
                 ReleaseMetadata.MODE_DIRECT
         ).get();
 
@@ -187,16 +176,13 @@ class PromptCommandsTest {
 
     @Test
     void completeReleaseAvailabilityIsAvailableInPrTwoPhaseMode() {
-        @SuppressWarnings("unchecked")
-        ObjectProvider<SerializingAppContext> contextProvider = mock(ObjectProvider.class);
         SerializingAppContext context = mock(SerializingAppContext.class);
         ProjectSpec activeProject = new ProjectSpec();
         activeProject.setRepoDir(Path.of("/tmp/repo"));
         when(context.getActiveProject()).thenReturn(activeProject);
-        when(contextProvider.getIfAvailable()).thenReturn(context);
 
         Availability availability = new PromptCommands.CompleteReleaseAvailabilityProvider(
-                contextProvider,
+                context,
                 ReleaseMetadata.MODE_PR_TWO_PHASE
         ).get();
 

--- a/apps/promptlm-cli/src/test/java/dev/promptlm/cli/PromptCommandsTest.java
+++ b/apps/promptlm-cli/src/test/java/dev/promptlm/cli/PromptCommandsTest.java
@@ -18,7 +18,9 @@ package dev.promptlm.cli;
 
 import dev.promptlm.domain.promptspec.ChatCompletionRequest;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.ReleaseMetadata;
 import dev.promptlm.domain.promptspec.Request;
+import dev.promptlm.domain.projectspec.ProjectSpec;
 import dev.promptlm.lifecycle.PromptLifecycleFacade;
 import dev.promptlm.infrastructure.config.SerializingAppContext;
 import dev.promptlm.store.api.PromptStore;
@@ -27,6 +29,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.shell.core.command.availability.Availability;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -161,5 +164,101 @@ class PromptCommandsTest {
 
         assertFalse(availability.isAvailable());
         assertTrue(availability.reason().contains("could not be loaded"));
+    }
+
+    @Test
+    void completeReleaseAvailabilityIsUnavailableOutsidePrTwoPhaseMode() {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<SerializingAppContext> contextProvider = mock(ObjectProvider.class);
+        SerializingAppContext context = mock(SerializingAppContext.class);
+        ProjectSpec activeProject = new ProjectSpec();
+        activeProject.setRepoDir(Path.of("/tmp/repo"));
+        when(context.getActiveProject()).thenReturn(activeProject);
+        when(contextProvider.getIfAvailable()).thenReturn(context);
+
+        Availability availability = new PromptCommands.CompleteReleaseAvailabilityProvider(
+                contextProvider,
+                ReleaseMetadata.MODE_DIRECT
+        ).get();
+
+        assertFalse(availability.isAvailable());
+        assertTrue(availability.reason().contains("promptlm.release.promotion.mode=pr_two_phase"));
+    }
+
+    @Test
+    void completeReleaseAvailabilityIsAvailableInPrTwoPhaseMode() {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<SerializingAppContext> contextProvider = mock(ObjectProvider.class);
+        SerializingAppContext context = mock(SerializingAppContext.class);
+        ProjectSpec activeProject = new ProjectSpec();
+        activeProject.setRepoDir(Path.of("/tmp/repo"));
+        when(context.getActiveProject()).thenReturn(activeProject);
+        when(contextProvider.getIfAvailable()).thenReturn(context);
+
+        Availability availability = new PromptCommands.CompleteReleaseAvailabilityProvider(
+                contextProvider,
+                ReleaseMetadata.MODE_PR_TWO_PHASE
+        ).get();
+
+        assertTrue(availability.isAvailable());
+    }
+
+    @Test
+    void releaseRendersRequestedStateWhenPrTwoPhaseIsPending() {
+        PromptLifecycleFacade lifecycleFacade = mock(PromptLifecycleFacade.class);
+        PromptSpec requested = PromptSpec.builder()
+                .withGroup("support")
+                .withName("welcome")
+                .withVersion("1.0.0")
+                .withRevision(0)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder().withType(ChatCompletionRequest.TYPE).build())
+                .build()
+                .withReleaseMetadata(new ReleaseMetadata(
+                        ReleaseMetadata.STATE_REQUESTED,
+                        ReleaseMetadata.MODE_PR_TWO_PHASE,
+                        "1.0.0",
+                        "support/welcome-v1.0.0",
+                        "release/support-welcome-1.0.0",
+                        11,
+                        "https://github.com/promptLM/promptlm-app/pull/11",
+                        false
+                ));
+        when(lifecycleFacade.release("prompt-id")).thenReturn(requested);
+
+        PromptCommands commands = new PromptCommands(mock(PromptRenderer.class), mock(PromptStore.class), lifecycleFacade);
+        String result = commands.release("prompt-id");
+
+        assertEquals("requested 1.0.0 pr#11", result);
+    }
+
+    @Test
+    void completeReleaseDelegatesToLifecycleFacade() {
+        PromptLifecycleFacade lifecycleFacade = mock(PromptLifecycleFacade.class);
+        PromptSpec released = PromptSpec.builder()
+                .withGroup("support")
+                .withName("welcome")
+                .withVersion("1.0.0")
+                .withRevision(0)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder().withType(ChatCompletionRequest.TYPE).build())
+                .build()
+                .withReleaseMetadata(new ReleaseMetadata(
+                        ReleaseMetadata.STATE_RELEASED,
+                        ReleaseMetadata.MODE_PR_TWO_PHASE,
+                        "1.0.0",
+                        "support/welcome-v1.0.0",
+                        "main",
+                        11,
+                        "https://github.com/promptLM/promptlm-app/pull/11",
+                        false
+                ));
+        when(lifecycleFacade.completeRelease("prompt-id", "11")).thenReturn(released);
+
+        PromptCommands commands = new PromptCommands(mock(PromptRenderer.class), mock(PromptStore.class), lifecycleFacade);
+        String result = commands.completeRelease("prompt-id", "11");
+
+        assertEquals("1.0.0", result);
+        verify(lifecycleFacade).completeRelease("prompt-id", "11");
     }
 }

--- a/apps/promptlm-webapp/src/main/resources/application.yml
+++ b/apps/promptlm-webapp/src/main/resources/application.yml
@@ -6,6 +6,9 @@ watch:
 debug: false
 
 promptlm:
+  release:
+    promotion:
+      mode: ${PROMPTLM_RELEASE_PROMOTION_MODE:direct}
   openapi:
     examples:
       enabled: false

--- a/build-full.sh
+++ b/build-full.sh
@@ -16,9 +16,30 @@
 set -e
 ./build-jdk.sh
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+if [ ! -f "$ENV_FILE" ]; then
+  ENV_FILE="$ROOT_DIR/.env.example"
+fi
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
 
 echo "acceptance test normal build"
 PROMPTLM_TEST_GROUPS=integration PROMPTLM_TEST_EXCLUDED_GROUPS= ./test.sh
 
 echo "Native build"
-set -a; source .env; set +a; mvn -DskipTests -Pnative -am -DskipTests package
+mvn -B -Pnative -pl apps/promptlm-cli,apps/promptlm-webapp -am -DskipTests package
+
+echo "acceptance test native smoke"
+mvn -B -f "$ROOT_DIR/acceptance-tests/pom.xml" \
+  -DfailIfNoTests=true \
+  -DfailIfNoSpecifiedTests=true \
+  -Dpromptlm.test.groups=native-smoke \
+  -Dpromptlm.test.excludedGroups= \
+  -Dpromptlm.test.cli.native.path="$ROOT_DIR/apps/promptlm-cli/target/promptlm-cli" \
+  -Dpromptlm.test.webapp.native.path="$ROOT_DIR/apps/promptlm-webapp/target/promptlm-webapp" \
+  test

--- a/components/promptlm-api-client/package.json
+++ b/components/promptlm-api-client/package.json
@@ -14,8 +14,8 @@
     "validate:asyncapi": "node ./scripts/validate-asyncapi.mjs",
     "generate": "npm run validate:asyncapi && npm run generate:asyncapi && npm run generate:openapi && npm run generate:client",
     "generate:asyncapi": "node ./scripts/generate-asyncapi.mjs",
-    "generate:openapi": "openapi-typescript ../../apps/promptlm-web-app/target/generated/openapi/promptlm-webapp-openapi.json --output ./src/generated/openapi.ts",
-    "generate:client": "openapi -i ../../apps/promptlm-web-app/target/generated/openapi/promptlm-webapp-openapi.json -o ./src/generated/client --client fetch",
+    "generate:openapi": "openapi-typescript ../../apps/promptlm-webapp/target/generated/openapi/promptlm-webapp-openapi.json --output ./src/generated/openapi.ts",
+    "generate:client": "openapi -i ../../apps/promptlm-webapp/target/generated/openapi/promptlm-webapp-openapi.json -o ./src/generated/client --client fetch",
     "build": "tsc -p tsconfig.json"
   },
   "devDependencies": {

--- a/components/promptlm-api-client/src/generated/client/core/OpenAPI.ts
+++ b/components/promptlm-api-client/src/generated/client/core/OpenAPI.ts
@@ -34,7 +34,7 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    BASE: 'http://localhost:9090',
+    BASE: 'http://localhost:59812',
     VERSION: '0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',

--- a/components/promptlm-api-client/src/generated/client/models/JsonNode.ts
+++ b/components/promptlm-api-client/src/generated/client/models/JsonNode.ts
@@ -19,11 +19,10 @@
 export type JsonNode = {
     number?: boolean;
     container?: boolean;
-    floatingPointNumber?: boolean;
-    missingNode?: boolean;
     nodeType?: JsonNode.nodeType;
     string?: boolean;
     integralNumber?: boolean;
+    missingNode?: boolean;
     valueNode?: boolean;
     pojo?: boolean;
     short?: boolean;
@@ -38,6 +37,7 @@ export type JsonNode = {
     textual?: boolean;
     boolean?: boolean;
     binary?: boolean;
+    floatingPointNumber?: boolean;
     empty?: boolean;
     array?: boolean;
     null?: boolean;

--- a/components/promptlm-api-client/src/generated/client/models/ProjectSpec.ts
+++ b/components/promptlm-api-client/src/generated/client/models/ProjectSpec.ts
@@ -134,13 +134,13 @@ export type ProjectSpec = {
      */
     promptCount?: number;
     /**
-     * Remote repository URL
-     */
-    repositoryUrl?: string;
-    /**
      * Local filesystem path where the repository is checked out
      */
     localPath?: string;
+    /**
+     * Remote repository URL
+     */
+    repositoryUrl?: string;
 };
 export namespace ProjectSpec {
     export enum healthStatus {

--- a/components/promptlm-api-client/src/generated/client/services/PromptSpecificationsService.ts
+++ b/components/promptlm-api-client/src/generated/client/services/PromptSpecificationsService.ts
@@ -130,9 +130,9 @@ export class PromptSpecificationsService {
     }
     /**
      * Release a new version of a prompt
-     * Creates a new, immutable release of a prompt specification with an incremented version number. The new version is based on the latest existing version of the prompt.
+     * Requests release for a prompt specification. In direct mode the response state is released. In pr_two_phase mode the response state is requested until /release/complete is called.
      * @param promptSpecId The unique identifier of the prompt specification to release.
-     * @returns PromptSpec The newly released prompt specification.
+     * @returns PromptSpec Release operation response as prompt specification. Header X-PromptLM-Release-State mirrors extensions.x-promptlm.release.state (requested|released).
      * @throws ApiError
      */
     public static releasePrompt(
@@ -143,6 +143,32 @@ export class PromptSpecificationsService {
             url: '/api/prompts/{promptSpecId}/release',
             path: {
                 'promptSpecId': promptSpecId,
+            },
+            errors: {
+                404: `Prompt specification with the given ID not found.`,
+            },
+        });
+    }
+    /**
+     * Complete a pending prompt release
+     * Finalizes a previously requested PR-mode release after validating the referenced pull request has been merged into main. Header X-PromptLM-Release-State is released on success.
+     * @param promptSpecId The unique identifier of the prompt specification to complete.
+     * @param pr Pull request number or URL for the pending release request.
+     * @returns PromptSpec Completed release response.
+     * @throws ApiError
+     */
+    public static completeReleasePrompt(
+        promptSpecId: string,
+        pr: string,
+    ): CancelablePromise<PromptSpec> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/prompts/{promptSpecId}/release/complete',
+            path: {
+                'promptSpecId': promptSpecId,
+            },
+            query: {
+                'pr': pr,
             },
             errors: {
                 404: `Prompt specification with the given ID not found.`,

--- a/components/promptlm-api-client/src/generated/openapi.ts
+++ b/components/promptlm-api-client/src/generated/openapi.ts
@@ -165,9 +165,29 @@ export interface paths {
         put?: never;
         /**
          * Release a new version of a prompt
-         * @description Creates a new, immutable release of a prompt specification with an incremented version number. The new version is based on the latest existing version of the prompt.
+         * @description Requests release for a prompt specification. In direct mode the response state is released. In pr_two_phase mode the response state is requested until /release/complete is called.
          */
         post: operations["releasePrompt"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/prompts/{promptSpecId}/release/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Complete a pending prompt release
+         * @description Finalizes a previously requested PR-mode release after validating the referenced pull request has been merged into main. Header X-PromptLM-Release-State is released on success.
+         */
+        post: operations["completeReleasePrompt"];
         delete?: never;
         options?: never;
         head?: never;
@@ -367,12 +387,11 @@ export interface components {
         JsonNode: {
             number?: boolean;
             container?: boolean;
-            floatingPointNumber?: boolean;
-            missingNode?: boolean;
             /** @enum {string} */
             nodeType?: "ARRAY" | "BINARY" | "BOOLEAN" | "MISSING" | "NULL" | "NUMBER" | "OBJECT" | "POJO" | "STRING";
             string?: boolean;
             integralNumber?: boolean;
+            missingNode?: boolean;
             valueNode?: boolean;
             pojo?: boolean;
             short?: boolean;
@@ -385,6 +404,7 @@ export interface components {
             textual?: boolean;
             boolean?: boolean;
             binary?: boolean;
+            floatingPointNumber?: boolean;
             empty?: boolean;
             array?: boolean;
             null?: boolean;
@@ -970,15 +990,15 @@ export interface components {
              */
             promptCount?: number;
             /**
-             * @description Remote repository URL
-             * @example https://github.com/my-org/my-repo
-             */
-            repositoryUrl?: string;
-            /**
              * @description Local filesystem path where the repository is checked out
              * @example /Users/me/repos/my-repo
              */
             localPath?: string;
+            /**
+             * @description Remote repository URL
+             * @example https://github.com/my-org/my-repo
+             */
+            repositoryUrl?: string;
         };
         /** @description Repository path */
         ConnectRepositoryRequest: {
@@ -1088,19 +1108,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "id": "11111111-1111-1111-1111-111111111111",
-                     *       "name": "Alpha Workspace",
-                     *       "description": "Primary prompt workspace",
-                     *       "promptCount": 2,
-                     *       "createdAt": "2025-01-20T08:00:00Z",
-                     *       "updatedAt": "2025-02-26T12:00:00Z",
-                     *       "localPath": "/repos/alpha",
-                     *       "repositoryUrl": "https://example.com/alpha.git",
-                     *       "healthStatus": "HEALTHY"
-                     *     }
-                     */
                     "application/json": components["schemas"]["ProjectSpec"];
                 };
             };
@@ -1134,7 +1141,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /** @example 33333333-3333-3333-3333-333333333333 */
                     "application/json": string;
                 };
             };
@@ -1159,19 +1165,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "id": "33333333-3333-3333-3333-333333333333",
-                     *       "name": "Gamma Workspace",
-                     *       "description": "Created project",
-                     *       "promptCount": 0,
-                     *       "createdAt": "2025-02-27T10:35:00Z",
-                     *       "updatedAt": "2025-02-27T10:35:00Z",
-                     *       "localPath": "/repos/gamma",
-                     *       "repositoryUrl": "https://example.com/gamma.git",
-                     *       "healthStatus": "HEALTHY"
-                     *     }
-                     */
                     "application/json": components["schemas"]["ProjectSpec"];
                 };
             };
@@ -1195,49 +1188,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "id": "prompt-101",
-                     *       "name": "customer_support",
-                     *       "group": "support",
-                     *       "description": "Handle customer support messages.",
-                     *       "status": "ACTIVE",
-                     *       "version": "1.0.0",
-                     *       "revision": 4,
-                     *       "createdAt": "2025-02-01T10:00:00Z",
-                     *       "updatedAt": "2025-02-20T10:00:00Z",
-                     *       "request": {
-                     *         "type": "chat/completion",
-                     *         "vendor": "openai",
-                     *         "model": "gpt-4o",
-                     *         "parameters": {
-                     *           "temperature": 0.6,
-                     *           "maxTokens": 256,
-                     *           "topP": 1
-                     *         },
-                     *         "messages": [
-                     *           {
-                     *             "role": "system",
-                     *             "content": "You are a prompt assistant."
-                     *           },
-                     *           {
-                     *             "role": "user",
-                     *             "content": "Summarize the request."
-                     *           }
-                     *         ]
-                     *       },
-                     *       "placeholders": {
-                     *         "startPattern": "{{",
-                     *         "endPattern": "}}",
-                     *         "list": [
-                     *           {
-                     *             "name": "user_name",
-                     *             "defaultValue": "Ada"
-                     *           }
-                     *         ]
-                     *       }
-                     *     }
-                     */
                     "application/json": components["schemas"]["PromptSpec"];
                 };
             };
@@ -1274,38 +1224,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "id": "prompt-201",
-                     *       "name": "quarterly_report",
-                     *       "group": "reporting",
-                     *       "description": "Draft a quarterly status update.",
-                     *       "version": "0.1.0",
-                     *       "revision": 2,
-                     *       "createdAt": "2025-02-27T09:00:00Z",
-                     *       "updatedAt": "2025-02-27T09:05:00Z",
-                     *       "request": {
-                     *         "type": "chat/completion",
-                     *         "vendor": "openai",
-                     *         "model": "gpt-4o",
-                     *         "parameters": {
-                     *           "temperature": 0.7,
-                     *           "maxTokens": 512,
-                     *           "topP": 1
-                     *         },
-                     *         "messages": [
-                     *           {
-                     *             "role": "system",
-                     *             "content": "You are a helpful assistant."
-                     *           },
-                     *           {
-                     *             "role": "user",
-                     *             "content": "Write the quarterly update."
-                     *           }
-                     *         ]
-                     *       }
-                     *     }
-                     */
                     "application/json": components["schemas"]["PromptSpec"];
                 };
             };
@@ -1402,19 +1320,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "id": "33333333-3333-3333-3333-333333333333",
-                     *       "name": "Gamma Workspace",
-                     *       "description": "Created project",
-                     *       "promptCount": 0,
-                     *       "createdAt": "2025-02-27T10:35:00Z",
-                     *       "updatedAt": "2025-02-27T10:35:00Z",
-                     *       "localPath": "/repos/gamma",
-                     *       "repositoryUrl": "https://example.com/gamma.git",
-                     *       "healthStatus": "HEALTHY"
-                     *     }
-                     */
                     "application/json": components["schemas"]["ProjectSpec"];
                 };
             };
@@ -1435,72 +1340,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example [
-                     *       {
-                     *         "id": "prompt-101",
-                     *         "name": "customer_support",
-                     *         "group": "support",
-                     *         "description": "Handle customer support messages.",
-                     *         "status": "ACTIVE",
-                     *         "version": "1.0.0",
-                     *         "revision": 4,
-                     *         "createdAt": "2025-02-01T10:00:00Z",
-                     *         "updatedAt": "2025-02-20T10:00:00Z",
-                     *         "request": {
-                     *           "type": "chat/completion",
-                     *           "vendor": "openai",
-                     *           "model": "gpt-4o",
-                     *           "parameters": {
-                     *             "temperature": 0.6,
-                     *             "maxTokens": 256,
-                     *             "topP": 1
-                     *           },
-                     *           "messages": [
-                     *             {
-                     *               "role": "system",
-                     *               "content": "You are a prompt assistant."
-                     *             },
-                     *             {
-                     *               "role": "user",
-                     *               "content": "Summarize the request."
-                     *             }
-                     *           ]
-                     *         }
-                     *       },
-                     *       {
-                     *         "id": "prompt-102",
-                     *         "name": "release_notes",
-                     *         "group": "release",
-                     *         "description": "Draft weekly release notes.",
-                     *         "status": "RETIRED",
-                     *         "version": "0.9.0",
-                     *         "revision": 2,
-                     *         "createdAt": "2025-01-15T09:00:00Z",
-                     *         "updatedAt": "2025-02-10T08:00:00Z",
-                     *         "request": {
-                     *           "type": "chat/completion",
-                     *           "vendor": "anthropic",
-                     *           "model": "claude-3-5",
-                     *           "parameters": {
-                     *             "temperature": 0.5,
-                     *             "maxTokens": 512,
-                     *             "topP": 0.9
-                     *           },
-                     *           "messages": [
-                     *             {
-                     *               "role": "system",
-                     *               "content": "You are a release note assistant."
-                     *             },
-                     *             {
-                     *               "role": "user",
-                     *               "content": "Draft release notes for this week."
-                     *             }
-                     *           ]
-                     *         }
-                     *       }
-                     *     ]
-                     */
                     "application/json": components["schemas"]["PromptSpec"][];
                 };
             };
@@ -1525,38 +1364,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "id": "prompt-201",
-                     *       "name": "quarterly_report",
-                     *       "group": "reporting",
-                     *       "description": "Draft a quarterly status update.",
-                     *       "version": "0.1.0",
-                     *       "revision": 1,
-                     *       "createdAt": "2025-02-27T09:00:00Z",
-                     *       "updatedAt": "2025-02-27T09:00:00Z",
-                     *       "request": {
-                     *         "type": "chat/completion",
-                     *         "vendor": "openai",
-                     *         "model": "gpt-4o",
-                     *         "parameters": {
-                     *           "temperature": 0.7,
-                     *           "maxTokens": 512,
-                     *           "topP": 1
-                     *         },
-                     *         "messages": [
-                     *           {
-                     *             "role": "system",
-                     *             "content": "You are a helpful assistant."
-                     *           },
-                     *           {
-                     *             "role": "user",
-                     *             "content": "Write the quarterly update."
-                     *           }
-                     *         ]
-                     *       }
-                     *     }
-                     */
                     "application/json": components["schemas"]["PromptSpec"];
                 };
             };
@@ -1583,45 +1390,47 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description The newly released prompt specification. */
+            /** @description Release operation response as prompt specification. Header X-PromptLM-Release-State mirrors extensions.x-promptlm.release.state (requested|released). */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "id": "prompt-101",
-                     *       "name": "customer_support",
-                     *       "group": "support",
-                     *       "description": "Handle customer support messages.",
-                     *       "status": "ACTIVE",
-                     *       "version": "1.0.1",
-                     *       "revision": 5,
-                     *       "createdAt": "2025-02-01T10:00:00Z",
-                     *       "updatedAt": "2025-02-27T10:20:00Z",
-                     *       "request": {
-                     *         "type": "chat/completion",
-                     *         "vendor": "openai",
-                     *         "model": "gpt-4o",
-                     *         "parameters": {
-                     *           "temperature": 0.6,
-                     *           "maxTokens": 256,
-                     *           "topP": 1
-                     *         },
-                     *         "messages": [
-                     *           {
-                     *             "role": "system",
-                     *             "content": "You are a prompt assistant."
-                     *           },
-                     *           {
-                     *             "role": "user",
-                     *             "content": "Summarize the request."
-                     *           }
-                     *         ]
-                     *       }
-                     *     }
-                     */
+                    "application/json": components["schemas"]["PromptSpec"];
+                };
+            };
+            /** @description Prompt specification with the given ID not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["PromptSpec"];
+                };
+            };
+        };
+    };
+    completeReleasePrompt: {
+        parameters: {
+            query: {
+                /** @description Pull request number or URL for the pending release request. */
+                pr: string;
+            };
+            header?: never;
+            path: {
+                /** @description The unique identifier of the prompt specification to complete. */
+                promptSpecId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Completed release response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
                     "application/json": components["schemas"]["PromptSpec"];
                 };
             };
@@ -1658,43 +1467,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "id": "prompt-101",
-                     *       "name": "customer_support",
-                     *       "group": "support",
-                     *       "description": "Handle customer support messages.",
-                     *       "status": "ACTIVE",
-                     *       "version": "1.0.0",
-                     *       "revision": 5,
-                     *       "createdAt": "2025-02-01T10:00:00Z",
-                     *       "updatedAt": "2025-02-27T10:15:00Z",
-                     *       "request": {
-                     *         "type": "chat/completion",
-                     *         "vendor": "openai",
-                     *         "model": "gpt-4o",
-                     *         "parameters": {
-                     *           "temperature": 0.6,
-                     *           "maxTokens": 256,
-                     *           "topP": 1
-                     *         },
-                     *         "messages": [
-                     *           {
-                     *             "role": "system",
-                     *             "content": "You are a prompt assistant."
-                     *           },
-                     *           {
-                     *             "role": "user",
-                     *             "content": "Summarize the request."
-                     *           }
-                     *         ]
-                     *       },
-                     *       "response": {
-                     *         "type": "chat/completion",
-                     *         "content": "Mock response for customer_support"
-                     *       }
-                     *     }
-                     */
                     "application/json": components["schemas"]["PromptSpec"];
                 };
             };
@@ -1704,7 +1476,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["PromptSpec"];
+                    "*/*": Record<string, never>;
                 };
             };
             /** @description Error executing the prompt */
@@ -1713,7 +1485,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["PromptSpec"];
+                    "*/*": Record<string, never>;
                 };
             };
         };
@@ -1737,43 +1509,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "id": "prompt-101",
-                     *       "name": "customer_support",
-                     *       "group": "support",
-                     *       "description": "Handle customer support messages.",
-                     *       "status": "ACTIVE",
-                     *       "version": "1.0.0",
-                     *       "revision": 5,
-                     *       "createdAt": "2025-02-01T10:00:00Z",
-                     *       "updatedAt": "2025-02-27T10:15:00Z",
-                     *       "request": {
-                     *         "type": "chat/completion",
-                     *         "vendor": "openai",
-                     *         "model": "gpt-4o",
-                     *         "parameters": {
-                     *           "temperature": 0.6,
-                     *           "maxTokens": 256,
-                     *           "topP": 1
-                     *         },
-                     *         "messages": [
-                     *           {
-                     *             "role": "system",
-                     *             "content": "You are a prompt assistant."
-                     *           },
-                     *           {
-                     *             "role": "user",
-                     *             "content": "Summarize the request."
-                     *           }
-                     *         ]
-                     *       },
-                     *       "response": {
-                     *         "type": "chat/completion",
-                     *         "content": "Mock response for customer_support"
-                     *       }
-                     *     }
-                     */
                     "application/json": components["schemas"]["PromptSpec"];
                 };
             };
@@ -1783,7 +1518,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["PromptSpec"];
+                    "*/*": Record<string, never>;
                 };
             };
             /** @description Error executing the prompt */
@@ -1792,7 +1527,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["PromptSpec"];
+                    "*/*": Record<string, never>;
                 };
             };
         };
@@ -1812,20 +1547,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example [
-                     *       {
-                     *         "id": "owner-1",
-                     *         "displayName": "PromptLM",
-                     *         "type": "ORGANIZATION"
-                     *       },
-                     *       {
-                     *         "id": "owner-2",
-                     *         "displayName": "FK",
-                     *         "type": "USER"
-                     *       }
-                     *     ]
-                     */
                     "application/json": components["schemas"]["RepositoryOwner"][];
                 };
             };
@@ -1846,32 +1567,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example [
-                     *       {
-                     *         "id": "11111111-1111-1111-1111-111111111111",
-                     *         "name": "Alpha Workspace",
-                     *         "description": "Primary prompt workspace",
-                     *         "promptCount": 2,
-                     *         "createdAt": "2025-01-20T08:00:00Z",
-                     *         "updatedAt": "2025-02-26T12:00:00Z",
-                     *         "localPath": "/repos/alpha",
-                     *         "repositoryUrl": "https://example.com/alpha.git",
-                     *         "healthStatus": "HEALTHY"
-                     *       },
-                     *       {
-                     *         "id": "22222222-2222-2222-2222-222222222222",
-                     *         "name": "Beta Workspace",
-                     *         "description": "Experimental prompts",
-                     *         "promptCount": 1,
-                     *         "createdAt": "2025-01-10T08:00:00Z",
-                     *         "updatedAt": "2025-02-24T12:00:00Z",
-                     *         "localPath": "/repos/beta",
-                     *         "repositoryUrl": "https://example.com/beta.git",
-                     *         "healthStatus": "HEALTHY"
-                     *       }
-                     *     ]
-                     */
                     "application/json": components["schemas"]["ProjectSpec"][];
                 };
             };
@@ -1912,19 +1607,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "totalPrompts": 2,
-                     *       "activePrompts": 1,
-                     *       "retiredPrompts": 0,
-                     *       "countByGroup": {
-                     *         "support": 1,
-                     *         "release": 1
-                     *       },
-                     *       "activeProjects": 2,
-                     *       "lastUpdated": "2025-02-27T10:30:00Z"
-                     *     }
-                     */
                     "application/json": components["schemas"]["PromptStats"];
                 };
             };
@@ -1968,26 +1650,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "vendors": [
-                     *         {
-                     *           "vendor": "anthropic",
-                     *           "displayName": "Anthropic",
-                     *           "active": true,
-                     *           "models": [
-                     *             {
-                     *               "id": "claude-3-5",
-                     *               "displayName": "claude-3-5",
-                     *               "source": "config",
-                     *               "supportsChat": true,
-                     *               "requiresConfig": false
-                     *             }
-                     *           ]
-                     *         }
-                     *       ]
-                     *     }
-                     */
                     "application/json": components["schemas"]["ModelCatalogResponse"];
                 };
             };

--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/events/PromptReleaseRequestedEvent.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/events/PromptReleaseRequestedEvent.java
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-package dev.promptlm;
+package dev.promptlm.domain.events;
 
-import dev.promptlm.store.github.GitHubProperties;
-import dev.promptlm.store.github.ReleasePromotionProperties;
-import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import dev.promptlm.domain.promptspec.PromptSpec;
 
-@Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties({GitHubProperties.class, ReleasePromotionProperties.class})
-public class GitHubPromptStoreConfig {
+/**
+ * Domain event fired when a release request is created but not yet promoted to main.
+ */
+public record PromptReleaseRequestedEvent(PromptSpec promptSpec) {
 }

--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/events/PromptReleasedEvent.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/events/PromptReleasedEvent.java
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-package dev.promptlm;
+package dev.promptlm.domain.events;
 
-import dev.promptlm.store.github.GitHubProperties;
-import dev.promptlm.store.github.ReleasePromotionProperties;
-import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import dev.promptlm.domain.promptspec.PromptSpec;
 
-@Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties({GitHubProperties.class, ReleasePromotionProperties.class})
-public class GitHubPromptStoreConfig {
+/**
+ * Domain event fired when a release has been fully promoted to main and considered completed.
+ */
+public record PromptReleasedEvent(PromptSpec promptSpec) {
 }

--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpec.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpec.java
@@ -436,6 +436,11 @@ public class PromptSpec {
         return Objects.equals(this.extensions, updated) ? this : withExtensions(updated);
     }
 
+    public PromptSpec withReleaseMetadata(ReleaseMetadata releaseMetadata) {
+        Map<String, JsonNode> updated = ReleaseExtensions.withRelease(this.extensions, releaseMetadata);
+        return Objects.equals(this.extensions, updated) ? this : withExtensions(updated);
+    }
+
     public PromptSpec withExtensions(Map<String, JsonNode> extensions) {
         return Objects.equals(this.extensions, extensions)
                 ? this
@@ -552,6 +557,14 @@ public class PromptSpec {
             return EvaluationResults.notConfigured();
         }
         return EvaluationExtensions.readResults(extensions);
+    }
+
+    @JsonIgnore
+    public ReleaseMetadata getReleaseMetadata() {
+        if (extensions.isEmpty()) {
+            return null;
+        }
+        return ReleaseExtensions.readRelease(extensions);
     }
 
     public Map<String, JsonNode> getExtensions() {

--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/ReleaseExtensions.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/ReleaseExtensions.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.domain.promptspec;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+import dev.promptlm.domain.ObjectMapperFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class ReleaseExtensions {
+
+    public static final String KEY = "x-promptlm";
+    private static final String RELEASE_KEY = "release";
+    private static final ObjectMapper MAPPER = ObjectMapperFactory.createJsonMapper();
+
+    private ReleaseExtensions() {
+    }
+
+    public static ReleaseMetadata readRelease(Map<String, JsonNode> extensions) {
+        if (extensions == null || extensions.isEmpty()) {
+            return null;
+        }
+        JsonNode promptlm = extensions.get(KEY);
+        if (promptlm == null || !promptlm.isObject()) {
+            return null;
+        }
+        JsonNode releaseNode = promptlm.get(RELEASE_KEY);
+        if (releaseNode == null || releaseNode.isNull()) {
+            return null;
+        }
+        return MAPPER.convertValue(releaseNode, ReleaseMetadata.class);
+    }
+
+    public static Map<String, JsonNode> withRelease(Map<String, JsonNode> extensions, ReleaseMetadata metadata) {
+        Map<String, JsonNode> updated = (extensions == null || extensions.isEmpty())
+                ? new LinkedHashMap<>()
+                : new LinkedHashMap<>(extensions);
+
+        ObjectNode promptlmNode = resolvePromptlmNode(updated);
+        if (metadata == null) {
+            promptlmNode.remove(RELEASE_KEY);
+        } else {
+            promptlmNode.set(RELEASE_KEY, MAPPER.valueToTree(metadata));
+        }
+
+        if (promptlmNode.isEmpty()) {
+            updated.remove(KEY);
+        } else {
+            updated.put(KEY, promptlmNode);
+        }
+
+        return updated;
+    }
+
+    private static ObjectNode resolvePromptlmNode(Map<String, JsonNode> extensions) {
+        JsonNode existing = extensions.get(KEY);
+        if (existing != null && existing.isObject()) {
+            return ((ObjectNode) existing).deepCopy();
+        }
+        return MAPPER.createObjectNode();
+    }
+}

--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/ReleaseMetadata.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/ReleaseMetadata.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.domain.promptspec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Release operation metadata attached under PromptSpec extensions.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ReleaseMetadata(
+        @JsonProperty("state") String state,
+        @JsonProperty("mode") String mode,
+        @JsonProperty("version") String version,
+        @JsonProperty("tag") String tag,
+        @JsonProperty("branch") String branch,
+        @JsonProperty("prNumber") Integer prNumber,
+        @JsonProperty("prUrl") String prUrl,
+        @JsonProperty("existing") Boolean existing) {
+
+    public static final String STATE_REQUESTED = "requested";
+    public static final String STATE_RELEASED = "released";
+    public static final String MODE_DIRECT = "direct";
+    public static final String MODE_PR_TWO_PHASE = "pr_two_phase";
+
+    public ReleaseMetadata {
+        if (state == null || state.isBlank()) {
+            throw new IllegalArgumentException("Release metadata state must not be blank");
+        }
+        if (mode == null || mode.isBlank()) {
+            throw new IllegalArgumentException("Release metadata mode must not be blank");
+        }
+    }
+
+    public boolean isRequested() {
+        return STATE_REQUESTED.equalsIgnoreCase(state);
+    }
+
+    public boolean isReleased() {
+        return STATE_RELEASED.equalsIgnoreCase(state);
+    }
+}

--- a/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/PromptSpecExtensionsTest.java
+++ b/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/PromptSpecExtensionsTest.java
@@ -120,6 +120,59 @@ class PromptSpecExtensionsTest {
     }
 
     @Test
+    void releaseMetadataIsStoredUnderPromptlmExtension() throws Exception {
+        PromptSpec spec = PromptSpec.builder()
+                .withGroup("group")
+                .withName("name")
+                .withVersion("1.0.0")
+                .withRevision(1)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder()
+                        .withType(ChatCompletionRequest.TYPE)
+                        .build())
+                .build()
+                .withReleaseMetadata(new ReleaseMetadata(
+                        ReleaseMetadata.STATE_REQUESTED,
+                        ReleaseMetadata.MODE_PR_TWO_PHASE,
+                        "1.0.0",
+                        "prompt-v1.0.0",
+                        "release/prompt-1.0.0",
+                        42,
+                        "https://github.com/org/repo/pull/42",
+                        false
+                ));
+
+        assertThat(spec.getReleaseMetadata()).isNotNull();
+        assertThat(spec.getReleaseMetadata().state()).isEqualTo(ReleaseMetadata.STATE_REQUESTED);
+        assertThat(spec.getReleaseMetadata().mode()).isEqualTo(ReleaseMetadata.MODE_PR_TWO_PHASE);
+        assertThat(spec.getExtensions()).containsKey("x-promptlm");
+        assertThat(spec.getExtension("x-promptlm").get("release").get("prNumber").asInt()).isEqualTo(42);
+    }
+
+    @Test
+    void deserializesReleaseMetadataFromPromptlmExtension() throws Exception {
+        String yaml = """
+                name: Sample
+                group: sample
+                version: 1.0
+                extensions:
+                  x-promptlm:
+                    release:
+                      state: released
+                      mode: direct
+                      version: 1.0
+                      tag: sample-v1.0
+                      existing: true
+                """;
+
+        PromptSpec spec = mapper.readValue(yaml, PromptSpec.class);
+
+        assertThat(spec.getReleaseMetadata()).isNotNull();
+        assertThat(spec.getReleaseMetadata().isReleased()).isTrue();
+        assertThat(spec.getReleaseMetadata().existing()).isTrue();
+    }
+
+    @Test
     void rejectsNonExtensionKey() {
         ObjectNode node = mapper.createObjectNode().put("foo", "bar");
         Map<String, JsonNode> extensions = Map.of("custom", node);

--- a/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/PromptLifecycleFacade.java
+++ b/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/PromptLifecycleFacade.java
@@ -62,4 +62,8 @@ public class PromptLifecycleFacade {
     public PromptSpec release(String id) {
         return lifecycleService.releasePrompt(id);
     }
+
+    public PromptSpec completeRelease(String id, String pullRequestReference) {
+        return lifecycleService.completeReleasePrompt(id, pullRequestReference);
+    }
 }

--- a/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleService.java
+++ b/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleService.java
@@ -17,10 +17,13 @@
 package dev.promptlm.lifecycle.application;
 
 import dev.promptlm.domain.events.PromptCreatedEvent;
+import dev.promptlm.domain.events.PromptReleaseRequestedEvent;
+import dev.promptlm.domain.events.PromptReleasedEvent;
 import dev.promptlm.domain.promptspec.ChatCompletionRequest;
 import dev.promptlm.domain.promptspec.EvaluationStatus;
 import dev.promptlm.domain.promptspec.EvaluationResults;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.ReleaseMetadata;
 import dev.promptlm.domain.promptspec.Request;
 import dev.promptlm.release.PromptReleaseException;
 import dev.promptlm.release.PromptReleasePolicy;
@@ -219,7 +222,35 @@ class DefaultPromptLifecycleService implements PromptLifecycleService {
         }
 
         releasePolicy.validateRelease(promptSpec);
-        return repository.release(promptSpec);
+        PromptSpec released = repository.requestRelease(promptSpec);
+        ReleaseMetadata releaseMetadata = requireReleaseMetadata(released);
+        if (releaseMetadata.isRequested()) {
+            eventPublisher.publishEvent(new PromptReleaseRequestedEvent(released));
+        } else if (releaseMetadata.isReleased()) {
+            eventPublisher.publishEvent(new PromptReleasedEvent(released));
+        } else {
+            throw new PromptReleaseException("Unsupported release state '%s' for prompt %s"
+                    .formatted(releaseMetadata.state(), promptSpecId));
+        }
+
+        return released;
+    }
+
+    @Override
+    public PromptSpec completeReleasePrompt(String promptSpecId, String pullRequestReference) {
+        repository.getLatestVersion(promptSpecId)
+                .orElseThrow(() -> new PromptReleaseException(
+                        "Could not find prompt %s".formatted(promptSpecId)));
+
+        PromptSpec released = repository.completeRelease(promptSpecId, pullRequestReference);
+        ReleaseMetadata releaseMetadata = requireReleaseMetadata(released);
+        if (!releaseMetadata.isReleased()) {
+            throw new PromptReleaseException("Release completion for prompt %s did not return state 'released'"
+                    .formatted(promptSpecId));
+        }
+
+        eventPublisher.publishEvent(new PromptReleasedEvent(released));
+        return released;
     }
 
     @Override
@@ -262,5 +293,14 @@ class DefaultPromptLifecycleService implements PromptLifecycleService {
         Map<String, JsonNode> merged = new LinkedHashMap<>(base);
         merged.putAll(updates);
         return merged;
+    }
+
+    private static ReleaseMetadata requireReleaseMetadata(PromptSpec promptSpec) {
+        ReleaseMetadata metadata = promptSpec.getReleaseMetadata();
+        if (metadata == null) {
+            throw new PromptReleaseException(
+                    "Release operation did not provide required release metadata for prompt %s".formatted(promptSpec.getId()));
+        }
+        return metadata;
     }
 }

--- a/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/PromptLifecycleService.java
+++ b/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/PromptLifecycleService.java
@@ -44,5 +44,7 @@ public interface PromptLifecycleService {
 
     PromptSpec releasePrompt(String promptSpecId);
 
+    PromptSpec completeReleasePrompt(String promptSpecId, String pullRequestReference);
+
     PromptSpec persistEvaluatedPrompt(PromptSpec evaluatedPromptSpec);
 }

--- a/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/PromptStorePort.java
+++ b/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/PromptStorePort.java
@@ -32,5 +32,11 @@ public interface PromptStorePort {
 
     Optional<PromptSpec> getLatestVersion(String promptSpecId);
 
-    PromptSpec release(PromptSpec promptSpec);
+    PromptSpec requestRelease(PromptSpec promptSpec);
+
+    PromptSpec completeRelease(String promptSpecId, String pullRequestReference);
+
+    default PromptSpec release(PromptSpec promptSpec) {
+        return requestRelease(promptSpec);
+    }
 }

--- a/components/promptlm-lifecycle/src/test/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleServiceTest.java
+++ b/components/promptlm-lifecycle/src/test/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleServiceTest.java
@@ -24,6 +24,7 @@ import dev.promptlm.domain.promptspec.EvaluationResult;
 import dev.promptlm.domain.promptspec.EvaluationResults;
 import dev.promptlm.domain.promptspec.EvaluationStatus;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.ReleaseMetadata;
 import dev.promptlm.release.PromptReleaseException;
 import dev.promptlm.release.PromptReleasePolicy;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +35,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import dev.promptlm.domain.events.PromptCreatedEvent;
+import dev.promptlm.domain.events.PromptReleaseRequestedEvent;
+import dev.promptlm.domain.events.PromptReleasedEvent;
 
 import java.util.List;
 import java.util.Map;
@@ -367,14 +370,31 @@ class DefaultPromptLifecycleServiceTest {
                 .withId(PROMPT_ID)
                 .withRevision(4)
                 .withEvaluationResults(EvaluationResults.notConfigured());
+        PromptSpec released = evaluated
+                .withVersion("1.0.0")
+                .withReleaseMetadata(new ReleaseMetadata(
+                        ReleaseMetadata.STATE_RELEASED,
+                        ReleaseMetadata.MODE_DIRECT,
+                        "1.0.0",
+                        "group/name-v1.0.0",
+                        "main",
+                        null,
+                        null,
+                        false
+                ));
 
         when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(evaluated));
+        when(repository.requestRelease(evaluated)).thenReturn(released);
 
         PromptSpec promptSpec = service.releasePrompt(PROMPT_ID);
+        assertThat(promptSpec).isEqualTo(released);
 
         verify(releasePolicy).validateRelease(evaluated);
         verify(repository).getLatestVersion(PROMPT_ID);
-        verify(repository).release(evaluated);
+        verify(repository).requestRelease(evaluated);
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue()).isInstanceOf(PromptReleasedEvent.class);
     }
 
     @Test
@@ -411,31 +431,54 @@ class DefaultPromptLifecycleServiceTest {
     }
 
     @Test
-    void releasePromptIgnoresEvaluationWhenNotConfigured() {
+    void releasePromptPublishesRequestedEventWhenStoreReturnsRequestedState() {
         EvaluationResults notConfigured = new EvaluationResults(List.of(), EvaluationStatus.NOT_CONFIGURED);
         PromptSpec evaluated = basePromptSpec.withEvaluationResults(notConfigured);
-        PromptSpec released = evaluated.withVersion("1.0.0");
+        PromptSpec requested = evaluated.withReleaseMetadata(new ReleaseMetadata(
+                ReleaseMetadata.STATE_REQUESTED,
+                ReleaseMetadata.MODE_PR_TWO_PHASE,
+                "1.0.0",
+                "group/name-v1.0.0",
+                "release/group-name-1.0.0",
+                11,
+                "https://github.com/promptLM/promptlm-app/pull/11",
+                false
+        ));
 
         when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(evaluated));
-        when(repository.release(evaluated)).thenReturn(released);
+        when(repository.requestRelease(evaluated)).thenReturn(requested);
 
         PromptSpec result = service.releasePrompt(PROMPT_ID);
 
-        assertThat(result).isEqualTo(released);
+        assertThat(result).isEqualTo(requested);
 
         verify(releasePolicy).validateRelease(evaluated);
         verify(repository).getLatestVersion(PROMPT_ID);
-        verify(repository).release(evaluated);
+        verify(repository).requestRelease(evaluated);
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue()).isInstanceOf(PromptReleaseRequestedEvent.class);
     }
 
     @Test
     void releasePromptReturnsReleasedSpecWhenEvaluationSuccessful() {
         EvaluationResults successResults = new EvaluationResults(List.of(new EvaluationResult("eval", "type", 1.0, null, null)));
         PromptSpec evaluated = basePromptSpec.withEvaluationResults(successResults);
-        PromptSpec released = evaluated.withVersion("1.0.0");
+        PromptSpec released = evaluated
+                .withVersion("1.0.0")
+                .withReleaseMetadata(new ReleaseMetadata(
+                        ReleaseMetadata.STATE_RELEASED,
+                        ReleaseMetadata.MODE_DIRECT,
+                        "1.0.0",
+                        "group/name-v1.0.0",
+                        "main",
+                        null,
+                        null,
+                        false
+                ));
 
         when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(evaluated));
-        when(repository.release(evaluated)).thenReturn(released);
+        when(repository.requestRelease(evaluated)).thenReturn(released);
 
         PromptSpec result = service.releasePrompt(PROMPT_ID);
 
@@ -443,6 +486,71 @@ class DefaultPromptLifecycleServiceTest {
 
         verify(releasePolicy).validateRelease(evaluated);
         verify(repository).getLatestVersion(PROMPT_ID);
-        verify(repository).release(evaluated);
+        verify(repository).requestRelease(evaluated);
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue()).isInstanceOf(PromptReleasedEvent.class);
+    }
+
+    @Test
+    void releasePromptThrowsWhenStoreResponseOmitsReleaseMetadata() {
+        EvaluationResults successResults = new EvaluationResults(List.of(new EvaluationResult("eval", "type", 1.0, null, null)));
+        PromptSpec evaluated = basePromptSpec.withEvaluationResults(successResults);
+
+        when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(evaluated));
+        when(repository.requestRelease(evaluated)).thenReturn(evaluated.withVersion("1.0.0"));
+
+        assertThatThrownBy(() -> service.releasePrompt(PROMPT_ID))
+                .isInstanceOf(PromptReleaseException.class)
+                .hasMessageContaining("required release metadata");
+
+        verify(releasePolicy).validateRelease(evaluated);
+        verify(repository).requestRelease(evaluated);
+    }
+
+    @Test
+    void completeReleasePromptPublishesReleasedEvent() {
+        PromptSpec existing = basePromptSpec.withId(PROMPT_ID);
+        PromptSpec released = existing.withReleaseMetadata(new ReleaseMetadata(
+                ReleaseMetadata.STATE_RELEASED,
+                ReleaseMetadata.MODE_PR_TWO_PHASE,
+                "1.0.0",
+                "group/name-v1.0.0",
+                "main",
+                11,
+                "https://github.com/promptLM/promptlm-app/pull/11",
+                false
+        ));
+        when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(existing));
+        when(repository.completeRelease(PROMPT_ID, "11")).thenReturn(released);
+
+        PromptSpec result = service.completeReleasePrompt(PROMPT_ID, "11");
+
+        assertThat(result).isEqualTo(released);
+        verify(repository).completeRelease(PROMPT_ID, "11");
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue()).isInstanceOf(PromptReleasedEvent.class);
+    }
+
+    @Test
+    void completeReleasePromptFailsWhenStoreDoesNotReturnReleasedState() {
+        PromptSpec existing = basePromptSpec.withId(PROMPT_ID);
+        PromptSpec requested = existing.withReleaseMetadata(new ReleaseMetadata(
+                ReleaseMetadata.STATE_REQUESTED,
+                ReleaseMetadata.MODE_PR_TWO_PHASE,
+                "1.0.0",
+                "group/name-v1.0.0",
+                "release/group-name-1.0.0",
+                11,
+                "https://github.com/promptLM/promptlm-app/pull/11",
+                false
+        ));
+        when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(existing));
+        when(repository.completeRelease(PROMPT_ID, "11")).thenReturn(requested);
+
+        assertThatThrownBy(() -> service.completeReleasePrompt(PROMPT_ID, "11"))
+                .isInstanceOf(PromptReleaseException.class)
+                .hasMessageContaining("did not return state 'released'");
     }
 }

--- a/components/promptlm-openapi-examples/src/main/resources/openapi/examples/manifest.json
+++ b/components/promptlm-openapi-examples/src/main/resources/openapi/examples/manifest.json
@@ -8,6 +8,7 @@
     {"method": "POST", "path": "/api/prompts/execute", "status": "200", "example": "openapi/examples/prompt-execute.json"},
     {"method": "GET", "path": "/api/prompts/template", "status": "200", "example": "openapi/examples/prompt-template.json"},
     {"method": "POST", "path": "/api/prompts/{promptSpecId}/release", "status": "200", "example": "openapi/examples/prompt-release.json"},
+    {"method": "POST", "path": "/api/prompts/{promptSpecId}/release/complete", "status": "200", "example": "openapi/examples/prompt-release-complete.json"},
     {"method": "GET", "path": "/api/prompts/stats", "status": "200", "example": "openapi/examples/prompt-stats.json"},
     {"method": "GET", "path": "/api/llm/catalog", "status": "200", "example": "openapi/examples/model-catalog.json"},
     {"method": "GET", "path": "/api/store", "status": "200", "example": "openapi/examples/project-active.json"},

--- a/components/promptlm-openapi-examples/src/main/resources/openapi/examples/prompt-release-complete.json
+++ b/components/promptlm-openapi-examples/src/main/resources/openapi/examples/prompt-release-complete.json
@@ -4,8 +4,8 @@
   "group": "support",
   "description": "Handle customer support messages",
   "status": "ACTIVE",
-  "version": "1.0.1-SNAPSHOT",
-  "revision": 5,
+  "version": "1.0.1",
+  "revision": 0,
   "createdAt": "2025-02-01T10:00:00Z",
   "updatedAt": "2025-02-27T10:20:00Z",
   "request": {
@@ -31,11 +31,11 @@
   "extensions": {
     "x-promptlm": {
       "release": {
-        "state": "requested",
+        "state": "released",
         "mode": "pr_two_phase",
         "version": "1.0.1",
         "tag": "support/customer_support-v1.0.1",
-        "branch": "release/support-customer_support-1.0.1",
+        "branch": "main",
         "prNumber": 17,
         "prUrl": "https://github.com/promptLM/promptlm-app/pull/17",
         "existing": false

--- a/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/PromptStore.java
+++ b/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/PromptStore.java
@@ -97,7 +97,19 @@ public interface PromptStore {
     /**
      * Create a new release with incremented version number.
      */
-    PromptSpec release(PromptSpec completed);
+    PromptSpec requestRelease(PromptSpec completed);
+
+    /**
+     * Finalize a previously requested release after promotion to main has been confirmed.
+     */
+    PromptSpec completeRelease(String promptSpecId, String pullRequestReference);
+
+    /**
+     * Backwards-compatible alias for requesting a release.
+     */
+    default PromptSpec release(PromptSpec completed) {
+        return requestRelease(completed);
+    }
 
     Optional<PromptSpec> findPromptSpec(String group, String name);
 

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/Git.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/Git.java
@@ -294,7 +294,7 @@ class Git {
         try (org.eclipse.jgit.api.Git git = org.eclipse.jgit.api.Git.open(repo)) {
             String branch = git.getRepository().getBranch();
             String remoteUrl = git.getRepository().getConfig().getString("remote", "origin", "url");
-            log.debug("DEBUG: Attempting to pushAll to: " + remoteUrl);
+            log.debug("Pushing to remote: {}", remoteUrl);
             RefSpec refSpec = new RefSpec(branch + ":refs/heads/" + branch);
             PushCommand pushCommand = git.push()
                     .setRemote("origin")
@@ -313,7 +313,7 @@ class Git {
         }
     }
 
-    private void assertPushSucceeded(Iterable<PushResult> pushResults, String remoteUrl) {
+    private static void assertPushSucceeded(Iterable<PushResult> pushResults, String remoteUrl) {
         for (PushResult pushResult : pushResults) {
             for (RemoteRefUpdate update : pushResult.getRemoteUpdates()) {
                 RemoteRefUpdate.Status status = update.getStatus();
@@ -336,33 +336,6 @@ class Git {
         }
     }
 
-    private PushCommand createDefaultPushCommand(org.eclipse.jgit.api.Git git) {
-        PushCommand pushCommand = git.push()
-                .setRemote("origin")
-                .setPushTags();
-        
-        // Force JGit to use HTTP transport without smart HTTP detection
-        try {
-            // Get the remote URL and log it for debugging
-            String remoteUrl = git.getRepository().getConfig().getString("remote", "origin", "url");
-            log.debug("DEBUG: Pushing to remote URL: " + remoteUrl);
-            
-            // Try to force non-smart HTTP by setting transport config
-            pushCommand.setTransportConfigCallback(transport -> {
-                if (transport instanceof org.eclipse.jgit.transport.TransportHttp) {
-                    org.eclipse.jgit.transport.TransportHttp httpTransport = (org.eclipse.jgit.transport.TransportHttp) transport;
-                    // Disable smart HTTP and use traditional HTTP
-                    log.debug("DEBUG: Configuring HTTP transport for traditional Git HTTP");
-                }
-            });
-            
-        } catch (Exception e) {
-            log.warn("Could not configure transport, using default: " + e.getMessage());
-        }
-        
-        return pushCommand;
-    }
-
     private void fetch(org.eclipse.jgit.api.Git git) throws GitAPIException {
         String remoteUrl = git.getRepository().getConfig().getString("remote", "origin", "url");
         var fetchCommand = git.fetch().setRemote("origin");
@@ -378,7 +351,13 @@ class Git {
             return null;
         }
         if (!trustedRemotePolicy.isTrustedForCredentialForwarding(remoteUrl)) {
-            log.warn("Skipping credential forwarding for untrusted remote: {}", remoteUrl);
+            if (trustedRemotePolicy.isHttpOrHttpsRemote(remoteUrl)) {
+                throw new GitException(
+                        "Cannot push to " + remoteUrl + ": the remote host does not match the configured " +
+                        "backend (promptlm.store.remote.base-url). " +
+                        "Ensure REPO_REMOTE_URL points to the Git server hosting your repositories."
+                );
+            }
             return null;
         }
         return credentialsProvider.getCredentials();
@@ -394,7 +373,7 @@ class Git {
 
     public void checkoutOrCreateBranch(String newBranchName, File repo) {
         try (org.eclipse.jgit.api.Git git = org.eclipse.jgit.api.Git.open(repo)) {
-            boolean branchExists = git.branchList().call().stream().anyMatch(b -> b.getName().equals(newBranchName));
+            boolean branchExists = git.branchList().call().stream().anyMatch(b -> b.getName().equals("refs/heads/" + newBranchName));
             if (branchExists) {
                 checkout(git, newBranchName);
                 fetch(git);
@@ -501,6 +480,22 @@ class Git {
             git.tag().setName(tag).call();
         } catch (IOException | GitAPIException e) {
             throw new GitException("Failed to tag " + tag, e);
+        }
+    }
+
+    public boolean tagExists(String tag, File repo) {
+        String expectedRef = "refs/tags/" + tag;
+        try (org.eclipse.jgit.api.Git git = org.eclipse.jgit.api.Git.open(repo)) {
+            return git.tagList().call().stream()
+                    .anyMatch(ref -> expectedRef.equals(ref.getName()));
+        } catch (IOException | GitAPIException e) {
+            throw new GitException("Failed to inspect tags in " + repo, e);
+        }
+    }
+
+    public void tagIfMissing(String tag, File repo) {
+        if (!tagExists(tag, repo)) {
+            tag(tag, repo);
         }
     }
 }

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubPromptStore.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubPromptStore.java
@@ -23,15 +23,23 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import dev.promptlm.domain.AppContext;
 import dev.promptlm.domain.promptspec.ChatCompletionRequest;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.ReleaseMetadata;
 import dev.promptlm.store.api.PromptStore;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -40,12 +48,19 @@ public class GitHubPromptStore implements PromptStore {
 
     public static final String MAIN_BRANCH = "main";
     public static final String DEV_BRANCH = "development";
+    private static final String RELEASE_BRANCH_PREFIX = "release/";
+    private static final Pattern PR_REFERENCE_NUMBER = Pattern.compile("^(\\d+)$");
+    private static final Pattern PR_REFERENCE_URL = Pattern.compile(".*/pull/(\\d+).*");
+
     private final ObjectMapper modelYamlMapper;
     private final GitFileNameStrategy fileNameStrategy;
     private final Git git;
     private final AppContext appContext;
     private final VersioningStrategy versioningStrategy;
     private final GitRepositoryMetadata repositoryMetadata;
+    private final ReleasePromotionProperties releasePromotionProperties;
+    private final ReleasePullRequestGateway releasePullRequestGateway;
+    private final Map<String, ReentrantLock> releaseLocks = new ConcurrentHashMap<>();
 
     public GitHubPromptStore(@Qualifier("modelYamlMapper") ObjectMapper modelYamlMapper,
                              GitFileNameStrategy fileNameStrategy,
@@ -53,12 +68,41 @@ public class GitHubPromptStore implements PromptStore {
                              AppContext appContext,
                              IntVersioningStrategy versioningStrategy,
                              GitRepositoryMetadata repositoryMetadata) {
+        this(
+                modelYamlMapper,
+                fileNameStrategy,
+                git,
+                appContext,
+                versioningStrategy,
+                repositoryMetadata,
+                defaultReleaseProperties(),
+                null
+        );
+    }
+
+    @Autowired
+    public GitHubPromptStore(@Qualifier("modelYamlMapper") ObjectMapper modelYamlMapper,
+                             GitFileNameStrategy fileNameStrategy,
+                             Git git,
+                             AppContext appContext,
+                             IntVersioningStrategy versioningStrategy,
+                             GitRepositoryMetadata repositoryMetadata,
+                             ReleasePromotionProperties releasePromotionProperties,
+                             ReleasePullRequestGateway releasePullRequestGateway) {
         this.modelYamlMapper = modelYamlMapper;
         this.versioningStrategy = versioningStrategy;
         this.fileNameStrategy = fileNameStrategy;
         this.git = git;
         this.appContext = appContext;
         this.repositoryMetadata = repositoryMetadata;
+        this.releasePromotionProperties = releasePromotionProperties;
+        this.releasePullRequestGateway = releasePullRequestGateway;
+    }
+
+    private static ReleasePromotionProperties defaultReleaseProperties() {
+        ReleasePromotionProperties properties = new ReleasePromotionProperties();
+        properties.setMode(ReleasePromotionMode.DIRECT.value());
+        return properties;
     }
 
     /**
@@ -240,37 +284,77 @@ public class GitHubPromptStore implements PromptStore {
     }
 
     @Override
-    public PromptSpec release(PromptSpec promptSpec) {
+    public PromptSpec requestRelease(PromptSpec promptSpec) {
+        if (promptSpec == null) {
+            throw new IllegalArgumentException("Prompt spec must not be null");
+        }
 
-        // checkout main branch
-        File repo = checkoutMainBranch();
+        return withPromptReleaseLock(promptSpec.getId(), () -> requestReleaseUnlocked(promptSpec));
+    }
 
-        PromptSpec releasedPrompt = promptSpec;
+    @Override
+    public PromptSpec completeRelease(String promptSpecId, String pullRequestReference) {
+        if (promptSpecId == null || promptSpecId.isBlank()) {
+            throw new IllegalArgumentException("promptSpecId must not be blank");
+        }
+        if (pullRequestReference == null || pullRequestReference.isBlank()) {
+            throw new IllegalArgumentException("pullRequestReference must not be blank");
+        }
+
+        return withPromptReleaseLock(promptSpecId, () -> completeReleaseUnlocked(promptSpecId, pullRequestReference));
+    }
+
+    private PromptSpec requestReleaseUnlocked(PromptSpec promptSpec) {
+        ReleasePromotionMode mode = releasePromotionProperties.resolveMode();
+        return switch (mode) {
+            case DIRECT -> requestDirectRelease(promptSpec);
+            case PR_TWO_PHASE -> requestPrTwoPhaseRelease(promptSpec);
+        };
+    }
+
+    private PromptSpec requestDirectRelease(PromptSpec promptSpec) {
+        Path repoPath = requireActiveRepoPath();
+        File repo = repoPath.toFile();
+        PromptSpec releaseCandidate = releaseCandidate(promptSpec);
+        String releaseVersion = releaseCandidate.getVersion();
+        String releaseTag = versioningStrategy.calculateReleaseTag(releaseCandidate);
+
+        if (git.tagExists(releaseTag, repo)) {
+            return releaseCandidate.withReleaseMetadata(releasedMetadata(
+                    ReleaseMetadata.MODE_DIRECT,
+                    releaseVersion,
+                    releaseTag,
+                    MAIN_BRANCH,
+                    null,
+                    null,
+                    true
+            ));
+        }
+
         try {
-            // cherry-pick prompt from development onto main branch
+            checkoutMainBranch(repo);
             cherryPickFromDevelopmentBranch(promptSpec, repo);
-
-            // set release version
-            String releaseVersion = versioningStrategy.calculateReleaseVersion(promptSpec);
-            releasedPrompt = promptSpec.withVersion(releaseVersion).withRevision(0);
-            storePrompt(releasedPrompt, "Released", false);
-            String tag = versioningStrategy.calculateReleaseTag(releasedPrompt);
-            String message = "Release " + tag;
-            Path repoPath = appContext.getActiveProject().getRepoDir();
-            writeMetadata(repoPath, releasedPrompt, tag, releaseVersion);
-            git.addAllAndCommit(repo, message);
-            git.tag(tag, repo);
+            PromptSpec releasedPrompt = storePrompt(releaseCandidate, "Released", false);
+            writeMetadata(repoPath, releasedPrompt, releaseTag, releaseVersion);
+            git.addAllAndCommit(repo, "Release " + releaseTag);
+            git.tagIfMissing(releaseTag, repo);
             git.pushAll(repo);
 
-            // checkout development for next snapshot
             git.checkoutBranch(DEV_BRANCH, repo);
-
-            // set next snapshot version
             String newVersion = versioningStrategy.getNextDevelopmentVersion(releasedPrompt);
             PromptSpec developmentPrompt = releasedPrompt.withVersion(newVersion);
             storePrompt(developmentPrompt, "New development version.", true);
             git.pushAll(repo);
-            return developmentPrompt;
+
+            return releasedPrompt.withReleaseMetadata(releasedMetadata(
+                    ReleaseMetadata.MODE_DIRECT,
+                    releaseVersion,
+                    releaseTag,
+                    MAIN_BRANCH,
+                    null,
+                    null,
+                    false
+            ));
         } catch (Exception e) {
             throw new GitException("Failed to release prompt %s".formatted(promptSpec.getId()), e);
         } finally {
@@ -278,14 +362,307 @@ public class GitHubPromptStore implements PromptStore {
         }
     }
 
+    private PromptSpec requestPrTwoPhaseRelease(PromptSpec promptSpec) {
+        Path repoPath = requireActiveRepoPath();
+        File repo = repoPath.toFile();
+        String repositoryFullName = git.getFullName(repoPath);
+        ReleasePullRequestGateway pullRequestGateway = requireReleasePullRequestGateway();
+        pullRequestGateway.validatePrModeCapabilities(repositoryFullName);
+
+        PromptSpec releaseCandidate = releaseCandidate(promptSpec);
+        String releaseVersion = releaseCandidate.getVersion();
+        String releaseTag = versioningStrategy.calculateReleaseTag(releaseCandidate);
+        String releaseBranch = buildReleaseBranchName(promptSpec.getId(), releaseVersion);
+
+        if (git.tagExists(releaseTag, repo)) {
+            return releaseCandidate.withReleaseMetadata(releasedMetadata(
+                    ReleaseMetadata.MODE_PR_TWO_PHASE,
+                    releaseVersion,
+                    releaseTag,
+                    MAIN_BRANCH,
+                    null,
+                    null,
+                    true
+            ));
+        }
+
+        List<ReleasePullRequest> openReleasePullRequests = pullRequestGateway.listOpenPullRequests(repositoryFullName, MAIN_BRANCH).stream()
+                .filter(pr -> isReleaseBranchForPrompt(pr.headRef(), promptSpec.getId()))
+                .toList();
+        Optional<ReleasePullRequest> sameVersionRequest = openReleasePullRequests.stream()
+                .filter(pr -> releaseBranch.equals(pr.headRef()))
+                .findFirst();
+        if (sameVersionRequest.isPresent()) {
+            ReleasePullRequest existing = sameVersionRequest.get();
+            return releaseCandidate.withReleaseMetadata(requestedMetadata(
+                    releaseVersion,
+                    releaseTag,
+                    releaseBranch,
+                    existing.number(),
+                    existing.url(),
+                    true
+            ));
+        }
+        Optional<ReleasePullRequest> conflictingRequest = openReleasePullRequests.stream().findFirst();
+        if (conflictingRequest.isPresent()) {
+            throw new GitException(
+                    "Conflicting pending release request for prompt %s already exists on branch %s (PR #%d)."
+                            .formatted(promptSpec.getId(), conflictingRequest.get().headRef(), conflictingRequest.get().number())
+            );
+        }
+
+        try {
+            git.checkoutBranch(DEV_BRANCH, repo);
+            git.checkoutOrCreateBranch(releaseBranch, repo);
+            storePrompt(releaseCandidate, "Release requested", false);
+            git.pushAll(repo);
+
+            ReleasePullRequest created = pullRequestGateway.createReleasePullRequest(
+                    repositoryFullName,
+                    releaseBranch,
+                    MAIN_BRANCH,
+                    "Release %s %s".formatted(promptSpec.getId(), releaseVersion),
+                    "Release request for prompt %s version %s".formatted(promptSpec.getId(), releaseVersion)
+            );
+            return releaseCandidate.withReleaseMetadata(requestedMetadata(
+                    releaseVersion,
+                    releaseTag,
+                    releaseBranch,
+                    created.number(),
+                    created.url(),
+                    false
+            ));
+        } catch (Exception e) {
+            throw new GitException("Failed to request release for prompt %s".formatted(promptSpec.getId()), e);
+        } finally {
+            git.checkoutBranch(DEV_BRANCH, repo);
+        }
+    }
+
+    private PromptSpec completeReleaseUnlocked(String promptSpecId, String pullRequestReference) {
+        if (releasePromotionProperties.resolveMode() != ReleasePromotionMode.PR_TWO_PHASE) {
+            throw new IllegalStateException(
+                    "Release completion is only available when promptlm.release.promotion.mode=pr_two_phase"
+            );
+        }
+
+        Path repoPath = requireActiveRepoPath();
+        File repo = repoPath.toFile();
+        String repositoryFullName = git.getFullName(repoPath);
+        ReleasePullRequestGateway pullRequestGateway = requireReleasePullRequestGateway();
+        pullRequestGateway.validatePrModeCapabilities(repositoryFullName);
+
+        int pullRequestNumber = parsePullRequestReference(pullRequestReference);
+        ReleasePullRequest pullRequest = pullRequestGateway.getPullRequest(repositoryFullName, pullRequestNumber);
+        if (!MAIN_BRANCH.equals(pullRequest.baseRef())) {
+            throw new GitException(
+                    "Pull request #%d must target %s but targets %s"
+                            .formatted(pullRequestNumber, MAIN_BRANCH, pullRequest.baseRef())
+            );
+        }
+
+        String releaseVersion = extractReleaseVersionFromBranch(promptSpecId, pullRequest.headRef())
+                .orElseThrow(() -> new GitException(
+                        "Pull request #%d does not match release branch pattern for prompt %s"
+                                .formatted(pullRequestNumber, promptSpecId)
+                ));
+        PromptSpec releaseCandidate = releaseCandidate(requirePromptById(promptSpecId).withVersion(releaseVersion));
+        String releaseTag = versioningStrategy.calculateReleaseTag(releaseCandidate);
+
+        if (git.tagExists(releaseTag, repo)) {
+            return releaseCandidate.withReleaseMetadata(releasedMetadata(
+                    ReleaseMetadata.MODE_PR_TWO_PHASE,
+                    releaseVersion,
+                    releaseTag,
+                    MAIN_BRANCH,
+                    pullRequest.number(),
+                    pullRequest.url(),
+                    true
+            ));
+        }
+
+        if (!pullRequest.merged()) {
+            throw new GitException(
+                    "Pull request #%d has not been merged into %s"
+                            .formatted(pullRequestNumber, MAIN_BRANCH)
+            );
+        }
+
+        try {
+            git.checkoutBranch(MAIN_BRANCH, repo);
+            writeMetadata(repoPath, releaseCandidate, releaseTag, releaseVersion);
+            commitMetadataIfChanged(repo, releaseTag);
+            git.tagIfMissing(releaseTag, repo);
+            git.pushAll(repo);
+
+            PromptSpec releasedOnMain = searchInPromptSpecIncludingRetired(
+                    repo,
+                    spec -> promptSpecId.equals(spec.getId()),
+                    path -> true
+            ).orElse(releaseCandidate);
+
+            git.checkoutBranch(DEV_BRANCH, repo);
+            String nextDevelopmentVersion = versioningStrategy.getNextDevelopmentVersion(releaseCandidate);
+            PromptSpec developmentPrompt = releasedOnMain.withVersion(nextDevelopmentVersion);
+            storePrompt(developmentPrompt, "New development version.", true);
+            git.pushAll(repo);
+
+            return releasedOnMain.withVersion(releaseVersion).withReleaseMetadata(releasedMetadata(
+                    ReleaseMetadata.MODE_PR_TWO_PHASE,
+                    releaseVersion,
+                    releaseTag,
+                    MAIN_BRANCH,
+                    pullRequest.number(),
+                    pullRequest.url(),
+                    false
+            ));
+        } catch (Exception e) {
+            throw new GitException(
+                    "Failed to complete release for prompt %s from PR reference %s"
+                            .formatted(promptSpecId, pullRequestReference),
+                    e
+            );
+        } finally {
+            git.checkoutBranch(DEV_BRANCH, repo);
+        }
+    }
+
+    private Optional<String> extractReleaseVersionFromBranch(String promptSpecId, String branchName) {
+        String expectedPrefix = buildReleaseBranchNamePrefix(promptSpecId);
+        if (branchName == null || !branchName.startsWith(expectedPrefix)) {
+            return Optional.empty();
+        }
+        String releaseVersion = branchName.substring(expectedPrefix.length());
+        return releaseVersion.isBlank() ? Optional.empty() : Optional.of(releaseVersion);
+    }
+
+    private boolean isReleaseBranchForPrompt(String branchName, String promptSpecId) {
+        return branchName != null && branchName.startsWith(buildReleaseBranchNamePrefix(promptSpecId));
+    }
+
+    private String buildReleaseBranchName(String promptSpecId, String releaseVersion) {
+        return buildReleaseBranchNamePrefix(promptSpecId) + releaseVersion;
+    }
+
+    private String buildReleaseBranchNamePrefix(String promptSpecId) {
+        return RELEASE_BRANCH_PREFIX + sanitizePromptIdForBranch(promptSpecId) + "-";
+    }
+
+    private static String sanitizePromptIdForBranch(String promptSpecId) {
+        return promptSpecId.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9._-]", "-");
+    }
+
+    private int parsePullRequestReference(String pullRequestReference) {
+        String value = pullRequestReference.trim();
+        Matcher numberMatcher = PR_REFERENCE_NUMBER.matcher(value);
+        if (numberMatcher.matches()) {
+            return Integer.parseInt(numberMatcher.group(1));
+        }
+
+        Matcher urlMatcher = PR_REFERENCE_URL.matcher(value);
+        if (urlMatcher.matches()) {
+            return Integer.parseInt(urlMatcher.group(1));
+        }
+
+        throw new IllegalArgumentException(
+                "Invalid pull request reference '%s'. Provide a numeric PR id or pull request URL."
+                        .formatted(pullRequestReference)
+        );
+    }
+
+    private PromptSpec releaseCandidate(PromptSpec promptSpec) {
+        String releaseVersion = versioningStrategy.calculateReleaseVersion(promptSpec);
+        return promptSpec.withVersion(releaseVersion).withRevision(0);
+    }
+
+    private PromptSpec requirePromptById(String promptSpecId) {
+        return getLatestVersion(promptSpecId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Could not find PromptSpec with id %s".formatted(promptSpecId))
+                );
+    }
+
+    private PromptSpec withPromptReleaseLock(String promptId, Supplier<PromptSpec> operation) {
+        String lockKey = promptId == null || promptId.isBlank() ? "__unknown__" : promptId;
+        ReentrantLock lock = releaseLocks.computeIfAbsent(lockKey, ignored -> new ReentrantLock());
+        lock.lock();
+        try {
+            return operation.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private ReleasePullRequestGateway requireReleasePullRequestGateway() {
+        if (releasePullRequestGateway == null) {
+            throw new IllegalStateException(
+                    "PR-mode release requires a pull request gateway implementation"
+            );
+        }
+        return releasePullRequestGateway;
+    }
+
+    private Path requireActiveRepoPath() {
+        if (appContext.getActiveProject() == null || appContext.getActiveProject().getRepoDir() == null) {
+            throw new IllegalStateException("No active project repository is configured for release operations");
+        }
+        return appContext.getActiveProject().getRepoDir();
+    }
+
+    private void commitMetadataIfChanged(File repo, String releaseTag) {
+        try {
+            git.addAllAndCommit(repo, "Release " + releaseTag);
+        } catch (GitException e) {
+            String message = e.getMessage() == null ? "" : e.getMessage().toLowerCase(Locale.ROOT);
+            if (!message.contains("nothing to commit")) {
+                throw e;
+            }
+        }
+    }
+
+    private ReleaseMetadata requestedMetadata(String releaseVersion,
+                                              String releaseTag,
+                                              String releaseBranch,
+                                              Integer pullRequestNumber,
+                                              String pullRequestUrl,
+                                              boolean existing) {
+        return new ReleaseMetadata(
+                ReleaseMetadata.STATE_REQUESTED,
+                ReleaseMetadata.MODE_PR_TWO_PHASE,
+                releaseVersion,
+                releaseTag,
+                releaseBranch,
+                pullRequestNumber,
+                pullRequestUrl,
+                existing
+        );
+    }
+
+    private ReleaseMetadata releasedMetadata(String mode,
+                                             String releaseVersion,
+                                             String releaseTag,
+                                             String branch,
+                                             Integer pullRequestNumber,
+                                             String pullRequestUrl,
+                                             boolean existing) {
+        return new ReleaseMetadata(
+                ReleaseMetadata.STATE_RELEASED,
+                mode,
+                releaseVersion,
+                releaseTag,
+                branch,
+                pullRequestNumber,
+                pullRequestUrl,
+                existing
+        );
+    }
+
     private void cherryPickFromDevelopmentBranch(PromptSpec promptSpec, File repo) {
         git.cherryPick(DEV_BRANCH, promptSpec, repo);
     }
 
-    private File checkoutMainBranch() {
-        File repo = appContext.getActiveProject().getRepoDir().toFile();
+    private void checkoutMainBranch(File repo) {
         git.checkoutBranch(MAIN_BRANCH, repo);
-        return repo;
     }
 
     private void writeMetadata(Path repoPath, PromptSpec picked, String tag, String releaseVersion) {
@@ -293,7 +670,7 @@ public class GitHubPromptStore implements PromptStore {
         List<GitRepositoryMetadataFile.Version> versions = metadataFile.getVersions();
 
         GitRepositoryMetadataFile.Version v = versions.stream()
-                .filter(m -> m.getId().equals(picked.getId()))
+                .filter(m -> m.getId().equals(picked.getId()) && releaseVersion.equals(m.getVersion()))
                 .findFirst()
                 .orElse(newVersion(versions));
         v.setName(picked.getName());

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubReleasePullRequestGateway.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubReleasePullRequestGateway.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+class GitHubReleasePullRequestGateway implements ReleasePullRequestGateway {
+
+    private static final String REQUIRED_PR_MODE_PERMISSIONS = """
+            PR-mode release requires repository permissions for:
+            - create/read pull requests
+            - read branch refs
+            - create/read tags
+            - push access on release branches
+            Ensure promptlm.store.remote credentials provide repository write access.""";
+
+    private final GitHubProperties gitHubProperties;
+
+    GitHubReleasePullRequestGateway(GitHubProperties gitHubProperties) {
+        this.gitHubProperties = gitHubProperties;
+    }
+
+    @Override
+    public ReleasePullRequest createReleasePullRequest(String repositoryFullName,
+                                                       String headBranch,
+                                                       String baseBranch,
+                                                       String title,
+                                                       String body) {
+        try {
+            GHRepository repository = buildClient().getRepository(repositoryFullName);
+            GHPullRequest pullRequest = repository.createPullRequest(title, headBranch, baseBranch, body);
+            return toReleasePullRequest(pullRequest);
+        } catch (IOException e) {
+            throw new GitException("Failed to create release pull request for %s".formatted(repositoryFullName), e);
+        }
+    }
+
+    @Override
+    public ReleasePullRequest getPullRequest(String repositoryFullName, int pullRequestNumber) {
+        try {
+            GHRepository repository = buildClient().getRepository(repositoryFullName);
+            return toReleasePullRequest(repository.getPullRequest(pullRequestNumber));
+        } catch (IOException e) {
+            throw new GitException(
+                    "Failed to read pull request #%d for %s".formatted(pullRequestNumber, repositoryFullName),
+                    e
+            );
+        }
+    }
+
+    @Override
+    public List<ReleasePullRequest> listOpenPullRequests(String repositoryFullName, String baseBranch) {
+        try {
+            GHRepository repository = buildClient().getRepository(repositoryFullName);
+            return repository.getPullRequests(GHIssueState.OPEN).stream()
+                    .map(this::toReleasePullRequest)
+                    .filter(pr -> baseBranch.equals(pr.baseRef()))
+                    .toList();
+        } catch (IOException e) {
+            throw new GitException("Failed to list open pull requests for %s".formatted(repositoryFullName), e);
+        }
+    }
+
+    @Override
+    public void validatePrModeCapabilities(String repositoryFullName) {
+        if (gitHubProperties.getUsername() == null || gitHubProperties.getUsername().isBlank()
+                || gitHubProperties.getToken() == null || gitHubProperties.getToken().isBlank()) {
+            throw new IllegalStateException(
+                    "PR-mode release requires configured promptlm.store.remote.username and promptlm.store.remote.token.\n"
+                            + REQUIRED_PR_MODE_PERMISSIONS
+            );
+        }
+
+        try {
+            GitHub client = buildClient();
+            GHRepository repository = client.getRepository(repositoryFullName);
+            if (!repository.hasPullAccess() || !repository.hasPushAccess()) {
+                throw new IllegalStateException(
+                        "PR-mode release token is missing required repository access for %s.\n%s"
+                                .formatted(repositoryFullName, REQUIRED_PR_MODE_PERMISSIONS)
+                );
+            }
+
+            repository.getBranch(GitHubPromptStore.MAIN_BRANCH);
+            repository.getPullRequests(GHIssueState.OPEN);
+            repository.listTags().iterator().hasNext();
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Unable to validate PR-mode release capabilities for %s: %s%n%s"
+                            .formatted(repositoryFullName, e.getMessage(), REQUIRED_PR_MODE_PERMISSIONS),
+                    e
+            );
+        }
+    }
+
+    private GitHub buildClient() throws IOException {
+        return GitHubBuilder.fromProperties(gitHubProperties.asProperties())
+                .withEndpoint(gitHubProperties.getEndpoint())
+                .build();
+    }
+
+    private ReleasePullRequest toReleasePullRequest(GHPullRequest pullRequest) {
+        try {
+            return new ReleasePullRequest(
+                    pullRequest.getNumber(),
+                    pullRequest.getHtmlUrl().toString(),
+                    pullRequest.getState().name().toLowerCase(),
+                    pullRequest.isMerged(),
+                    pullRequest.getHead().getRef(),
+                    pullRequest.getBase().getRef(),
+                    pullRequest.getMergeCommitSha()
+            );
+        } catch (IOException e) {
+            throw new GitException("Failed to map pull request #%d".formatted(pullRequest.getNumber()), e);
+        }
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/PromptStoreAdapter.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/PromptStoreAdapter.java
@@ -53,7 +53,12 @@ class PromptStoreAdapter implements PromptStorePort {
     }
 
     @Override
-    public PromptSpec release(PromptSpec promptSpec) {
-        return promptStore.release(promptSpec);
+    public PromptSpec requestRelease(PromptSpec promptSpec) {
+        return promptStore.requestRelease(promptSpec);
+    }
+
+    @Override
+    public PromptSpec completeRelease(String promptSpecId, String pullRequestReference) {
+        return promptStore.completeRelease(promptSpecId, pullRequestReference);
     }
 }

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ReleasePromotionMode.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ReleasePromotionMode.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import java.util.Arrays;
+
+enum ReleasePromotionMode {
+    DIRECT("direct"),
+    PR_TWO_PHASE("pr_two_phase");
+
+    private final String value;
+
+    ReleasePromotionMode(String value) {
+        this.value = value;
+    }
+
+    String value() {
+        return value;
+    }
+
+    static ReleasePromotionMode from(String value) {
+        return Arrays.stream(values())
+                .filter(mode -> mode.value.equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "Unsupported promptlm.release.promotion.mode '%s'. Supported values: direct, pr_two_phase."
+                                .formatted(value)
+                ));
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ReleasePromotionProperties.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ReleasePromotionProperties.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "promptlm.release.promotion")
+public class ReleasePromotionProperties {
+
+    private String mode = ReleasePromotionMode.DIRECT.value();
+
+    public String getMode() {
+        return mode;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    ReleasePromotionMode resolveMode() {
+        return ReleasePromotionMode.from(mode);
+    }
+
+    @PostConstruct
+    void validate() {
+        resolveMode();
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ReleasePullRequest.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ReleasePullRequest.java
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package dev.promptlm;
+package dev.promptlm.store.github;
 
-import dev.promptlm.store.github.GitHubProperties;
-import dev.promptlm.store.github.ReleasePromotionProperties;
-import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties({GitHubProperties.class, ReleasePromotionProperties.class})
-public class GitHubPromptStoreConfig {
+record ReleasePullRequest(
+        int number,
+        String url,
+        String state,
+        boolean merged,
+        String headRef,
+        String baseRef,
+        String mergeCommitSha) {
 }

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ReleasePullRequestGateway.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ReleasePullRequestGateway.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import java.util.List;
+
+interface ReleasePullRequestGateway {
+
+    ReleasePullRequest createReleasePullRequest(String repositoryFullName,
+                                                String headBranch,
+                                                String baseBranch,
+                                                String title,
+                                                String body);
+
+    ReleasePullRequest getPullRequest(String repositoryFullName, int pullRequestNumber);
+
+    List<ReleasePullRequest> listOpenPullRequests(String repositoryFullName, String baseBranch);
+
+    void validatePrModeCapabilities(String repositoryFullName);
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/TrustedRemotePolicy.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/TrustedRemotePolicy.java
@@ -49,6 +49,10 @@ class TrustedRemotePolicy {
         return parsed != null && isTrustedHttpRemote(parsed);
     }
 
+    boolean isHttpOrHttpsRemote(String remoteUrl) {
+        return tryParseHttpRemote(remoteUrl) != null;
+    }
+
     private boolean isTrustedHttpRemote(URI remoteUrl) {
         TrustedEndpoint trustedEndpoint = resolveTrustedEndpoint();
         if (!trustedEndpoint.scheme().equalsIgnoreCase(remoteUrl.getScheme())) {

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitHubPromptStoreReleaseFlowTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitHubPromptStoreReleaseFlowTest.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import dev.promptlm.domain.BasicAppContext;
+import dev.promptlm.domain.ObjectMapperFactory;
+import dev.promptlm.domain.projectspec.ProjectSpec;
+import dev.promptlm.domain.promptspec.ChatCompletionRequest;
+import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.ReleaseMetadata;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jgit.revwalk.RevCommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GitHubPromptStoreReleaseFlowTest {
+
+    @Test
+    void requestReleaseInPrModeCreatesBranchAndPullRequest(@TempDir Path repoDir) {
+        RecordingGit git = new RecordingGit();
+        StubPullRequestGateway pullRequestGateway = new StubPullRequestGateway();
+        pullRequestGateway.nextCreated = new ReleasePullRequest(
+                17,
+                "https://github.com/promptLM/promptlm-app/pull/17",
+                "open",
+                false,
+                "release/support-welcome-1.2.3",
+                GitHubPromptStore.MAIN_BRANCH,
+                null
+        );
+
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_PR_TWO_PHASE, git, pullRequestGateway);
+        PromptSpec result = store.requestRelease(promptSpec("1.2.3-SNAPSHOT"));
+
+        assertThat(result.getReleaseMetadata()).isNotNull();
+        assertThat(result.getReleaseMetadata().state()).isEqualTo(ReleaseMetadata.STATE_REQUESTED);
+        assertThat(result.getReleaseMetadata().mode()).isEqualTo(ReleaseMetadata.MODE_PR_TWO_PHASE);
+        assertThat(result.getReleaseMetadata().branch()).isEqualTo("release/support-welcome-1.2.3");
+        assertThat(result.getReleaseMetadata().prNumber()).isEqualTo(17);
+        assertThat(result.getReleaseMetadata().existing()).isFalse();
+        assertThat(pullRequestGateway.validateCalls).isEqualTo(1);
+        assertThat(pullRequestGateway.createCalls).isEqualTo(1);
+        assertThat(git.createdBranches).contains("release/support-welcome-1.2.3");
+        assertThat(git.commitMessages).contains("Release requested");
+    }
+
+    @Test
+    void requestReleaseInPrModeReturnsExistingWhenSameVersionAlreadyRequested(@TempDir Path repoDir) {
+        RecordingGit git = new RecordingGit();
+        StubPullRequestGateway pullRequestGateway = new StubPullRequestGateway();
+        pullRequestGateway.openPullRequests = List.of(new ReleasePullRequest(
+                22,
+                "https://github.com/promptLM/promptlm-app/pull/22",
+                "open",
+                false,
+                "release/support-welcome-1.2.3",
+                GitHubPromptStore.MAIN_BRANCH,
+                null
+        ));
+
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_PR_TWO_PHASE, git, pullRequestGateway);
+        PromptSpec result = store.requestRelease(promptSpec("1.2.3-SNAPSHOT"));
+
+        assertThat(result.getReleaseMetadata().state()).isEqualTo(ReleaseMetadata.STATE_REQUESTED);
+        assertThat(result.getReleaseMetadata().existing()).isTrue();
+        assertThat(result.getReleaseMetadata().prNumber()).isEqualTo(22);
+        assertThat(pullRequestGateway.createCalls).isZero();
+        assertThat(git.createdBranches).isEmpty();
+        assertThat(git.commitMessages).isEmpty();
+    }
+
+    @Test
+    void requestReleaseInPrModeRejectsConflictingPendingVersion(@TempDir Path repoDir) {
+        RecordingGit git = new RecordingGit();
+        StubPullRequestGateway pullRequestGateway = new StubPullRequestGateway();
+        pullRequestGateway.openPullRequests = List.of(new ReleasePullRequest(
+                41,
+                "https://github.com/promptLM/promptlm-app/pull/41",
+                "open",
+                false,
+                "release/support-welcome-1.2.2",
+                GitHubPromptStore.MAIN_BRANCH,
+                null
+        ));
+
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_PR_TWO_PHASE, git, pullRequestGateway);
+
+        assertThatThrownBy(() -> store.requestRelease(promptSpec("1.2.3-SNAPSHOT")))
+                .isInstanceOf(GitException.class)
+                .hasMessageContaining("Conflicting pending release request for prompt support/welcome");
+        assertThat(pullRequestGateway.createCalls).isZero();
+    }
+
+    @Test
+    void requestReleaseInPrModeReturnsReleasedWhenTagAlreadyExists(@TempDir Path repoDir) {
+        RecordingGit git = new RecordingGit();
+        git.tags.add("support/welcome-v1.2.3");
+        StubPullRequestGateway pullRequestGateway = new StubPullRequestGateway();
+
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_PR_TWO_PHASE, git, pullRequestGateway);
+        PromptSpec result = store.requestRelease(promptSpec("1.2.3-SNAPSHOT"));
+
+        assertThat(result.getReleaseMetadata().state()).isEqualTo(ReleaseMetadata.STATE_RELEASED);
+        assertThat(result.getReleaseMetadata().mode()).isEqualTo(ReleaseMetadata.MODE_PR_TWO_PHASE);
+        assertThat(result.getReleaseMetadata().existing()).isTrue();
+        assertThat(pullRequestGateway.listCalls).isZero();
+        assertThat(pullRequestGateway.createCalls).isZero();
+    }
+
+    @Test
+    void requestReleaseInPrModeFailsWhenGatewayIsMissing(@TempDir Path repoDir) {
+        RecordingGit git = new RecordingGit();
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_PR_TWO_PHASE, git, null);
+
+        assertThatThrownBy(() -> store.requestRelease(promptSpec("1.2.3-SNAPSHOT")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("PR-mode release requires a pull request gateway implementation");
+    }
+
+    @Test
+    void requestReleaseInDirectModePreservesReleaseAndSnapshotFlow(@TempDir Path repoDir) {
+        RecordingGit git = new RecordingGit();
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_DIRECT, git, null);
+
+        PromptSpec result = store.requestRelease(promptSpec("1.2.3-SNAPSHOT"));
+
+        assertThat(result.getReleaseMetadata().state()).isEqualTo(ReleaseMetadata.STATE_RELEASED);
+        assertThat(result.getReleaseMetadata().mode()).isEqualTo(ReleaseMetadata.MODE_DIRECT);
+        assertThat(result.getReleaseMetadata().existing()).isFalse();
+        assertThat(result.getVersion()).isEqualTo("1.2.3");
+        assertThat(git.cherryPickCalls).isEqualTo(1);
+        assertThat(git.tags).contains("support/welcome-v1.2.3");
+        assertThat(git.commitMessages).contains("Released", "Release support/welcome-v1.2.3", "New development version.");
+
+        Optional<PromptSpec> latest = store.getLatestVersion("support/welcome");
+        assertThat(latest).isPresent();
+        assertThat(latest.orElseThrow().getVersion()).isEqualTo("1.2.4-SNAPSHOT");
+    }
+
+    @Test
+    void completeReleaseIsOnlyAvailableInPrMode(@TempDir Path repoDir) {
+        RecordingGit git = new RecordingGit();
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_DIRECT, git, null);
+
+        assertThatThrownBy(() -> store.completeRelease("support/welcome", "11"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("only available when promptlm.release.promotion.mode=pr_two_phase");
+    }
+
+    @Test
+    void completeReleaseRejectsUnmergedPullRequest(@TempDir Path repoDir) {
+        RecordingGit git = new RecordingGit();
+        StubPullRequestGateway pullRequestGateway = new StubPullRequestGateway();
+        pullRequestGateway.pullRequests.put(11, new ReleasePullRequest(
+                11,
+                "https://github.com/promptLM/promptlm-app/pull/11",
+                "open",
+                false,
+                "release/support-welcome-1.2.3",
+                GitHubPromptStore.MAIN_BRANCH,
+                null
+        ));
+
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_PR_TWO_PHASE, git, pullRequestGateway);
+        store.saveToDisk(promptSpec("1.2.3-SNAPSHOT"));
+
+        assertThatThrownBy(() -> store.completeRelease("support/welcome", "11"))
+                .isInstanceOf(GitException.class)
+                .hasMessageContaining("has not been merged into main");
+        assertThat(git.tags).isEmpty();
+    }
+
+    @Test
+    void completeReleaseReturnsExistingWhenReleaseTagAlreadyExists(@TempDir Path repoDir) {
+        RecordingGit git = new RecordingGit();
+        git.tags.add("support/welcome-v1.2.3");
+
+        StubPullRequestGateway pullRequestGateway = new StubPullRequestGateway();
+        pullRequestGateway.pullRequests.put(11, new ReleasePullRequest(
+                11,
+                "https://github.com/promptLM/promptlm-app/pull/11",
+                "closed",
+                false,
+                "release/support-welcome-1.2.3",
+                GitHubPromptStore.MAIN_BRANCH,
+                "abc123"
+        ));
+
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_PR_TWO_PHASE, git, pullRequestGateway);
+        store.saveToDisk(promptSpec("1.2.3-SNAPSHOT"));
+
+        PromptSpec result = store.completeRelease("support/welcome", "https://github.com/promptLM/promptlm-app/pull/11");
+
+        assertThat(result.getReleaseMetadata().state()).isEqualTo(ReleaseMetadata.STATE_RELEASED);
+        assertThat(result.getReleaseMetadata().existing()).isTrue();
+        assertThat(result.getReleaseMetadata().prNumber()).isEqualTo(11);
+        assertThat(git.commitMessages).isEmpty();
+    }
+
+    @Test
+    void completeReleaseFinalizesMergedPrAndAdvancesDevelopmentSnapshot(@TempDir Path repoDir) {
+        RecordingGit git = new RecordingGit();
+        StubPullRequestGateway pullRequestGateway = new StubPullRequestGateway();
+        pullRequestGateway.pullRequests.put(11, new ReleasePullRequest(
+                11,
+                "https://github.com/promptLM/promptlm-app/pull/11",
+                "closed",
+                true,
+                "release/support-welcome-1.2.3",
+                GitHubPromptStore.MAIN_BRANCH,
+                "abc123"
+        ));
+
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_PR_TWO_PHASE, git, pullRequestGateway);
+        store.saveToDisk(promptSpec("1.2.3-SNAPSHOT"));
+
+        PromptSpec result = store.completeRelease("support/welcome", "11");
+
+        assertThat(result.getReleaseMetadata().state()).isEqualTo(ReleaseMetadata.STATE_RELEASED);
+        assertThat(result.getReleaseMetadata().mode()).isEqualTo(ReleaseMetadata.MODE_PR_TWO_PHASE);
+        assertThat(result.getReleaseMetadata().existing()).isFalse();
+        assertThat(result.getVersion()).isEqualTo("1.2.3");
+        assertThat(git.tags).contains("support/welcome-v1.2.3");
+        assertThat(git.commitMessages).contains("Release support/welcome-v1.2.3", "New development version.");
+
+        Optional<PromptSpec> latest = store.getLatestVersion("support/welcome");
+        assertThat(latest).isPresent();
+        assertThat(latest.orElseThrow().getVersion()).isEqualTo("1.2.4-SNAPSHOT");
+    }
+
+    @Test
+    void requestReleaseInPrModeIsSerializedPerPromptForConcurrentCalls(@TempDir Path repoDir) throws Exception {
+        RecordingGit git = new RecordingGit();
+        ConcurrencyPullRequestGateway pullRequestGateway = new ConcurrencyPullRequestGateway();
+        GitHubPromptStore store = newStore(repoDir, ReleaseMetadata.MODE_PR_TWO_PHASE, git, pullRequestGateway);
+        PromptSpec promptSpec = promptSpec("1.2.3-SNAPSHOT");
+
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        Callable<PromptSpec> action = () -> {
+            ready.countDown();
+            assertThat(start.await(5, TimeUnit.SECONDS)).isTrue();
+            return store.requestRelease(promptSpec);
+        };
+
+        Future<PromptSpec> first = executor.submit(action);
+        Future<PromptSpec> second = executor.submit(action);
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        start.countDown();
+
+        List<PromptSpec> results = new ArrayList<>();
+        try {
+            results.add(first.get(10, TimeUnit.SECONDS));
+            results.add(second.get(10, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(pullRequestGateway.createCalls.get()).isEqualTo(1);
+        assertThat(results).anySatisfy(spec -> assertThat(spec.getReleaseMetadata().existing()).isFalse());
+        assertThat(results).anySatisfy(spec -> assertThat(spec.getReleaseMetadata().existing()).isTrue());
+    }
+
+    private static GitHubPromptStore newStore(Path repoDir,
+                                              String mode,
+                                              RecordingGit git,
+                                              ReleasePullRequestGateway pullRequestGateway) {
+        ReleasePromotionProperties releaseProperties = new ReleasePromotionProperties();
+        releaseProperties.setMode(mode);
+
+        BasicAppContext appContext = new BasicAppContext();
+        appContext.setActiveProject(ProjectSpec.fromRepo(repoDir));
+
+        return new GitHubPromptStore(
+                ObjectMapperFactory.createYamlMapper(),
+                new GitFileNameStrategy(),
+                git,
+                appContext,
+                new IntVersioningStrategy(),
+                new GitRepositoryMetadata(ObjectMapperFactory.createJsonMapper()),
+                releaseProperties,
+                pullRequestGateway
+        );
+    }
+
+    private static PromptSpec promptSpec(String version) {
+        return PromptSpec.builder()
+                .withGroup("support")
+                .withName("welcome")
+                .withVersion(version)
+                .withRevision(7)
+                .withDescription("Support prompt")
+                .withRequest(ChatCompletionRequest.builder()
+                        .withType(ChatCompletionRequest.TYPE)
+                        .withVendor("openai")
+                        .withModel("gpt-4o")
+                        .withMessages(List.of())
+                        .build())
+                .build()
+                .withId("support/welcome");
+    }
+
+    private static final class RecordingGit extends Git {
+        private final List<String> commitMessages = new ArrayList<>();
+        private final List<String> createdBranches = new ArrayList<>();
+        private final Set<String> tags = new HashSet<>();
+        private int cherryPickCalls;
+
+        private RecordingGit() {
+            super(
+                    new EnvGitCredentialsProvider(gitHubProperties()),
+                    new TrustedRemotePolicy(gitHubProperties()),
+                    new BasicAppContext()
+            );
+        }
+
+        @Override
+        public String getFullName(Path repoDir) {
+            return "promptLM/promptlm-app";
+        }
+
+        @Override
+        public void checkoutBranch(String branchName, File repo) {
+        }
+
+        @Override
+        public void checkoutOrCreateBranch(String branchName, File repo) {
+            createdBranches.add(branchName);
+        }
+
+        @Override
+        public RevCommit addAllAndCommit(File repo, String msg) {
+            commitMessages.add(msg);
+            return null;
+        }
+
+        @Override
+        public void pushAll(File repo) {
+        }
+
+        @Override
+        public void cherryPick(String devBranch, PromptSpec completed, File repo) {
+            cherryPickCalls++;
+        }
+
+        @Override
+        public boolean tagExists(String tag, File repo) {
+            return tags.contains(tag);
+        }
+
+        @Override
+        public void tagIfMissing(String tag, File repo) {
+            tags.add(tag);
+        }
+    }
+
+    private static final class StubPullRequestGateway implements ReleasePullRequestGateway {
+        private List<ReleasePullRequest> openPullRequests = List.of();
+        private final Map<Integer, ReleasePullRequest> pullRequests = new HashMap<>();
+        private ReleasePullRequest nextCreated;
+        private int validateCalls;
+        private int createCalls;
+        private int listCalls;
+
+        @Override
+        public ReleasePullRequest createReleasePullRequest(String repositoryFullName,
+                                                           String headBranch,
+                                                           String baseBranch,
+                                                           String title,
+                                                           String body) {
+            createCalls++;
+            if (nextCreated == null) {
+                throw new IllegalStateException("nextCreated is not configured");
+            }
+            return nextCreated;
+        }
+
+        @Override
+        public ReleasePullRequest getPullRequest(String repositoryFullName, int pullRequestNumber) {
+            ReleasePullRequest pullRequest = pullRequests.get(pullRequestNumber);
+            if (pullRequest == null) {
+                throw new IllegalStateException("No PR configured for number " + pullRequestNumber);
+            }
+            return pullRequest;
+        }
+
+        @Override
+        public List<ReleasePullRequest> listOpenPullRequests(String repositoryFullName, String baseBranch) {
+            listCalls++;
+            return openPullRequests;
+        }
+
+        @Override
+        public void validatePrModeCapabilities(String repositoryFullName) {
+            validateCalls++;
+        }
+    }
+
+    private static final class ConcurrencyPullRequestGateway implements ReleasePullRequestGateway {
+        private final AtomicInteger createCalls = new AtomicInteger();
+        private final AtomicReference<ReleasePullRequest> existing = new AtomicReference<>();
+
+        @Override
+        public ReleasePullRequest createReleasePullRequest(String repositoryFullName,
+                                                           String headBranch,
+                                                           String baseBranch,
+                                                           String title,
+                                                           String body) {
+            createCalls.incrementAndGet();
+            try {
+                Thread.sleep(75);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            ReleasePullRequest created = new ReleasePullRequest(
+                    55,
+                    "https://github.com/promptLM/promptlm-app/pull/55",
+                    "open",
+                    false,
+                    headBranch,
+                    baseBranch,
+                    null
+            );
+            existing.set(created);
+            return created;
+        }
+
+        @Override
+        public ReleasePullRequest getPullRequest(String repositoryFullName, int pullRequestNumber) {
+            throw new UnsupportedOperationException("Not used in this test");
+        }
+
+        @Override
+        public List<ReleasePullRequest> listOpenPullRequests(String repositoryFullName, String baseBranch) {
+            ReleasePullRequest current = existing.get();
+            return current == null ? List.of() : List.of(current);
+        }
+
+        @Override
+        public void validatePrModeCapabilities(String repositoryFullName) {
+        }
+    }
+
+    private static GitHubProperties gitHubProperties() {
+        GitHubProperties properties = new GitHubProperties();
+        properties.setBaseUrl("https://api.github.com");
+        return properties;
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitHubReleasePullRequestGatewayTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitHubReleasePullRequestGatewayTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GitHubReleasePullRequestGatewayTest {
+
+    @Test
+    void validatePrModeCapabilitiesFailsFastWhenCredentialsAreMissing() {
+        GitHubProperties properties = new GitHubProperties();
+        properties.setUsername("");
+        properties.setToken("");
+        properties.setBaseUrl("https://api.github.com");
+
+        GitHubReleasePullRequestGateway gateway = new GitHubReleasePullRequestGateway(properties);
+
+        assertThatThrownBy(() -> gateway.validatePrModeCapabilities("promptLM/promptlm-app"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("promptlm.store.remote.username")
+                .hasMessageContaining("promptlm.store.remote.token")
+                .hasMessageContaining("create/read pull requests")
+                .hasMessageContaining("create/read tags");
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitPushSafetyTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitPushSafetyTest.java
@@ -17,6 +17,7 @@
 package dev.promptlm.store.github;
 
 import dev.promptlm.domain.BasicAppContext;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class GitPushSafetyTest {
@@ -83,6 +85,93 @@ class GitPushSafetyTest {
         assertThatThrownBy(() -> git.pushAll(repo2Dir.toFile()))
                 .isInstanceOf(GitException.class)
                 .hasMessageContaining("non-fast-forward");
+    }
+
+    /**
+     * Verifies that when credentials are configured but the repository's remote points to an HTTP/HTTPS
+     * host that does not match the configured backend, pushAll fails with a clear GitException
+     * explaining the mismatch — instead of the cryptic JGit "no CredentialsProvider" error.
+     */
+    @Test
+    void pushAllShouldThrowMeaningfulExceptionWhenHttpRemoteIsUntrustedAndCredentialsAreConfigured(@TempDir Path tempDir) throws Exception {
+        Path repoDir = tempDir.resolve("repo");
+
+        GitHubProperties properties = new GitHubProperties();
+        properties.setUsername("user");
+        properties.setToken("secret");
+        properties.setBaseUrl("http://localhost:3000");
+
+        Git git = new Git(new EnvGitCredentialsProvider(properties), new TrustedRemotePolicy(properties), new BasicAppContext());
+
+        git.createRepository(repoDir, "http://different-host:8080/owner/repo");
+        configureIdentity(repoDir);
+        Files.writeString(repoDir.resolve("README.md"), "hello\n");
+        git.addAllAndCommit(repoDir.toFile(), "initial commit");
+
+        assertThatThrownBy(() -> git.pushAll(repoDir.toFile()))
+                .isInstanceOf(GitException.class)
+                .hasMessageContaining("remote host does not match");
+    }
+
+    /**
+     * Verifies that checkoutOrCreateBranch detects an already-existing local branch and triggers a
+     * fetch to pick up remote changes, rather than skipping the fetch due to an incorrect branch
+     * name comparison. The assertion checks that refs/remotes/origin/main in repo1 is updated to
+     * the commit pushed by a second clone, which can only happen if fetch was actually executed.
+     */
+    @Test
+    void checkoutOrCreateBranchShouldFetchRemoteChangesWhenBranchAlreadyExists(@TempDir Path tempDir) throws Exception {
+        Path remoteDir = tempDir.resolve("remote.git");
+        Path repo1Dir = tempDir.resolve("repo1");
+        Path repo2Dir = tempDir.resolve("repo2");
+        String remoteUri = remoteDir.toUri().toString();
+
+        try (org.eclipse.jgit.api.Git ignored = org.eclipse.jgit.api.Git.init()
+                .setBare(true)
+                .setDirectory(remoteDir.toFile())
+                .call()) {
+            // bare remote created
+        }
+
+        GitHubProperties properties = new GitHubProperties();
+        properties.setUsername("user");
+        properties.setToken("token");
+        properties.setBaseUrl("http://localhost");
+
+        Git git = new Git(new EnvGitCredentialsProvider(properties), new TrustedRemotePolicy(properties), new BasicAppContext());
+
+        git.createRepository(repo1Dir, remoteUri);
+        configureIdentity(repo1Dir);
+        Files.writeString(repo1Dir.resolve("README.md"), "v1\n");
+        git.addAllAndCommit(repo1Dir.toFile(), "c1");
+        git.pushAll(repo1Dir.toFile());
+
+        // Advance the remote: a second clone pushes a new commit
+        try (org.eclipse.jgit.api.Git ignored = org.eclipse.jgit.api.Git.cloneRepository()
+                .setURI(remoteUri)
+                .setBranch("main")
+                .setDirectory(repo2Dir.toFile())
+                .call()) {
+            // clone created
+        }
+        configureIdentity(repo2Dir);
+        Files.writeString(repo2Dir.resolve("update.txt"), "remote change\n");
+        git.addAllAndCommit(repo2Dir.toFile(), "c2");
+        git.pushAll(repo2Dir.toFile());
+
+        ObjectId c2CommitId;
+        try (org.eclipse.jgit.api.Git remote = org.eclipse.jgit.api.Git.open(remoteDir.toFile())) {
+            c2CommitId = remote.getRepository().resolve("refs/heads/main");
+        }
+
+        // Branch "main" already exists in repo1; checkoutOrCreateBranch should detect it and fetch
+        git.checkoutOrCreateBranch("main", repo1Dir.toFile());
+
+        // refs/remotes/origin/main is only updated by fetch, so it must now point to c2
+        try (org.eclipse.jgit.api.Git repo1 = org.eclipse.jgit.api.Git.open(repo1Dir.toFile())) {
+            ObjectId remoteTracking = repo1.getRepository().resolve("refs/remotes/origin/main");
+            assertThat(remoteTracking).isEqualTo(c2CommitId);
+        }
     }
 
     private static void configureIdentity(Path repoDir) throws Exception {

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ReleasePromotionPropertiesTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ReleasePromotionPropertiesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import dev.promptlm.GitHubPromptStoreConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleasePromotionPropertiesTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ConfigurationPropertiesAutoConfiguration.class))
+            .withUserConfiguration(GitHubPromptStoreConfig.class);
+
+    @Test
+    void defaultsToDirectMode() {
+        contextRunner.run(context -> {
+            ReleasePromotionProperties properties = context.getBean(ReleasePromotionProperties.class);
+            assertThat(properties.getMode()).isEqualTo("direct");
+            assertThat(properties.resolveMode()).isEqualTo(ReleasePromotionMode.DIRECT);
+        });
+    }
+
+    @Test
+    void bindsPrTwoPhaseMode() {
+        contextRunner
+                .withPropertyValues("promptlm.release.promotion.mode=pr_two_phase")
+                .run(context -> {
+                    ReleasePromotionProperties properties = context.getBean(ReleasePromotionProperties.class);
+                    assertThat(properties.resolveMode()).isEqualTo(ReleasePromotionMode.PR_TWO_PHASE);
+                });
+    }
+
+    @Test
+    void failsFastForInvalidModeValue() {
+        ReleasePromotionProperties properties = new ReleasePromotionProperties();
+        properties.setMode("unknown");
+
+        assertThatThrownBy(properties::resolveMode)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Unsupported promptlm.release.promotion.mode");
+    }
+}

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
@@ -22,11 +22,13 @@ import dev.promptlm.lifecycle.PromptLifecycleFacade;
 import dev.promptlm.execution.PromptExecutor;
 import dev.promptlm.domain.promptspec.ChatCompletionRequest;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.ReleaseMetadata;
 import dev.promptlm.domain.promptspec.Request;
 import dev.promptlm.lifecycle.application.PromptSpecAlreadyExistsException;
 import dev.promptlm.store.api.PromptStore;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -62,6 +64,7 @@ import java.util.stream.Collectors;
 public class PromptSpecController {
 
     private static final String PROMPTS_DIRECTORY = "prompts";
+    private static final String RELEASE_STATE_HEADER = "X-PromptLM-Release-State";
 
     private final PromptStore promptStore;
     private final PromptExecutor promptExecutor;
@@ -408,15 +411,15 @@ public class PromptSpecController {
      * This will create a new version of the prompt with an incremented version number.
      *
      * @param promptSpecId The ID of the prompt to release.
-     * @return The newly released prompt specification.
+     * @return The release operation response payload.
      */
     @Operation(
             summary = "Release a new version of a prompt",
-            description = "Creates a new, immutable release of a prompt specification with an incremented version number. The new version is based on the latest existing version of the prompt.",
+            description = "Requests release for a prompt specification. In direct mode the response state is released. In pr_two_phase mode the response state is requested until /release/complete is called.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "The newly released prompt specification.",
+                            description = "Release operation response as prompt specification. Header X-PromptLM-Release-State mirrors extensions.x-promptlm.release.state (requested|released).",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = PromptSpec.class))
                     ),
                     @ApiResponse(
@@ -434,8 +437,55 @@ public class PromptSpecController {
             return ResponseEntity.notFound().build();
         }
 
-        PromptSpec releasedPrompt = promptStore.release(latestVersion.get());
-        return ResponseEntity.ok(releasedPrompt);
+        PromptSpec releaseResponse = promptLifecycleFacade.release(promptSpecId);
+        return releaseResponse(releaseResponse);
+    }
+
+    @Hidden
+    @PostMapping("/{group}/{name}/release")
+    public ResponseEntity<PromptSpec> releasePromptByGroupAndName(
+            @PathVariable("group") String group,
+            @PathVariable("name") String name) {
+        return releasePrompt(group + "/" + name);
+    }
+
+    @Operation(
+            summary = "Complete a pending prompt release",
+            description = "Finalizes a previously requested PR-mode release after validating the referenced pull request has been merged into main. Header X-PromptLM-Release-State is released on success.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Completed release response.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = PromptSpec.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Prompt specification with the given ID not found."
+                    )
+            }
+    )
+    @PostMapping("/{promptSpecId}/release/complete")
+    public ResponseEntity<PromptSpec> completeReleasePrompt(
+            @Parameter(description = "The unique identifier of the prompt specification to complete.")
+            @PathVariable("promptSpecId") String promptSpecId,
+            @Parameter(description = "Pull request number or URL for the pending release request.")
+            @RequestParam("pr") String pullRequestReference) {
+        Optional<PromptSpec> latestVersion = promptStore.getLatestVersion(promptSpecId);
+        if (latestVersion.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        PromptSpec releaseResponse = promptLifecycleFacade.completeRelease(promptSpecId, pullRequestReference);
+        return releaseResponse(releaseResponse);
+    }
+
+    @Hidden
+    @PostMapping("/{group}/{name}/release/complete")
+    public ResponseEntity<PromptSpec> completeReleasePromptByGroupAndName(
+            @PathVariable("group") String group,
+            @PathVariable("name") String name,
+            @RequestParam("pr") String pullRequestReference) {
+        return completeReleasePrompt(group + "/" + name, pullRequestReference);
     }
 
     /**
@@ -537,6 +587,16 @@ public class PromptSpecController {
         } catch (IOException | GitAPIException e) {
             throw new IllegalStateException("Failed to resolve active-project git metadata: " + normalizedRepoDir, e);
         }
+    }
+
+    private ResponseEntity<PromptSpec> releaseResponse(PromptSpec releaseResponse) {
+        ReleaseMetadata releaseMetadata = releaseResponse.getReleaseMetadata();
+        if (releaseMetadata == null || !StringUtils.hasText(releaseMetadata.state())) {
+            throw new IllegalStateException("Release response is missing required release metadata state");
+        }
+        return ResponseEntity.ok()
+                .header(RELEASE_STATE_HEADER, releaseMetadata.state())
+                .body(releaseResponse);
     }
 
     private Instant instantFromCommit(RevCommit commit) {

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/llm/ModelCatalogService.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/llm/ModelCatalogService.java
@@ -20,7 +20,7 @@ import dev.promptlm.execution.SpringAiVendorClient;
 import dev.promptlm.execution.litellm.LiteLlmGatewayProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -53,10 +53,10 @@ public class ModelCatalogService {
     private volatile LiteLlmCacheEntry liteLlmCache;
 
     public ModelCatalogService(List<SpringAiVendorClient> springAiVendors,
-                               ObjectProvider<LiteLlmGatewayProperties> liteLlmProperties,
+                               @Nullable LiteLlmGatewayProperties liteLlmProperties,
                                ModelCatalogProperties catalogProperties) {
         this.springAiVendors = springAiVendors == null ? List.of() : List.copyOf(springAiVendors);
-        this.liteLlmProperties = liteLlmProperties.getIfAvailable();
+        this.liteLlmProperties = liteLlmProperties;
         this.catalogProperties = catalogProperties;
     }
 

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
@@ -25,6 +25,7 @@ import dev.promptlm.domain.promptspec.ChatCompletionRequest;
 import dev.promptlm.domain.promptspec.ChatCompletionResponse;
 import dev.promptlm.domain.promptspec.PromptEvaluationDefinition;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.ReleaseMetadata;
 import dev.promptlm.lifecycle.PromptLifecycleFacade;
 import dev.promptlm.execution.PromptExecutor;
 import dev.promptlm.store.api.PromptStore;
@@ -62,6 +63,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -149,6 +151,83 @@ class PromptSpecControllerWebMvcTest {
         mockMvc.perform(get("/api/prompts").queryParam("sortBy", "group"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"));
+    }
+
+    @Test
+    void releaseEndpointDelegatesToLifecycleAndSetsReleaseStateHeader() throws Exception {
+        String promptId = "support/welcome";
+        PromptSpec stored = PromptSpec.builder()
+                .withGroup("support")
+                .withName("welcome")
+                .withVersion("1.0.0-SNAPSHOT")
+                .withRevision(3)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder()
+                        .withVendor("openai")
+                        .withModel("gpt-4o")
+                        .withMessages(List.of())
+                        .build())
+                .build()
+                .withId(promptId);
+        PromptSpec requested = stored.withReleaseMetadata(new ReleaseMetadata(
+                ReleaseMetadata.STATE_REQUESTED,
+                ReleaseMetadata.MODE_PR_TWO_PHASE,
+                "1.0.0",
+                "support/welcome-v1.0.0",
+                "release/support-welcome-1.0.0",
+                11,
+                "https://github.com/promptLM/promptlm-app/pull/11",
+                false
+        ));
+
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
+        when(promptLifecycleFacade.release(promptId)).thenReturn(requested);
+
+        mockMvc.perform(post("/api/prompts/{promptSpecId}/release", promptId))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-PromptLM-Release-State", "requested"))
+                .andExpect(jsonPath("$.extensions['x-promptlm'].release.state").value("requested"));
+
+        verify(promptLifecycleFacade).release(promptId);
+        verify(promptStore, times(0)).release(any(PromptSpec.class));
+    }
+
+    @Test
+    void completeReleaseEndpointDelegatesToLifecycleAndSetsReleaseStateHeader() throws Exception {
+        String promptId = "support/welcome";
+        PromptSpec stored = PromptSpec.builder()
+                .withGroup("support")
+                .withName("welcome")
+                .withVersion("1.0.0-SNAPSHOT")
+                .withRevision(3)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder()
+                        .withVendor("openai")
+                        .withModel("gpt-4o")
+                        .withMessages(List.of())
+                        .build())
+                .build()
+                .withId(promptId);
+        PromptSpec released = stored.withVersion("1.0.0").withReleaseMetadata(new ReleaseMetadata(
+                ReleaseMetadata.STATE_RELEASED,
+                ReleaseMetadata.MODE_PR_TWO_PHASE,
+                "1.0.0",
+                "support/welcome-v1.0.0",
+                "main",
+                11,
+                "https://github.com/promptLM/promptlm-app/pull/11",
+                false
+        ));
+
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
+        when(promptLifecycleFacade.completeRelease(promptId, "11")).thenReturn(released);
+
+        mockMvc.perform(post("/api/prompts/{promptSpecId}/release/complete", promptId).queryParam("pr", "11"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-PromptLM-Release-State", "released"))
+                .andExpect(jsonPath("$.extensions['x-promptlm'].release.state").value("released"));
+
+        verify(promptLifecycleFacade).completeRelease(promptId, "11");
     }
 
     @Test

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/llm/ModelCatalogServiceTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/llm/ModelCatalogServiceTest.java
@@ -21,7 +21,6 @@ import dev.promptlm.execution.gateway.GatewayResponse;
 import dev.promptlm.execution.litellm.LiteLlmGatewayProperties;
 import dev.promptlm.domain.promptspec.PromptSpec;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 
 import java.util.List;
 import java.util.Map;
@@ -36,7 +35,7 @@ class ModelCatalogServiceTest {
         SpringAiVendorClient vendorClient = new StubVendorClient("openai", Set.of("gpt-4o", "gpt-4o-mini"));
         ModelCatalogService service = new ModelCatalogService(
                 List.of(vendorClient),
-                new StaticObjectProvider<>(null),
+                null,
                 new ModelCatalogProperties()
         );
 
@@ -58,7 +57,7 @@ class ModelCatalogServiceTest {
 
         ModelCatalogService service = new ModelCatalogService(
                 List.of(vendorClient),
-                new StaticObjectProvider<>(null),
+                null,
                 properties
         );
 
@@ -80,7 +79,7 @@ class ModelCatalogServiceTest {
 
         ModelCatalogService service = new ModelCatalogService(
                 List.of(),
-                new StaticObjectProvider<>(liteLlmProperties),
+                liteLlmProperties,
                 new ModelCatalogProperties()
         );
 
@@ -126,31 +125,4 @@ class ModelCatalogServiceTest {
         }
     }
 
-    private static final class StaticObjectProvider<T> implements ObjectProvider<T> {
-        private final T value;
-
-        private StaticObjectProvider(T value) {
-            this.value = value;
-        }
-
-        @Override
-        public T getObject(Object... args) {
-            return value;
-        }
-
-        @Override
-        public T getObject() {
-            return value;
-        }
-
-        @Override
-        public T getIfAvailable() {
-            return value;
-        }
-
-        @Override
-        public T getIfUnique() {
-            return value;
-        }
-    }
 }

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/editorActions.test.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/editorActions.test.ts
@@ -47,7 +47,7 @@ const buildDraft = (): PromptDraftInput => ({
   evaluations: [],
 });
 
-const buildPrompt = (id: string): PromptSpec =>
+const buildPrompt = (id: string, state: 'requested' | 'released' = 'released'): PromptSpec =>
   ({
     id,
     name: 'support-prompt',
@@ -67,6 +67,20 @@ const buildPrompt = (id: string): PromptSpec =>
       endPattern: '}}',
       list: [{ name: 'customer_name', defaultValue: 'Taylor' }],
       defaults: { customer_name: 'Taylor' },
+    },
+    extensions: {
+      'x-promptlm': {
+        release: {
+          state,
+          mode: state === 'requested' ? 'pr_two_phase' : 'direct',
+          version: '1.0.0',
+          tag: 'support-prompt-v1.0.0',
+          branch: state === 'requested' ? 'release/support-prompt-1.0.0' : 'main',
+          prNumber: state === 'requested' ? 11 : undefined,
+          prUrl: state === 'requested' ? 'https://github.com/promptLM/promptlm-app/pull/11' : undefined,
+          existing: false,
+        },
+      },
     },
   }) as PromptSpec;
 
@@ -273,6 +287,22 @@ describe('releasePromptAction', () => {
     });
   });
 
+  it('shows requested messaging when the release state is requested', async () => {
+    const releasePrompt = vi.fn().mockResolvedValue(buildPrompt('prompt-30', 'requested'));
+
+    const result = await releasePromptAction({
+      mode: 'edit',
+      createdPromptId: null,
+      promptId: 'prompt-30',
+      releasePrompt,
+    });
+
+    expect(result.toast).toEqual({
+      severity: 'success',
+      message: 'Release requested.',
+    });
+  });
+
   it('returns display errors when release fails', async () => {
     const releasePrompt = vi.fn().mockRejectedValue(new Error('release failed'));
 
@@ -286,6 +316,26 @@ describe('releasePromptAction', () => {
     expect(result.toast).toEqual({
       severity: 'error',
       message: 'release failed',
+    });
+  });
+
+  it('returns display errors when release metadata is missing', async () => {
+    const promptWithoutMetadata = {
+      ...buildPrompt('prompt-40'),
+      extensions: undefined,
+    } as PromptSpec;
+    const releasePrompt = vi.fn().mockResolvedValue(promptWithoutMetadata);
+
+    const result = await releasePromptAction({
+      mode: 'edit',
+      createdPromptId: null,
+      promptId: 'prompt-40',
+      releasePrompt,
+    });
+
+    expect(result.toast).toEqual({
+      severity: 'error',
+      message: 'Release response is missing x-promptlm metadata.',
     });
   });
 });

--- a/components/promptlm-web-ui/src/features/prompt-editor/editorActions.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/editorActions.ts
@@ -160,6 +160,26 @@ export type ReleasePromptResult = {
   toast: ActionToast | null;
 };
 
+const readReleaseState = (prompt: PromptSpec): 'requested' | 'released' => {
+  const extensions = (prompt.extensions ?? {}) as Record<string, unknown>;
+  const promptlm = extensions['x-promptlm'];
+  if (!promptlm || typeof promptlm !== 'object') {
+    throw new Error('Release response is missing x-promptlm metadata.');
+  }
+
+  const release = (promptlm as Record<string, unknown>).release;
+  if (!release || typeof release !== 'object') {
+    throw new Error('Release response is missing x-promptlm.release metadata.');
+  }
+
+  const state = (release as Record<string, unknown>).state;
+  if (state === 'requested' || state === 'released') {
+    return state;
+  }
+
+  throw new Error(`Unsupported release state '${String(state)}'.`);
+};
+
 export const releasePromptAction = async ({
   mode,
   createdPromptId,
@@ -178,13 +198,21 @@ export const releasePromptAction = async ({
 
   try {
     const released = await releasePrompt(releasablePromptId);
+    const releaseState = readReleaseState(released);
+    const toastMessage =
+      releaseState === 'requested'
+        ? 'Release requested.'
+        : mode === 'edit'
+          ? 'Prompt released.'
+          : 'Prompt published.';
+
     return {
       releasedPrompt: released,
       nextCreatedPromptId: mode === 'create' ? (released.id ?? releasablePromptId) : createdPromptId,
       shouldRefreshPrompt: mode === 'edit',
       toast: {
         severity: 'success',
-        message: mode === 'edit' ? 'Prompt released.' : 'Prompt published.',
+        message: toastMessage,
       },
     };
   } catch (error) {


### PR DESCRIPTION
## Summary
- introduce release metadata and explicit release domain events
- add configurable release promotion modes (`direct` and `pr_two_phase`) with PR gateway abstractions
- implement release request + release completion flow across store, lifecycle, API, CLI, and generated client
- gate `prompt release complete` CLI availability so it is only exposed in `pr_two_phase` mode

## Validation
- `mvn -pl apps/promptlm-cli -am test -DskipITs`
- `mvn -pl apps/promptlm-cli -Dtest=PromptCommandsTest test`
