### PR TITLE
fix: GET /api/prompts/stats returns 500 when no active project is set

### DIFF
--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
@@ -366,9 +366,9 @@ public class PromptSpecController {
                 .filter(p -> p.getGroup() != null && !p.getGroup().isEmpty())
                 .collect(Collectors.groupingBy(PromptSpec::getGroup, Collectors.counting()));
 
-        ProjectSpec activeProject = AppContext.requireActiveProject(appContext);
+        ProjectSpec activeProject = appContext.getActiveProject();
         int activeProjects = appContext.getProjects().size();
-        Instant lastUpdated = resolveActiveProjectLastUpdatedFromGitMetadata(activeProject);
+        Instant lastUpdated = activeProject != null ? resolveActiveProjectLastUpdatedFromGitMetadata(activeProject) : null;
 
         return new PromptStats(
                 allPrompts.size(),

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
@@ -311,6 +311,36 @@ class PromptSpecControllerWebMvcTest {
                 .andExpect(jsonPath("$[1]").value("support"));
     }
 
+    /**
+     * Verifies that /api/prompts/stats succeeds when no active project is configured,
+     * returning prompt counts with null lastUpdated. Regression test for the
+     * IllegalStateException thrown on fresh app start before any repository is set up.
+     */
+    @Test
+    void getPromptStatsReturnsStatsWithNullLastUpdatedWhenNoActiveProjectIsSet() throws Exception {
+        PromptSpec activePrompt = PromptSpec.builder()
+                .withGroup("support")
+                .withName("welcome")
+                .withVersion("1.0.0")
+                .withRevision(1)
+                .withDescription("active prompt")
+                .withRequest(null)
+                .build();
+
+        when(promptStore.listAllPrompts(true)).thenReturn(List.of(activePrompt));
+        when(appContext.getActiveProject()).thenReturn(null);
+        when(appContext.getProjects()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/prompts/stats"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.totalPrompts").value(1))
+                .andExpect(jsonPath("$.activePrompts").value(1))
+                .andExpect(jsonPath("$.retiredPrompts").value(0))
+                .andExpect(jsonPath("$.activeProjects").value(0))
+                .andExpect(jsonPath("$.lastUpdated").doesNotExist());
+    }
+
     @Test
     void getPromptStatsFailsWhenActiveProjectRepoPathDoesNotExist() throws Exception {
         PromptSpec activePrompt = PromptSpec.builder()


### PR DESCRIPTION
## Problem

`GET /api/prompts/stats` threw a 500 `IllegalStateException` on a fresh app start or while creating a new repository — before any project was set as active. The frontend calls this endpoint immediately on startup.

Fixes #68

## Root cause

`getPromptStats()` called `AppContext.requireActiveProject()` which unconditionally throws when `activeProject` is `null`.

## Fix

Use `appContext.getActiveProject()` with a null-guard around the git metadata lookup. When no active project is set `lastUpdated` is `null`; prompt counts are still computed and returned normally.

## Test

Added `getPromptStatsReturnsStatsWithNullLastUpdatedWhenNoActiveProjectIsSet` to `PromptSpecControllerWebMvcTest` as a regression test.