### PR TITLE
Stabilize placeholder reliability for single-variant prompts

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
@@ -165,8 +165,18 @@ public class HappyPathUserJourneyTest {
 
         // add user message
         page.getByTestId("user-prompt-button").click();
-        Locator messageTextareas = page.getByTestId("prompt-messages").locator("textarea");
-        messageTextareas.last().fill("Number one [[number_one]] plus number two [[number_two]] equals?");
+        Locator promptTextarea = page.getByTestId("prompt-messages").locator("textarea").last();
+        promptTextarea.fill("Number one ");
+        insertPlaceholderToken("number_one");
+        promptTextarea = page.getByTestId("prompt-messages").locator("textarea").last();
+        promptTextarea.click();
+        page.keyboard().press("End");
+        page.keyboard().type(" plus number two ");
+        insertPlaceholderToken("number_two");
+        promptTextarea = page.getByTestId("prompt-messages").locator("textarea").last();
+        promptTextarea.click();
+        page.keyboard().press("End");
+        page.keyboard().type(" equals?");
 
         // Click the save button
         page.getByTestId("save-prompt-button").click();
@@ -195,7 +205,7 @@ public class HappyPathUserJourneyTest {
         assertThat(savedRequest.getMessages())
                 .isNotNull()
                 .anyMatch(message -> "user".equalsIgnoreCase(message.getRole())
-                        && "Number one 1 plus number two 2 equals?".equals(message.getContent()));
+                        && "Number one [[number_one]] plus number two [[number_two]] equals?".equals(message.getContent()));
     }
 
     @Test
@@ -386,6 +396,13 @@ public class HappyPathUserJourneyTest {
         valueEditor.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
         valueEditor.fill(value);
         page.keyboard().press("Escape");
+    }
+
+    private void insertPlaceholderToken(String placeholderName) {
+        Locator placeholderRow = page.getByTestId("placeholder-row-" + placeholderName);
+        placeholderRow.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
+        Locator placeholderToken = placeholderRow.locator("code").first();
+        placeholderToken.click();
     }
 
     // TODO: do only once

--- a/components/promptlm-web-ui/src/components/placeholders/PlaceholderManager.tsx
+++ b/components/promptlm-web-ui/src/components/placeholders/PlaceholderManager.tsx
@@ -18,7 +18,7 @@ import { Input } from '@promptlm/ui';
 import { Label } from '@promptlm/ui';
 import { Badge } from '@promptlm/ui';
 import { Textarea } from '@promptlm/ui';
-import { Plus, Trash2, X, Settings, ChevronDown } from 'lucide-react';
+import { Plus, Trash2, Settings, ChevronDown } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -32,7 +32,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@promptlm/ui';
-import { cn } from '@/lib/utils';
 
 export interface Placeholder {
   id: string;
@@ -64,9 +63,7 @@ export function PlaceholderManager({
 }: PlaceholderManagerProps) {
   const [newPlaceholderName, setNewPlaceholderName] = useState('');
   const [editingPlaceholder, setEditingPlaceholder] = useState<Placeholder | null>(null);
-  const [newValue, setNewValue] = useState('');
   const [configOpen, setConfigOpen] = useState(false);
-  const dialogDescriptionId = 'placeholder-config-description';
 
   const addPlaceholder = useCallback(() => {
     if (!newPlaceholderName.trim()) return;
@@ -94,43 +91,32 @@ export function PlaceholderManager({
   }, [placeholders, onPlaceholdersChange, editingPlaceholder]);
 
   const updatePlaceholder = useCallback((id: string, updates: Partial<Placeholder>) => {
+    const singleValue = updates.values ? [updates.values[0] ?? ''] : undefined;
     onPlaceholdersChange(
-      placeholders.map(p => p.id === id ? { ...p, ...updates } : p)
+      placeholders.map((placeholder) =>
+        placeholder.id === id
+          ? {
+              ...placeholder,
+              ...updates,
+              values: singleValue ?? placeholder.values,
+              currentValueIndex: 0,
+            }
+          : placeholder,
+      )
     );
     if (editingPlaceholder?.id === id) {
-      setEditingPlaceholder(prev => prev ? { ...prev, ...updates } : null);
+      setEditingPlaceholder((previous) =>
+        previous
+          ? {
+              ...previous,
+              ...updates,
+              values: singleValue ?? previous.values,
+              currentValueIndex: 0,
+            }
+          : null,
+      );
     }
   }, [placeholders, onPlaceholdersChange, editingPlaceholder]);
-
-  const addValueToPlaceholder = useCallback((id: string) => {
-    if (!newValue.trim()) return;
-    
-    const placeholder = placeholders.find(p => p.id === id);
-    if (!placeholder) return;
-    
-    updatePlaceholder(id, { values: [...placeholder.values, newValue.trim()] });
-    setNewValue('');
-  }, [newValue, placeholders, updatePlaceholder]);
-
-  const removeValueFromPlaceholder = useCallback((id: string, valueIndex: number) => {
-    const placeholder = placeholders.find(p => p.id === id);
-    if (!placeholder || placeholder.values.length <= 1) return;
-    
-    const newValues = placeholder.values.filter((_, i) => i !== valueIndex);
-    const newCurrentIndex = placeholder.currentValueIndex >= newValues.length 
-      ? newValues.length - 1 
-      : placeholder.currentValueIndex;
-    
-    updatePlaceholder(id, { values: newValues, currentValueIndex: newCurrentIndex });
-  }, [placeholders, updatePlaceholder]);
-
-  const cycleValue = useCallback((id: string) => {
-    const placeholder = placeholders.find(p => p.id === id);
-    if (!placeholder || placeholder.values.length <= 1) return;
-    
-    const nextIndex = (placeholder.currentValueIndex + 1) % placeholder.values.length;
-    updatePlaceholder(id, { currentValueIndex: nextIndex });
-  }, [placeholders, updatePlaceholder]);
 
   const formatPlaceholder = useCallback((name: string) => {
     return `${config.openSequence}${name}${config.closeSequence}`;
@@ -215,28 +201,20 @@ export function PlaceholderManager({
                 <div className="flex items-center gap-2">
                   <code
                     className="text-xs text-primary cursor-pointer hover:underline truncate"
-                    onClick={() => onInsertPlaceholder?.(placeholder.name)}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      onInsertPlaceholder?.(placeholder.name);
+                    }}
                     title="Click to insert"
                   >
                     {formatPlaceholder(placeholder.name)}
                   </code>
-                  <Badge
-                    variant="secondary"
-                    className="text-xs cursor-pointer hover:bg-secondary shrink-0"
-                    onClick={() => cycleValue(placeholder.id)}
-                    title="Click to cycle values"
-                  >
-                    {placeholder.values.length > 1 ? (
-                      <>
-                        {placeholder.currentValueIndex + 1}/{placeholder.values.length}
-                      </>
-                    ) : (
-                      '1 value'
-                    )}
+                  <Badge variant="secondary" className="text-xs shrink-0">
+                    1 value
                   </Badge>
                 </div>
                 <p className="text-xs text-muted-foreground truncate mt-0.5">
-                  {placeholder.values[placeholder.currentValueIndex] || '(empty)'}
+                  {placeholder.values[0] || '(empty)'}
                 </p>
               </div>
               <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -266,17 +244,8 @@ export function PlaceholderManager({
                     </DialogHeader>
                     <PlaceholderValueEditor
                       placeholder={placeholder}
-                      newValue={newValue}
-                      setNewValue={setNewValue}
-                      onAddValue={() => addValueToPlaceholder(placeholder.id)}
-                      onRemoveValue={(index) => removeValueFromPlaceholder(placeholder.id, index)}
-                      onSelectValue={(index) => updatePlaceholder(placeholder.id, { currentValueIndex: index })}
                       onUpdateDescription={(desc) => updatePlaceholder(placeholder.id, { description: desc })}
-                      onUpdateValue={(index, value) => {
-                        const newValues = [...placeholder.values];
-                        newValues[index] = value;
-                        updatePlaceholder(placeholder.id, { values: newValues });
-                      }}
+                      onUpdateValue={(value) => updatePlaceholder(placeholder.id, { values: [value], currentValueIndex: 0 })}
                     />
                   </DialogContent>
                 </Dialog>
@@ -303,22 +272,12 @@ export function PlaceholderManager({
 
 interface PlaceholderValueEditorProps {
   placeholder: Placeholder;
-  newValue: string;
-  setNewValue: (value: string) => void;
-  onAddValue: () => void;
-  onRemoveValue: (index: number) => void;
-  onSelectValue: (index: number) => void;
   onUpdateDescription: (description: string) => void;
-  onUpdateValue: (index: number, value: string) => void;
+  onUpdateValue: (value: string) => void;
 }
 
 function PlaceholderValueEditor({
   placeholder,
-  newValue,
-  setNewValue,
-  onAddValue,
-  onRemoveValue,
-  onSelectValue,
   onUpdateDescription,
   onUpdateValue,
 }: PlaceholderValueEditorProps) {
@@ -335,76 +294,16 @@ function PlaceholderValueEditor({
         />
       </div>
 
-      {/* Value Set */}
+      {/* Value */}
       <div className="space-y-2">
-        <Label className="text-xs">Value Set</Label>
-        <div className="space-y-2 max-h-[200px] overflow-y-auto scrollbar-thin">
-          {placeholder.values.map((value, index) => (
-            <div
-              key={index}
-              className={cn(
-                "flex items-start gap-2 p-2 rounded-md border transition-colors cursor-pointer",
-                index === placeholder.currentValueIndex
-                  ? "border-primary bg-primary/10"
-                  : "border-border bg-secondary/20 hover:border-primary/30"
-              )}
-              onClick={() => onSelectValue(index)}
-            >
-              <div className="flex-1">
-                <Textarea
-                  value={value}
-                  onChange={(e) => {
-                    e.stopPropagation();
-                    onUpdateValue(index, e.target.value);
-                  }}
-                  onClick={(e) => e.stopPropagation()}
-                  placeholder="Enter value..."
-                  data-testid={`placeholder-value-textarea-${placeholder.name}-${index}`}
-                  className="min-h-[60px] bg-transparent border-none p-0 resize-none focus-visible:ring-0 text-sm"
-                />
-              </div>
-              <div className="flex items-center gap-1 shrink-0">
-                {index === placeholder.currentValueIndex && (
-                  <Badge variant="default" className="text-xs">
-                    Active
-                  </Badge>
-                )}
-                {placeholder.values.length > 1 && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-muted-foreground hover:text-destructive"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onRemoveValue(index);
-                    }}
-                  >
-                    <X className="h-3 w-3" />
-                  </Button>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Add Value */}
-      <div className="flex gap-2">
-        <Input
-          placeholder="Add another value..."
-          value={newValue}
-          onChange={(e) => setNewValue(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && onAddValue()}
-          className="bg-secondary/30"
+        <Label className="text-xs">Value</Label>
+        <Textarea
+          value={placeholder.values[0] ?? ''}
+          onChange={(e) => onUpdateValue(e.target.value)}
+          placeholder="Enter value..."
+          data-testid={`placeholder-value-textarea-${placeholder.name}-0`}
+          className="min-h-[80px] bg-secondary/30 text-sm"
         />
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onAddValue}
-          disabled={!newValue.trim()}
-        >
-          <Plus className="h-4 w-4" />
-        </Button>
       </div>
     </div>
   );

--- a/components/promptlm-web-ui/src/components/placeholders/__tests__/PlaceholderManager.test.tsx
+++ b/components/promptlm-web-ui/src/components/placeholders/__tests__/PlaceholderManager.test.tsx
@@ -1,0 +1,101 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @vitest-environment jsdom */
+
+import React, { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { PlaceholderManager, type Placeholder } from '../PlaceholderManager';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderManager = async (props: {
+  placeholders: Placeholder[];
+  onPlaceholdersChange: (placeholders: Placeholder[]) => void;
+}) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <PlaceholderManager
+        placeholders={props.placeholders}
+        config={{ openSequence: '[[', closeSequence: ']]' }}
+        onPlaceholdersChange={props.onPlaceholdersChange}
+        onConfigChange={() => {}}
+      />,
+    );
+  });
+
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('PlaceholderManager', () => {
+  it('does not expose multi-value cycle affordances', async () => {
+    const onPlaceholdersChange = vi.fn();
+    const placeholders: Placeholder[] = [
+      {
+        id: 'placeholder-1',
+        name: 'number_one',
+        values: ['1', '2'],
+        currentValueIndex: 1,
+      },
+    ];
+
+    const view = await renderManager({ placeholders, onPlaceholdersChange });
+    try {
+      expect(view.container.querySelector('[title="Click to cycle values"]')).toBeNull();
+      expect(view.container.textContent).toContain('1 value');
+    } finally {
+      await view.unmount();
+    }
+  });
+
+  it('shows only one effective value even when multiple values are provided', async () => {
+    const onPlaceholdersChange = vi.fn();
+    const placeholders: Placeholder[] = [
+      {
+        id: 'placeholder-1',
+        name: 'number_one',
+        values: ['1', '2', '3'],
+        currentValueIndex: 2,
+      },
+    ];
+
+    const view = await renderManager({ placeholders, onPlaceholdersChange });
+    try {
+      const preview = view.container.querySelector('[data-testid="placeholder-row-number_one"] p');
+      expect(preview?.textContent).toContain('1');
+      expect(preview?.textContent).not.toContain('2');
+      expect(preview?.textContent).not.toContain('3');
+    } finally {
+      await view.unmount();
+    }
+  });
+});

--- a/components/promptlm-web-ui/src/features/prompt-editor/PromptEditorPage.tsx
+++ b/components/promptlm-web-ui/src/features/prompt-editor/PromptEditorPage.tsx
@@ -29,6 +29,7 @@ import { flushSync } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 
 import type {
+  MessageContentSelection,
   PromptEditorBannerMessage,
   PromptEditorEvaluationResult,
   PromptEditorExecution,
@@ -64,6 +65,7 @@ import {
 
 import { createEmptyPromptDraft, createPromptDraftFromPrompt, sanitizePromptDraft, usePromptEditorDraft } from './draftState';
 import { mergeExecutions, pickSelectedExecution, releasePromptAction, savePromptDraftAction } from './editorActions';
+import { createPlaceholderToken, insertPlaceholderToken } from './placeholderInsertion';
 import type { PromptEditorMode } from './types';
 import { usePromptEditorData } from './usePromptEditorData';
 import { validatePromptEditor } from './validation';
@@ -186,6 +188,7 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
   const [copied, setCopied] = useState(false);
   const [createdPromptId, setCreatedPromptId] = useState<string | null>(null);
   const [toolConfigs, setToolConfigs] = useState<PromptEditorToolConfig[]>([]);
+  const [messageSelection, setMessageSelection] = useState<MessageContentSelection | null>(null);
 
   const isEvaluationCapabilityEnabled = Boolean(capabilities.data?.features?.includes('evals'));
 
@@ -330,6 +333,33 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
     [placeholderManagerState.config, updatePlaceholderManager],
   );
 
+  const handleInsertPlaceholder = useCallback(
+    (name: string) => {
+      const token = createPlaceholderToken(
+        placeholderManagerState.config.openSequence,
+        name,
+        placeholderManagerState.config.closeSequence,
+      );
+      const insertion = insertPlaceholderToken(editor.state.draft.request.messages, token, messageSelection);
+      if (insertion.type === 'error') {
+        showToast('error', insertion.message);
+        return;
+      }
+
+      editor.updateMessage(insertion.messageIndex, 'content', insertion.nextContent);
+      if (insertion.type === 'selection') {
+        setMessageSelection({
+          messageIndex: insertion.messageIndex,
+          selectionStart: insertion.caretPosition,
+          selectionEnd: insertion.caretPosition,
+        });
+        return;
+      }
+      setMessageSelection(null);
+    },
+    [editor, messageSelection, placeholderManagerState.config.closeSequence, placeholderManagerState.config.openSequence, showToast],
+  );
+
   const handleAddToolConfig = useCallback(() => {
     setToolConfigs((previous) => [
       ...previous,
@@ -372,7 +402,6 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
       draft: editor.state.draft,
       evaluationEnabled: evaluationEnabledForPayload,
       validationHasErrors: currentValidation.hasErrors,
-      processText,
       createPrompt: data.createPrompt,
       updatePrompt: data.updatePrompt,
     });
@@ -697,7 +726,7 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
                       Placeholders
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
-                      Template variables injected before execution and save.
+                      Template variables resolved at runtime.
                     </Typography>
                   </Box>
                   {displayedValidation?.placeholders?.general ? (
@@ -710,6 +739,7 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
                     config={placeholderManagerState.config}
                     onPlaceholdersChange={handlePlaceholdersChange}
                     onConfigChange={handlePlaceholderConfigChange}
+                    onInsertPlaceholder={handleInsertPlaceholder}
                   />
                 </Stack>
               </Paper>
@@ -760,6 +790,7 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
                 onAddMessage={editor.addMessage}
                 onMessageChange={(index, field, value) => editor.updateMessage(index, field, value)}
                 onRemoveMessage={editor.removeMessage}
+                onContentSelectionChange={setMessageSelection}
                 onTryRun={handleTryRun}
                 onNavigateBack={() => navigate('/prompts')}
                 isBusy={isBusy}

--- a/components/promptlm-web-ui/src/features/prompt-editor/README.md
+++ b/components/promptlm-web-ui/src/features/prompt-editor/README.md
@@ -24,7 +24,7 @@ This feature owns the end-user prompt authoring experience in `@promptlm/web-ui`
 
 - API contract source of truth remains generated OpenAPI/AsyncAPI models in `@promptlm/api-client`.
 - `PromptEditorPage` works on `PromptDraftInput` and converts through `buildPromptSpecCreationRequest` / `buildExecutePromptRequest`.
-- Placeholder value substitution is applied only to runtime/request payload content before save/run.
+- Placeholder value substitution is applied only to runtime/request payload content before execution.
 
 ## Testing Strategy
 

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/editorActions.test.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/editorActions.test.ts
@@ -98,7 +98,6 @@ describe('savePromptDraftAction', () => {
       draft: buildDraft(),
       evaluationEnabled: false,
       validationHasErrors: false,
-      processText: (text) => text,
       createPrompt,
       updatePrompt,
     });
@@ -124,7 +123,6 @@ describe('savePromptDraftAction', () => {
       draft: buildDraft(),
       evaluationEnabled: false,
       validationHasErrors: true,
-      processText: (text) => text,
       createPrompt,
       updatePrompt,
     });
@@ -150,7 +148,6 @@ describe('savePromptDraftAction', () => {
       draft: buildDraft(),
       evaluationEnabled: true,
       validationHasErrors: false,
-      processText: (text) => text,
       createPrompt,
       updatePrompt,
     });
@@ -177,7 +174,6 @@ describe('savePromptDraftAction', () => {
       draft: buildDraft(),
       evaluationEnabled: false,
       validationHasErrors: false,
-      processText: (text) => text,
       createPrompt,
       updatePrompt,
     });
@@ -202,7 +198,6 @@ describe('savePromptDraftAction', () => {
       draft: buildDraft(),
       evaluationEnabled: false,
       validationHasErrors: false,
-      processText: (text) => text,
       createPrompt,
       updatePrompt,
     });
@@ -225,7 +220,6 @@ describe('savePromptDraftAction', () => {
       draft: buildDraft(),
       evaluationEnabled: false,
       validationHasErrors: false,
-      processText: (text) => text,
       createPrompt,
       updatePrompt,
     });
@@ -234,6 +228,44 @@ describe('savePromptDraftAction', () => {
       severity: 'error',
       message: 'save failed',
     });
+  });
+
+  it('persists raw placeholder tokens in saved message content', async () => {
+    const createPrompt = vi.fn().mockResolvedValue(buildPrompt('prompt-raw-token'));
+    const updatePrompt = vi.fn();
+    const draft = buildDraft();
+    draft.placeholders = {
+      startPattern: '[[',
+      endPattern: ']]',
+      list: [{ name: 'number_one', value: '1' }],
+      defaults: { number_one: '1' },
+    };
+    draft.request.messages = [
+      { role: 'user', content: 'Number one [[number_one]] equals?' },
+    ];
+
+    await savePromptDraftAction({
+      mode: 'create',
+      createdPromptId: null,
+      promptId: null,
+      activeProjectId: 'project-1',
+      activeProjectRepositoryUrl: 'https://example.com/repo',
+      draft,
+      evaluationEnabled: false,
+      validationHasErrors: false,
+      createPrompt,
+      updatePrompt,
+    });
+
+    expect(createPrompt).toHaveBeenCalledTimes(1);
+    const payload = createPrompt.mock.calls[0][0];
+    expect(payload.request?.messages).toEqual([
+      {
+        role: 'USER',
+        content: 'Number one [[number_one]] equals?',
+        name: undefined,
+      },
+    ]);
   });
 });
 

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/placeholderInsertion.test.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/placeholderInsertion.test.ts
@@ -1,0 +1,96 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+
+import { createPlaceholderToken, insertPlaceholderToken } from '../placeholderInsertion';
+
+describe('placeholder insertion helpers', () => {
+  it('builds tokens using configured delimiters', () => {
+    expect(createPlaceholderToken('[[', 'number_one', ']]')).toBe('[[number_one]]');
+  });
+
+  it('inserts token at focused caret location', () => {
+    const result = insertPlaceholderToken(
+      [{ role: 'user', content: 'Number one plus number two.' }],
+      '[[number_one]]',
+      {
+        messageIndex: 0,
+        selectionStart: 7,
+        selectionEnd: 7,
+      },
+    );
+
+    expect(result).toEqual({
+      type: 'selection',
+      messageIndex: 0,
+      nextContent: 'Number [[number_one]]one plus number two.',
+      caretPosition: 21,
+    });
+  });
+
+  it('replaces selected text when inserting token', () => {
+    const result = insertPlaceholderToken(
+      [{ role: 'user', content: 'Number one plus number two.' }],
+      '[[number_two]]',
+      {
+        messageIndex: 0,
+        selectionStart: 16,
+        selectionEnd: 26,
+      },
+    );
+
+    expect(result).toEqual({
+      type: 'selection',
+      messageIndex: 0,
+      nextContent: 'Number one plus [[number_two]].',
+      caretPosition: 30,
+    });
+  });
+
+  it('falls back to appending to the last user message when nothing is focused', () => {
+    const result = insertPlaceholderToken(
+      [
+        { role: 'system', content: 'You are a helper.' },
+        { role: 'assistant', content: 'How can I help?' },
+        { role: 'user', content: 'Answer: ' },
+      ],
+      '[[number_one]]',
+      null,
+    );
+
+    expect(result).toEqual({
+      type: 'fallback',
+      messageIndex: 2,
+      nextContent: 'Answer: [[number_one]]',
+      caretPosition: 22,
+    });
+  });
+
+  it('returns an error when no user message exists for fallback insertion', () => {
+    const result = insertPlaceholderToken(
+      [
+        { role: 'system', content: 'You are a helper.' },
+        { role: 'assistant', content: 'How can I help?' },
+      ],
+      '[[number_one]]',
+      null,
+    );
+
+    expect(result).toEqual({
+      type: 'error',
+      message: 'Add a user message before inserting placeholders.',
+    });
+  });
+});

--- a/components/promptlm-web-ui/src/features/prompt-editor/editorActions.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/editorActions.ts
@@ -34,7 +34,6 @@ export type SavePromptDraftInput = {
   draft: PromptDraftInput;
   evaluationEnabled: boolean;
   validationHasErrors: boolean;
-  processText: (text: string) => string;
   createPrompt: (payload: PromptSpecCreationRequest) => Promise<PromptSpec>;
   updatePrompt: (id: string, payload: PromptSpecCreationRequest) => Promise<PromptSpec>;
 };
@@ -46,20 +45,6 @@ export type SavePromptDraftResult = {
   toast: ActionToast;
 };
 
-const withProcessedPlaceholders = (
-  draft: PromptDraftInput,
-  processText: (text: string) => string,
-): PromptDraftInput => ({
-  ...draft,
-  request: {
-    ...draft.request,
-    messages: draft.request.messages.map((message) => ({
-      ...message,
-      content: processText(message.content),
-    })),
-  },
-});
-
 export const savePromptDraftAction = async ({
   mode,
   createdPromptId,
@@ -69,7 +54,6 @@ export const savePromptDraftAction = async ({
   draft,
   evaluationEnabled,
   validationHasErrors,
-  processText,
   createPrompt,
   updatePrompt,
 }: SavePromptDraftInput): Promise<SavePromptDraftResult> => {
@@ -102,7 +86,7 @@ export const savePromptDraftAction = async ({
     evaluationEnabled,
     activeProjectRepositoryUrl ?? undefined,
   );
-  const payload = buildPromptSpecCreationRequest(withProcessedPlaceholders(preparedDraft, processText));
+  const payload = buildPromptSpecCreationRequest(preparedDraft);
 
   try {
     if (mode === 'create' && !createdPromptId) {

--- a/components/promptlm-web-ui/src/features/prompt-editor/placeholderInsertion.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/placeholderInsertion.ts
@@ -1,0 +1,100 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { PromptDraftInput } from '@/api/promptPayloads';
+import type { MessageContentSelection } from '@promptlm/ui';
+
+const USER_ROLE = 'user';
+
+export type InsertPlaceholderTokenResult =
+  | {
+      type: 'selection';
+      messageIndex: number;
+      nextContent: string;
+      caretPosition: number;
+    }
+  | {
+      type: 'fallback';
+      messageIndex: number;
+      nextContent: string;
+      caretPosition: number;
+    }
+  | {
+      type: 'error';
+      message: string;
+    };
+
+const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+
+const normalizeSelectionRange = (
+  selectionStart: number,
+  selectionEnd: number,
+  contentLength: number,
+): { start: number; end: number } => {
+  const boundedStart = clamp(selectionStart, 0, contentLength);
+  const boundedEnd = clamp(selectionEnd, 0, contentLength);
+  if (boundedStart <= boundedEnd) {
+    return { start: boundedStart, end: boundedEnd };
+  }
+  return { start: boundedEnd, end: boundedStart };
+};
+
+const findLastUserMessageIndex = (messages: PromptDraftInput['request']['messages']): number => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index].role.toLowerCase() === USER_ROLE) {
+      return index;
+    }
+  }
+  return -1;
+};
+
+export const createPlaceholderToken = (openSequence: string, name: string, closeSequence: string): string => {
+  return `${openSequence}${name}${closeSequence}`;
+};
+
+export const insertPlaceholderToken = (
+  messages: PromptDraftInput['request']['messages'],
+  token: string,
+  selection: MessageContentSelection | null,
+): InsertPlaceholderTokenResult => {
+  if (selection) {
+    const selectedMessage = messages[selection.messageIndex];
+    if (selectedMessage) {
+      const content = selectedMessage.content;
+      const { start, end } = normalizeSelectionRange(selection.selectionStart, selection.selectionEnd, content.length);
+      return {
+        type: 'selection',
+        messageIndex: selection.messageIndex,
+        nextContent: `${content.slice(0, start)}${token}${content.slice(end)}`,
+        caretPosition: start + token.length,
+      };
+    }
+  }
+
+  const lastUserMessageIndex = findLastUserMessageIndex(messages);
+  if (lastUserMessageIndex >= 0) {
+    const content = messages[lastUserMessageIndex].content;
+    return {
+      type: 'fallback',
+      messageIndex: lastUserMessageIndex,
+      nextContent: `${content}${token}`,
+      caretPosition: content.length + token.length,
+    };
+  }
+
+  return {
+    type: 'error',
+    message: 'Add a user message before inserting placeholders.',
+  };
+};

--- a/components/ui/src/prompt-editor/PromptEditorSections.tsx
+++ b/components/ui/src/prompt-editor/PromptEditorSections.tsx
@@ -910,6 +910,7 @@ export type MessagesCardProps = {
   onAddMessage: (role: PromptEditorMessageRole) => void;
   onMessageChange: (index: number, field: 'role' | 'content' | 'name', value: string) => void;
   onRemoveMessage: (index: number) => void;
+  onContentSelectionChange?: (selection: MessageContentSelection | null) => void;
   onTryRun: () => void;
   onNavigateBack: () => void;
   isBusy: boolean;
@@ -919,12 +920,19 @@ export type MessagesCardProps = {
   errors?: MessagesErrors;
 };
 
+export type MessageContentSelection = {
+  messageIndex: number;
+  selectionStart: number;
+  selectionEnd: number;
+};
+
 export const MessagesCard: React.FC<MessagesCardProps> = ({
   messages,
   availableRoles,
   onAddMessage,
   onMessageChange,
   onRemoveMessage,
+  onContentSelectionChange,
   onTryRun,
   onNavigateBack,
   isBusy,
@@ -932,128 +940,154 @@ export const MessagesCard: React.FC<MessagesCardProps> = ({
   hasActiveProject,
   isActiveProjectLoading,
   errors,
-}) => (
-  <SectionCard title="Prompt messages" subtitle="Ordered chat conversation fed to the model">
-    {errors?.general ? (
-      <Alert severity="error" variant="outlined" sx={{ mb: 2 }}>
-        {errors.general}
-      </Alert>
-    ) : null}
-    <Stack direction="row" spacing={1} flexWrap="wrap">
-      {availableRoles.map((role) => (
-        <Button
-          key={role}
-          variant="outlined"
-          size="small"
-          onClick={() => onAddMessage(role)}
-          data-testid={role === 'user' ? 'user-prompt-button' : undefined}
-        >
-          Add {MESSAGE_ROLE_LABEL[role]}
-        </Button>
-      ))}
-    </Stack>
-    <Stack spacing={2} sx={{ mt: 1 }} data-testid="prompt-messages">
-      {messages.map((message, index) => {
-        const messageErrors = errors?.list?.[index];
-        return (
-          <Paper key={message.id} variant="outlined" sx={{ p: 2, borderRadius: 2, borderColor: 'divider' }}>
-            <Stack spacing={1.5}>
-              <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <Chip size="small" color={MESSAGE_ROLE_COLORS[message.role]} label={MESSAGE_ROLE_LABEL[message.role]} />
-                  <FormControl sx={{ minWidth: 160 }} size="small" error={Boolean(messageErrors?.role)}>
-                    <Select value={message.role} onChange={(event) => onMessageChange(index, 'role', event.target.value)}>
-                      {DEFAULT_MESSAGE_ROLES.map((role) => (
-                        <MenuItem key={role} value={role}>
-                          {MESSAGE_ROLE_LABEL[role]}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                    {messageErrors?.role ? <FormHelperText>{messageErrors.role}</FormHelperText> : null}
-                  </FormControl>
-                </Stack>
-                <Tooltip title="Remove message">
-                  <span>
-                    <IconButton size="small" onClick={() => onRemoveMessage(index)}>
-                      <DeleteOutline fontSize="small" />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              </Stack>
-              {message.role === 'tool' ? (
-                <TextField
-                  label="Tool name"
-                  size="small"
-                  value={message.name ?? ''}
-                  onChange={(event) => onMessageChange(index, 'name', event.target.value)}
-                  fullWidth
-                  error={Boolean(messageErrors?.name)}
-                  helperText={messageErrors?.name}
-                />
-              ) : null}
-              <Stack spacing={0.75}>
-                <Typography variant="caption" color={messageErrors?.content ? 'error' : 'text.secondary'}>
-                  Content
-                </Typography>
-                <Box
-                  component="textarea"
-                  value={message.content}
-                  onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => onMessageChange(index, 'content', event.target.value)}
-                  rows={message.role === 'system' ? 3 : 2}
-                  data-testid={message.role === 'user' && index === messages.length - 1 ? 'prompt-text' : undefined}
-                  aria-label={`Message content ${index + 1}`}
-                  sx={{
-                    width: '100%',
-                    resize: 'vertical',
-                    borderRadius: 1,
-                    border: 1,
-                    borderColor: messageErrors?.content ? 'error.main' : 'divider',
-                    px: 1.75,
-                    py: 1.25,
-                    font: 'inherit',
-                    color: 'text.primary',
-                    backgroundColor: 'background.paper',
-                    '&:focus': {
-                      outline: 'none',
-                      borderColor: messageErrors?.content ? 'error.main' : 'primary.main',
-                      boxShadow: (theme) =>
-                        `0 0 0 2px ${messageErrors?.content ? theme.palette.error.light : theme.palette.primary.light}`,
-                    },
-                  }}
-                />
-                {messageErrors?.content ? <FormHelperText error>{messageErrors.content}</FormHelperText> : null}
-              </Stack>
-            </Stack>
-          </Paper>
-        );
-      })}
-    </Stack>
-    <Stack
-      direction={{ xs: 'column', sm: 'row' }}
-      spacing={1.5}
-      alignItems={{ xs: 'stretch', sm: 'center' }}
-      justifyContent="space-between"
-      sx={{ mt: 2 }}
-    >
-      <Button variant="text" onClick={onNavigateBack} disabled={isBusy}>
-        Back to Prompts
-      </Button>
-      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
-        <Button variant="outlined" onClick={onTryRun} disabled={isBusy}>
-          Run
-        </Button>
-        <Button
-          type="submit"
-          variant="contained"
-          disabled={isSaving || !hasActiveProject || isActiveProjectLoading}
-          data-testid="save-prompt-button"
-        >
-          Save
-        </Button>
+}) => {
+  const emitSelection = React.useCallback(
+    (messageIndex: number, target: HTMLTextAreaElement) => {
+      if (!onContentSelectionChange) {
+        return;
+      }
+      const selectionStart = target.selectionStart ?? 0;
+      const selectionEnd = target.selectionEnd ?? selectionStart;
+      onContentSelectionChange({
+        messageIndex,
+        selectionStart,
+        selectionEnd,
+      });
+    },
+    [onContentSelectionChange],
+  );
+
+  return (
+    <SectionCard title="Prompt messages" subtitle="Ordered chat conversation fed to the model">
+      {errors?.general ? (
+        <Alert severity="error" variant="outlined" sx={{ mb: 2 }}>
+          {errors.general}
+        </Alert>
+      ) : null}
+      <Stack direction="row" spacing={1} flexWrap="wrap">
+        {availableRoles.map((role) => (
+          <Button
+            key={role}
+            variant="outlined"
+            size="small"
+            onClick={() => onAddMessage(role)}
+            data-testid={role === 'user' ? 'user-prompt-button' : undefined}
+          >
+            Add {MESSAGE_ROLE_LABEL[role]}
+          </Button>
+        ))}
       </Stack>
-    </Stack>
-  </SectionCard>
-);
+      <Stack spacing={2} sx={{ mt: 1 }} data-testid="prompt-messages">
+        {messages.map((message, index) => {
+          const messageErrors = errors?.list?.[index];
+          return (
+            <Paper key={message.id} variant="outlined" sx={{ p: 2, borderRadius: 2, borderColor: 'divider' }}>
+              <Stack spacing={1.5}>
+                <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Chip size="small" color={MESSAGE_ROLE_COLORS[message.role]} label={MESSAGE_ROLE_LABEL[message.role]} />
+                    <FormControl sx={{ minWidth: 160 }} size="small" error={Boolean(messageErrors?.role)}>
+                      <Select value={message.role} onChange={(event) => onMessageChange(index, 'role', event.target.value)}>
+                        {DEFAULT_MESSAGE_ROLES.map((role) => (
+                          <MenuItem key={role} value={role}>
+                            {MESSAGE_ROLE_LABEL[role]}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                      {messageErrors?.role ? <FormHelperText>{messageErrors.role}</FormHelperText> : null}
+                    </FormControl>
+                  </Stack>
+                  <Tooltip title="Remove message">
+                    <span>
+                      <IconButton size="small" onClick={() => onRemoveMessage(index)}>
+                        <DeleteOutline fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                </Stack>
+                {message.role === 'tool' ? (
+                  <TextField
+                    label="Tool name"
+                    size="small"
+                    value={message.name ?? ''}
+                    onChange={(event) => onMessageChange(index, 'name', event.target.value)}
+                    fullWidth
+                    error={Boolean(messageErrors?.name)}
+                    helperText={messageErrors?.name}
+                  />
+                ) : null}
+                <Stack spacing={0.75}>
+                  <Typography variant="caption" color={messageErrors?.content ? 'error' : 'text.secondary'}>
+                    Content
+                  </Typography>
+                  <Box
+                    component="textarea"
+                    value={message.content}
+                    onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+                      onMessageChange(index, 'content', event.target.value);
+                      emitSelection(index, event.currentTarget);
+                    }}
+                    onFocus={(event: React.FocusEvent<HTMLTextAreaElement>) => emitSelection(index, event.currentTarget)}
+                    onClick={(event: React.MouseEvent<HTMLTextAreaElement>) => emitSelection(index, event.currentTarget)}
+                    onSelect={(event: React.SyntheticEvent<HTMLTextAreaElement>) => emitSelection(index, event.currentTarget)}
+                    onKeyUp={(event: React.KeyboardEvent<HTMLTextAreaElement>) => emitSelection(index, event.currentTarget)}
+                    onBlur={() => onContentSelectionChange?.(null)}
+                    rows={message.role === 'system' ? 3 : 2}
+                    data-testid={message.role === 'user' && index === messages.length - 1 ? 'prompt-text' : undefined}
+                    aria-label={`Message content ${index + 1}`}
+                    sx={{
+                      width: '100%',
+                      resize: 'vertical',
+                      borderRadius: 1,
+                      border: 1,
+                      borderColor: messageErrors?.content ? 'error.main' : 'divider',
+                      px: 1.75,
+                      py: 1.25,
+                      font: 'inherit',
+                      color: 'text.primary',
+                      backgroundColor: 'background.paper',
+                      '&:focus': {
+                        outline: 'none',
+                        borderColor: messageErrors?.content ? 'error.main' : 'primary.main',
+                        boxShadow: (theme) =>
+                          `0 0 0 2px ${messageErrors?.content ? theme.palette.error.light : theme.palette.primary.light}`,
+                      },
+                    }}
+                  />
+                  {messageErrors?.content ? <FormHelperText error>{messageErrors.content}</FormHelperText> : null}
+                </Stack>
+              </Stack>
+            </Paper>
+          );
+        })}
+      </Stack>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={1.5}
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        justifyContent="space-between"
+        sx={{ mt: 2 }}
+      >
+        <Button variant="text" onClick={onNavigateBack} disabled={isBusy}>
+          Back to Prompts
+        </Button>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+          <Button variant="outlined" onClick={onTryRun} disabled={isBusy}>
+            Run
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={isSaving || !hasActiveProject || isActiveProjectLoading}
+            data-testid="save-prompt-button"
+          >
+            Save
+          </Button>
+        </Stack>
+      </Stack>
+    </SectionCard>
+  );
+};
 
 export type PromptPreviewCardProps = {
   draftSummary: string;

--- a/components/ui/src/prompt-editor/index.ts
+++ b/components/ui/src/prompt-editor/index.ts
@@ -35,6 +35,7 @@ export type {
   EvaluationResultsCardProps,
   EvaluationPlanErrors,
   LastExecutionCardProps,
+  MessageContentSelection,
   MessagesCardProps,
   MessagesErrors,
   MetadataCardProps,


### PR DESCRIPTION
## Summary
 wire placeholder row token insertion into prompt message content with caret/selection replacement, fallback append-to-last-user-message, and explicit error when no user message exists- stop substituting placeholder values during save so persisted prompt messages keep raw tokens
- simplify placeholder management UI to a single persisted value per placeholder (remove cycle/multi-value affordances for this release)
- update acceptance and unit tests for insertion flow, raw-token persistence, and single-value placeholder behavior

## Validation
- ./build-full.sh

## Issues
Closes #58
Closes #59
Closes #60
Closes #61