### PR TITLE
Fix release workflow ordering and rerun idempotency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,39 @@ jobs:
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
 
+      - name: Check if release version is already published
+        id: release-version-check
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.calculate_version.outputs.version }}"
+          package_name="dev.promptlm.promptlm-parent"
+          versions_file="$(mktemp)"
+          error_file="$(mktemp)"
+
+          set +e
+          gh api "/orgs/promptlm/packages/maven/${package_name}/versions?per_page=100" --paginate --jq '.[].name' >"$versions_file" 2>"$error_file"
+          api_exit=$?
+          set -e
+
+          if [[ $api_exit -eq 0 ]]; then
+            if grep -Fxq "$version" "$versions_file"; then
+              echo "already_published=true" >> "$GITHUB_OUTPUT"
+              echo "Release version ${version} already exists in GitHub Packages. Skipping deploy and rebuilding release jars only."
+            else
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+              echo "Release version ${version} not found in GitHub Packages. Running full Maven release deploy."
+            fi
+          elif grep -Eq "404|Package not found" "$error_file"; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "Maven package ${package_name} not found yet. Treating release version ${version} as not published."
+          else
+            cat "$error_file" >&2
+            exit "$api_exit"
+          fi
+
       - name: Prepare Maven Release
+        if: steps.release-version-check.outputs.already_published != 'true'
         run: |
           mvn -B release:clean release:prepare \
             -DscmCredentialsId=github \
@@ -115,7 +147,14 @@ jobs:
             -DdevelopmentVersion=${{ needs.calculate_version.outputs.version }}-SNAPSHOT
 
       - name: Perform Maven Release
+        if: steps.release-version-check.outputs.already_published != 'true'
         run: mvn release:perform -DlocalCheckout=true
+
+      - name: Rebuild app jars for already-published release version
+        if: steps.release-version-check.outputs.already_published == 'true'
+        run: |
+          mvn -B versions:set -DnewVersion=${{ needs.calculate_version.outputs.version }} -DgenerateBackupPoms=false
+          mvn -B -pl apps/promptlm-cli,apps/promptlm-webapp -am -DskipTests package
 
       - name: Upload JAR Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           echo "version=$next_version" >> "$GITHUB_OUTPUT"
 
   release:
-    needs: calculate_version
+    needs: [calculate_version, build-native-matrix, native-smoke]
     runs-on: ubuntu-latest
     env:
       GITHUB_ACTOR: ${{ github.actor }}
@@ -168,7 +168,7 @@ jobs:
           overwrite: true
 
   build-native-matrix:
-    needs: release
+    needs: calculate_version
     strategy:
       fail-fast: false
       matrix:
@@ -242,7 +242,7 @@ jobs:
           overwrite: true
 
   native-smoke:
-    needs: release
+    needs: calculate_version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- make release reruns idempotent by skipping release prepare/perform when the target version is already published
- rebuild only app jars in the already-published path so GitHub release assets can still be produced
- reorder workflow dependencies so native matrix + native smoke must pass before the release/deploy job runs

## Why
- rerunning a release for an already-published Maven version currently fails with HTTP 409 and aborts
- release/deploy was running before native validation, which could publish artifacts even when downstream validation failed

## Validation
- local: `mvn -B -DskipTests -pl apps/promptlm-cli,apps/promptlm-webapp -am package`
- local: workflow YAML parses successfully (`ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`)
- remote investigation: verified failure mode in run `24713045937` (native jobs failed after release had already executed)
