### PR TITLE
Fix release workflow gating and native release stability

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25.0.2'
           distribution: 'graalvm-community'
           components: 'native-image'
       - name: Build native executables
@@ -41,7 +41,7 @@ jobs:
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25.0.2'
           distribution: 'graalvm-community'
           components: 'native-image'
       - name: Build native executables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,39 @@ jobs:
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
 
+      - name: Check if release version is already published
+        id: release-version-check
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.calculate_version.outputs.version }}"
+          package_name="dev.promptlm.promptlm-parent"
+          versions_file="$(mktemp)"
+          error_file="$(mktemp)"
+
+          set +e
+          gh api "/orgs/promptlm/packages/maven/${package_name}/versions?per_page=100" --paginate --jq '.[].name' >"$versions_file" 2>"$error_file"
+          api_exit=$?
+          set -e
+
+          if [[ $api_exit -eq 0 ]]; then
+            if grep -Fxq "$version" "$versions_file"; then
+              echo "already_published=true" >> "$GITHUB_OUTPUT"
+              echo "Release version ${version} already exists in GitHub Packages. Skipping deploy and rebuilding release jars only."
+            else
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+              echo "Release version ${version} not found in GitHub Packages. Running full Maven release deploy."
+            fi
+          elif grep -Eq "404|Package not found" "$error_file"; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "Maven package ${package_name} not found yet. Treating release version ${version} as not published."
+          else
+            cat "$error_file" >&2
+            exit "$api_exit"
+          fi
+
       - name: Prepare Maven Release
+        if: steps.release-version-check.outputs.already_published != 'true'
         run: |
           mvn -B release:clean release:prepare \
             -DscmCredentialsId=github \
@@ -115,7 +147,14 @@ jobs:
             -DdevelopmentVersion=${{ needs.calculate_version.outputs.version }}-SNAPSHOT
 
       - name: Perform Maven Release
+        if: steps.release-version-check.outputs.already_published != 'true'
         run: mvn release:perform -DlocalCheckout=true
+
+      - name: Rebuild app jars for already-published release version
+        if: steps.release-version-check.outputs.already_published == 'true'
+        run: |
+          mvn -B versions:set -DnewVersion=${{ needs.calculate_version.outputs.version }} -DgenerateBackupPoms=false
+          mvn -B -pl apps/promptlm-cli,apps/promptlm-webapp -am -DskipTests package
 
       - name: Upload JAR Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ on:
           - minor
           - patch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   calculate_version:
     runs-on: ubuntu-latest
@@ -75,8 +79,35 @@ jobs:
           next_version="${major}.${minor}.${patch}"
           echo "version=$next_version" >> "$GITHUB_OUTPUT"
 
+  jvm-verify:
+    needs: calculate_version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Run JVM build and tests
+        run: mvn -B verify
+      - name: Run acceptance tests
+        run: mvn -B -f acceptance-tests/pom.xml -Dpromptlm.bootstrap.skip=true test
+      - name: Upload Acceptance Test Artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-acceptance-tests-${{ github.sha }}
+          if-no-files-found: warn
+          path: |
+            acceptance-tests/target/surefire-reports/**
+            acceptance-tests/target/screenshots/**
+            acceptance-tests/target/traces/**
+          retention-days: 1
+
   release:
-    needs: [calculate_version, build-native-matrix, native-smoke]
+    needs: [calculate_version, jvm-verify, build-native-matrix, native-smoke]
     runs-on: ubuntu-latest
     env:
       GITHUB_ACTOR: ${{ github.actor }}
@@ -148,7 +179,7 @@ jobs:
 
       - name: Perform Maven Release
         if: steps.release-version-check.outputs.already_published != 'true'
-        run: mvn release:perform -DlocalCheckout=true
+        run: mvn -B release:perform -DlocalCheckout=true -Darguments="-DdeployAtEnd=true"
 
       - name: Rebuild app jars for already-published release version
         if: steps.release-version-check.outputs.already_published == 'true'
@@ -185,7 +216,7 @@ jobs:
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25.0.2'
           distribution: 'graalvm-community'
           components: 'native-image'
       - name: Build native executables
@@ -249,7 +280,7 @@ jobs:
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25.0.2'
           distribution: 'graalvm-community'
           components: 'native-image'
       - name: Build native executables
@@ -371,6 +402,8 @@ jobs:
         uses: mikepenz/action-gh-release@v1
         with:
           tag_name: v${{ needs.calculate_version.outputs.version }}
+          allowUpdates: true
+          replacesArtifacts: true
           files: |
             target/jars/**/*.jar
             target/native/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           echo "version=$next_version" >> "$GITHUB_OUTPUT"
 
   release:
-    needs: calculate_version
+    needs: [calculate_version, build-native-matrix, native-smoke]
     runs-on: ubuntu-latest
     env:
       GITHUB_ACTOR: ${{ github.actor }}
@@ -168,7 +168,7 @@ jobs:
           overwrite: true
 
   build-native-matrix:
-    needs: release
+    needs: calculate_version
     strategy:
       fail-fast: false
       matrix:
@@ -242,7 +242,7 @@ jobs:
           overwrite: true
 
   native-smoke:
-    needs: release
+    needs: calculate_version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/acceptance-tests/src/test/java/dev/promptlm/test/NativeCliSmokeTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/NativeCliSmokeTest.java
@@ -149,7 +149,10 @@ class NativeCliSmokeTest {
 
         NativeBinaryLauncher.CommandResult releasePrompt = runCliCommand(List.of("prompt", "release", "--id", promptId));
         assertCommandSucceeded(releasePrompt);
-        assertThat(releasePrompt.output()).contains("-SNAPSHOT");
+        String releaseLine = lastNonBlankLine(releasePrompt.output());
+        assertThat(releaseLine)
+                .as("Release output should contain either a release version, a next development version, or a PR request marker")
+                .matches("^(requested\\s+\\S+\\s+pr#\\d+|\\d+\\.\\d+\\.\\d+(?:-SNAPSHOT)?)$");
     }
 
     /**

--- a/apps/promptlm-cli/pom.xml
+++ b/apps/promptlm-cli/pom.xml
@@ -129,6 +129,7 @@
                         <executions>
                             <execution>
                                 <id>process-aot</id>
+                                <phase>process-classes</phase>
                                 <goals>
                                     <goal>process-aot</goal>
                                 </goals>

--- a/apps/promptlm-cli/src/main/java/dev/promptlm/CliApplication.java
+++ b/apps/promptlm-cli/src/main/java/dev/promptlm/CliApplication.java
@@ -17,8 +17,6 @@
 package dev.promptlm;
 
 import dev.promptlm.infrastructure.config.ObjectMapperConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -36,8 +34,6 @@ import org.springframework.shell.core.command.CommandRegistry;
 @SpringBootApplication
 @Import(ObjectMapperConfiguration.class)
 public class CliApplication {
-    
-    private static final Logger log = LoggerFactory.getLogger(CliApplication.class);
 
     public static void main(String[] args) {
         new SpringApplicationBuilder(CliApplication.class)
@@ -83,10 +79,17 @@ public class CliApplication {
             new NonInteractiveShellRunner(commandParser, commandRegistry).run(sourceArgs);
         }
         catch (CommandNotFoundException ex) {
-            log.error("Error: Command '%s' not found.".formatted(ex.getCommandName()));
+            throw new IllegalArgumentException("Command '%s' not found.".formatted(ex.getCommandName()), ex);
         }
         catch (CommandExecutionException ex) {
-            log.error("Error: " + ex);
+            Throwable rootCause = ex;
+            while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+                rootCause = rootCause.getCause();
+            }
+            String message = rootCause != ex
+                    ? "Error executing command: " + rootCause
+                    : "Error executing command.";
+            throw new IllegalStateException(message, ex);
         }
     }
 

--- a/apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptLmUiLauncher.java
+++ b/apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptLmUiLauncher.java
@@ -165,6 +165,7 @@ public class PromptLmUiLauncher {
                 removeShutdownHook(shutdownHook);
             }
         }, "promptlm-ui-process-waiter");
+        waiter.setDaemon(true);
         waiter.start();
     }
 

--- a/apps/promptlm-webapp/pom.xml
+++ b/apps/promptlm-webapp/pom.xml
@@ -247,6 +247,22 @@ limitations under the License.
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>process-aot</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>process-aot</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
                         <version>${native.maven.plugin.version}</version>

--- a/components/promptlm-core/src/main/java/dev/promptlm/infrastructure/config/AppContextNativeRuntimeHints.java
+++ b/components/promptlm-core/src/main/java/dev/promptlm/infrastructure/config/AppContextNativeRuntimeHints.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.infrastructure.config;
+
+import dev.promptlm.domain.AppContext;
+import dev.promptlm.domain.BasicAppContext;
+import dev.promptlm.domain.projectspec.ProjectHealthStatus;
+import dev.promptlm.domain.projectspec.ProjectSpec;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+
+@Configuration(proxyBeanMethods = false)
+@ImportRuntimeHints(AppContextNativeRuntimeHints.Hints.class)
+class AppContextNativeRuntimeHints {
+
+    static final class Hints implements RuntimeHintsRegistrar {
+
+        @Override
+        public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+            for (Class<?> type : new Class<?>[]{
+                    AppContext.class,
+                    BasicAppContext.class,
+                    ChangeAwareBasicAppContext.class,
+                    ProjectSpec.class,
+                    ProjectHealthStatus.class
+            }) {
+                hints.reflection().registerType(type, hint -> hint.withMembers(MemberCategory.values()));
+            }
+        }
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitNativeRuntimeHints.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitNativeRuntimeHints.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import dev.promptlm.domain.PathToStringSerializer;
+import dev.promptlm.domain.promptspec.ChatCompletionRequest;
+import dev.promptlm.domain.promptspec.ChatCompletionResponse;
+import dev.promptlm.domain.promptspec.Evaluation;
+import dev.promptlm.domain.promptspec.EvaluationExtensions;
+import dev.promptlm.domain.promptspec.EvaluationResult;
+import dev.promptlm.domain.promptspec.EvaluationResults;
+import dev.promptlm.domain.promptspec.EvaluationSpec;
+import dev.promptlm.domain.promptspec.EvaluationStatus;
+import dev.promptlm.domain.promptspec.Execution;
+import dev.promptlm.domain.promptspec.ImagesGenerationsRequest;
+import dev.promptlm.domain.promptspec.PromptEvaluationDefinition;
+import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.ReleaseExtensions;
+import dev.promptlm.domain.promptspec.ReleaseMetadata;
+import dev.promptlm.domain.promptspec.Request;
+import dev.promptlm.domain.promptspec.Response;
+import dev.promptlm.domain.promptspec.ResponseFormat;
+import org.eclipse.jgit.diff.DiffAlgorithm;
+import org.eclipse.jgit.lib.CoreConfig;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+
+/**
+ * Runtime hints required for JGit behavior in native images.
+ */
+@Configuration(proxyBeanMethods = false)
+@ImportRuntimeHints(GitNativeRuntimeHints.JGitRuntimeHints.class)
+class GitNativeRuntimeHints {
+
+    static final class JGitRuntimeHints implements RuntimeHintsRegistrar {
+
+        private static final Class<?>[] PROMPT_SPEC_TYPES = new Class[]{
+                ChatCompletionRequest.class,
+                ChatCompletionResponse.class,
+                Evaluation.class,
+                EvaluationExtensions.class,
+                EvaluationResult.class,
+                EvaluationResults.class,
+                EvaluationSpec.class,
+                EvaluationStatus.class,
+                Execution.class,
+                ImagesGenerationsRequest.class,
+                PromptEvaluationDefinition.class,
+                PromptSpec.class,
+                PathToStringSerializer.class,
+                ReleaseExtensions.class,
+                ReleaseMetadata.class,
+                Request.class,
+                Response.class,
+                ResponseFormat.class,
+                GitRepositoryMetadataFile.class
+        };
+
+        @Override
+        public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+            hints.resources().registerPattern("repo-template.zip");
+            registerPromptSpecTypes(hints);
+            registerJGitEnumTypes(hints);
+        }
+
+        private static void registerPromptSpecTypes(RuntimeHints hints) {
+            for (Class<?> type : PROMPT_SPEC_TYPES) {
+                registerTypeAndNestedTypes(hints, type);
+            }
+        }
+
+        private static void registerJGitEnumTypes(RuntimeHints hints) {
+            registerNestedEnumTypes(hints, CoreConfig.class);
+            registerNestedEnumTypes(hints, DiffAlgorithm.class);
+        }
+
+        private static void registerNestedEnumTypes(RuntimeHints hints, Class<?> typeWithNestedEnums) {
+            for (Class<?> nestedClass : typeWithNestedEnums.getDeclaredClasses()) {
+                if (!nestedClass.isEnum()) {
+                    continue;
+                }
+                hints.reflection().registerType(nestedClass, hint -> hint.withMembers(
+                        MemberCategory.INVOKE_PUBLIC_METHODS,
+                        MemberCategory.INVOKE_DECLARED_METHODS
+                ));
+            }
+        }
+
+        private static void registerTypeAndNestedTypes(RuntimeHints hints, Class<?> type) {
+            hints.reflection().registerType(type, hint -> hint.withMembers(MemberCategory.values()));
+            for (Class<?> nestedClass : type.getDeclaredClasses()) {
+                hints.reflection().registerType(nestedClass, hint -> hint.withMembers(MemberCategory.values()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- gate the `release` job behind JVM verification and acceptance tests so release deploy cannot run before checks
- harden release reruns by checking already-published versions, using `deployAtEnd`, and allowing GitHub release artifact replacement
- align native workflows to GraalVM 25.0.2 and keep native-smoke as an explicit gate
- fix native runtime issues found in CLI/webapp release flow (AOT phase wiring, runtime hints, non-interactive CLI exit behavior, UI waiter daemon)
- update native smoke assertion to accept direct-release output as well as PR-mode output

## Validation
- `mvn -B verify`
- `mvn -B -f acceptance-tests/pom.xml -Dpromptlm.bootstrap.skip=true test`
- `mvn -B -Pnative -pl apps/promptlm-cli,apps/promptlm-webapp -am -DskipTests package`
- `mvn -B -DskipTests -pl components/repository-template -am install`
- `mvn -B -f acceptance-tests/pom.xml -Dpromptlm.test.groups=native-smoke -Dpromptlm.test.excludedGroups= -Dpromptlm.test.cli.native.path=../apps/promptlm-cli/target/promptlm-cli -Dpromptlm.test.webapp.native.path=../apps/promptlm-webapp/target/promptlm-webapp test`

All local runs above passed.
