### PR TITLE
Fix release workflow gating and first-release changelog handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,14 +386,31 @@ jobs:
           )
           cat target/native/SHA256SUMS
 
+      - name: Check whether repository has release tags
+        id: tag-check
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_count="$(gh api "/repos/${{ github.repository }}/tags?per_page=1" --jq 'length')"
+          if [[ "$tag_count" -gt 0 ]]; then
+            echo "has_tags=true" >> "$GITHUB_OUTPUT"
+            echo "Found existing tags; changelog will be generated from tag history."
+          else
+            echo "has_tags=false" >> "$GITHUB_OUTPUT"
+            echo "No existing tags found; using initial release notes fallback."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate Changelog
+        if: steps.tag-check.outputs.has_tags == 'true'
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           configurationJson: |
             {
               "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
-              "pr_templatze": "#{{TITLE}} (#{{ASSIGNEES[*]}})",
+              "pr_template": "#{{TITLE}} (#{{ASSIGNEES[*]}})",
               "categories": [
                 {
                   "title": "## 🚀 Features",
@@ -412,7 +429,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create Release
+      - name: Create Release (With Changelog)
+        if: steps.tag-check.outputs.has_tags == 'true'
         uses: mikepenz/action-gh-release@v1
         with:
           tag_name: v${{ needs.calculate_version.outputs.version }}
@@ -421,6 +439,28 @@ jobs:
           files: |
             target/jars/**/*.jar
             target/native/*
-          body: ${{steps.changelog.outputs.changelog}}
+          body: ${{ steps.changelog.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release (Initial Notes Fallback)
+        if: steps.tag-check.outputs.has_tags != 'true'
+        uses: mikepenz/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.calculate_version.outputs.version }}
+          allowUpdates: true
+          replacesArtifacts: true
+          files: |
+            target/jars/**/*.jar
+            target/native/*
+          body: |
+            ## Initial Release v${{ needs.calculate_version.outputs.version }}
+
+            This is the first published PromptLM release in this repository.
+
+            Included assets:
+            - JVM app JARs
+            - Native binaries for Linux, macOS, and Windows
+            - SHA256 checksums for native binaries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,20 @@ jobs:
           cache: 'maven'
       - name: Run JVM build and tests
         run: mvn -B verify
+
+  jvm-acceptance:
+    needs: jvm-verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Install artifacts required by acceptance-tests
+        run: mvn -B -DskipTests -pl apps/promptlm-cli,apps/promptlm-webapp,components/repository-template -am install
       - name: Run acceptance tests
         run: mvn -B -f acceptance-tests/pom.xml -Dpromptlm.bootstrap.skip=true test
       - name: Upload Acceptance Test Artifacts
@@ -107,7 +121,7 @@ jobs:
           retention-days: 1
 
   release:
-    needs: [calculate_version, jvm-verify, build-native-matrix, native-smoke]
+    needs: [calculate_version, jvm-verify, jvm-acceptance, build-native-matrix, native-smoke]
     runs-on: ubuntu-latest
     env:
       GITHUB_ACTOR: ${{ github.actor }}
@@ -199,7 +213,7 @@ jobs:
           overwrite: true
 
   build-native-matrix:
-    needs: calculate_version
+    needs: jvm-acceptance
     strategy:
       fail-fast: false
       matrix:
@@ -273,7 +287,7 @@ jobs:
           overwrite: true
 
   native-smoke:
-    needs: calculate_version
+    needs: jvm-acceptance
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,8 +299,8 @@ jobs:
           components: 'native-image'
       - name: Build native executables
         run: mvn -B -Pnative -pl apps/promptlm-cli,apps/promptlm-webapp -am -DskipTests package
-      - name: Install repository-template for acceptance test classpath
-        run: mvn -B -DskipTests -pl components/repository-template -am install
+      - name: Install artifacts required by acceptance-tests
+        run: mvn -B -DskipTests -pl apps/promptlm-cli,apps/promptlm-webapp,components/repository-template -am install
       - name: Run native smoke acceptance tests
         run: |
           mvn -B -f acceptance-tests/pom.xml \


### PR DESCRIPTION
## Summary
- split JVM verification from acceptance tests in the release workflow
- install module artifacts before acceptance and native-smoke acceptance jobs
- make changelog generation conditional on existing tags and add initial-release notes fallback
- fix changelog action config key typo (`pr_template`)

## Why
The release run failed in `create-github-release` when no tags existed in the repository (`git describe --tags` exit 128). This change makes first release runs succeed while keeping changelog generation for subsequent tagged releases.

## Validation
- local YAML parse: `.github/workflows/release.yml`
- local tag detection script returns `has_tags=false` in current no-tag repo state
- reviewed failing run `24771592013` (only changelog step failed)
