### PR TITLE
fix(release): make reruns idempotent when Maven version exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,39 @@ jobs:
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
 
+      - name: Check if release version is already published
+        id: release-version-check
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.calculate_version.outputs.version }}"
+          package_name="dev.promptlm.promptlm-parent"
+          versions_file="$(mktemp)"
+          error_file="$(mktemp)"
+
+          set +e
+          gh api "/orgs/promptlm/packages/maven/${package_name}/versions?per_page=100" --paginate --jq '.[].name' >"$versions_file" 2>"$error_file"
+          api_exit=$?
+          set -e
+
+          if [[ $api_exit -eq 0 ]]; then
+            if grep -Fxq "$version" "$versions_file"; then
+              echo "already_published=true" >> "$GITHUB_OUTPUT"
+              echo "Release version ${version} already exists in GitHub Packages. Skipping deploy and rebuilding release jars only."
+            else
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+              echo "Release version ${version} not found in GitHub Packages. Running full Maven release deploy."
+            fi
+          elif grep -Eq "404|Package not found" "$error_file"; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "Maven package ${package_name} not found yet. Treating release version ${version} as not published."
+          else
+            cat "$error_file" >&2
+            exit "$api_exit"
+          fi
+
       - name: Prepare Maven Release
+        if: steps.release-version-check.outputs.already_published != 'true'
         run: |
           mvn -B release:clean release:prepare \
             -DscmCredentialsId=github \
@@ -115,7 +147,14 @@ jobs:
             -DdevelopmentVersion=${{ needs.calculate_version.outputs.version }}-SNAPSHOT
 
       - name: Perform Maven Release
+        if: steps.release-version-check.outputs.already_published != 'true'
         run: mvn release:perform -DlocalCheckout=true
+
+      - name: Rebuild app jars for already-published release version
+        if: steps.release-version-check.outputs.already_published == 'true'
+        run: |
+          mvn -B versions:set -DnewVersion=${{ needs.calculate_version.outputs.version }} -DgenerateBackupPoms=false
+          mvn -B -pl apps/promptlm-cli,apps/promptlm-webapp -am -DskipTests package
 
       - name: Upload JAR Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem
Release reruns can fail very early with Maven deploy 409 conflicts when the target release version was already published to GitHub Packages in a previous attempt:

`Could not transfer artifact ... status code: 409, Conflict`

This blocks rerunning the workflow to recover from later-step failures (for example artifact upload/release-asset steps).

## Fix
In the `release` job:
- add a pre-check against GitHub Packages for `dev.promptlm.promptlm-parent:<releaseVersion>`
- if already published: skip `release:prepare` and `release:perform`
- rebuild only app jars at the target release version (`versions:set` + package) so downstream artifact/release steps can continue
- if not published: keep the existing full Maven release deploy path

## Local verification
- Verified package-version check logic against an existing version (`0.2.0`) => `already_published=true`
- Verified package-version check logic against a missing version (`9.9.9`) => `already_published=false`
- Verified fallback path in a disposable worktree by running:
  - `mvn -B versions:set -DnewVersion=0.2.0 -DgenerateBackupPoms=false`
  - `mvn -B -pl apps/promptlm-cli,apps/promptlm-webapp -am -DskipTests package`
  - Confirmed resulting jars:
    - `apps/promptlm-cli/target/promptlm-cli-0.2.0.jar`
    - `apps/promptlm-webapp/target/promptlm-webapp-0.2.0.jar`
