### PR TITLE
fix(release): upload correct JAR artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-jars
-          path: apps/**/target/*-exec.jar
+          path: |
+            apps/**/target/*.jar
+            !apps/**/target/*.jar.original
           if-no-files-found: error
           retention-days: 1
           overwrite: true


### PR DESCRIPTION
## Problem

Release run https://github.com/promptLM/promptlm-app/actions/runs/24709931054/job/72271858124 failed in `Upload JAR Artifact` with:\n\n`No files were found with the provided path: apps/**/target/*-exec.jar`\n\nSpring Boot repackage now leaves deployable artifacts as `*.jar` and keeps originals as `*.jar.original`.\n\n## Fix\n- Update release workflow artifact glob to:\n  - include `apps/**/target/*.jar`\n  - exclude `apps/**/target/*.jar.original`\n\n## Verification\n- Local build:\n  - `mvn -pl apps/promptlm-cli,apps/promptlm-webapp -am -DskipTests package`\n- Confirmed glob matches exactly:\n  - `apps/promptlm-cli/target/promptlm-cli-<version>.jar`\n  - `apps/promptlm-webapp/target/promptlm-webapp-<version>.jar`\n  - and excludes both `*.jar.original` files.