### PR TITLE
feat(ui): prompts-v2 design tokens + atoms with Storybook coverage

### DIFF
--- a/components/ui/.storybook/preview-head.html
+++ b/components/ui/.storybook/preview-head.html
@@ -1,0 +1,3 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" />

--- a/components/ui/.storybook/preview.tsx
+++ b/components/ui/.storybook/preview.tsx
@@ -16,6 +16,7 @@ import type { Decorator, Preview } from '@storybook/react';
 import React from 'react';
 import { CssBaseline, ThemeProvider } from '@mui/material';
 import { createPromptLMTheme } from '../src/theme/createPromptLMTheme';
+import '../src/prompts-v2/tokens.css';
 
 const withTheme: Decorator = (Story, context) => {
   const variant = context.globals.themeVariant ?? 'lightTech';

--- a/components/ui/package.json
+++ b/components/ui/package.json
@@ -9,13 +9,14 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./prompts-v2/tokens.css": "./dist/prompts-v2/tokens.css"
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json && node ./scripts/fix-dist-imports.mjs",
+    "build": "tsc -p tsconfig.json && node ./scripts/fix-dist-imports.mjs && node ./scripts/copy-assets.mjs",
     "test": "npm run build && mkdir -p ../../.tmp && esbuild test/ui-package-smoke.mjs --bundle --platform=node --format=cjs --external:react --external:react-dom --external:react-dom/server --external:@mui/material --external:@mui/material/* --external:@mui/icons-material --external:@mui/icons-material/* --external:@emotion/react --external:@emotion/styled --outfile=../../.tmp/ui-package-smoke.bundle.cjs && node ../../.tmp/ui-package-smoke.bundle.cjs",
     "test:watch": "npm run test",
     "storybook": "storybook dev -p 6006",

--- a/components/ui/scripts/copy-assets.mjs
+++ b/components/ui/scripts/copy-assets.mjs
@@ -1,0 +1,48 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Copies non-TS assets (CSS, etc.) from src/ into dist/ after tsc has run.
+// tsc itself only emits .js/.d.ts; CSS files referenced by consumers (e.g.
+// `@promptlm/ui/prompts-v2/tokens.css`) need to land in dist alongside.
+
+import { copyFile, mkdir, readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_DIR = fileURLToPath(new URL('../src/', import.meta.url));
+const DIST_DIR = fileURLToPath(new URL('../dist/', import.meta.url));
+const ASSET_EXTENSIONS = new Set(['.css']);
+
+const walkAndCopy = async (relDir) => {
+  const fromDir = path.join(SRC_DIR, relDir);
+  let entries;
+  try {
+    entries = await readdir(fromDir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+  for (const entry of entries) {
+    const childRel = path.join(relDir, entry.name);
+    if (entry.isDirectory()) {
+      await walkAndCopy(childRel);
+      continue;
+    }
+    const ext = path.extname(entry.name).toLowerCase();
+    if (!ASSET_EXTENSIONS.has(ext)) continue;
+    const fromPath = path.join(SRC_DIR, childRel);
+    const toPath = path.join(DIST_DIR, childRel);
+    await mkdir(path.dirname(toPath), { recursive: true });
+    await copyFile(fromPath, toPath);
+  }
+};
+
+await stat(DIST_DIR).catch(async () => {
+  await mkdir(DIST_DIR, { recursive: true });
+});
+await walkAndCopy('');

--- a/components/ui/src/index.ts
+++ b/components/ui/src/index.ts
@@ -66,3 +66,4 @@ export * from './components/ui/toggle-group';
 export * from './components/ui/toggle';
 export * from './components/ui/tooltip';
 export * from './prompt-editor';
+export * from './prompts-v2';

--- a/components/ui/src/prompts-v2/atoms/DiffLine.stories.tsx
+++ b/components/ui/src/prompts-v2/atoms/DiffLine.stories.tsx
@@ -1,0 +1,54 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { DiffLine } from './DiffLine';
+
+const meta: Meta<typeof DiffLine> = {
+  title: 'Prompts v2 / Atoms / DiffLine',
+  component: DiffLine,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof DiffLine>;
+
+export const InCodeBlock: Story = {
+  render: () => (
+    <pre
+      style={{
+        margin: 0,
+        padding: '14px 16px',
+        fontFamily: 'var(--pl-mono)',
+        fontSize: 12.5,
+        lineHeight: 1.7,
+        color: 'var(--pl-ink-800)',
+        whiteSpace: 'pre-wrap',
+        background: 'var(--pl-paper)',
+        border: '1px solid var(--pl-ink-200)',
+        borderRadius: 10,
+        width: 520,
+      }}
+    >
+      You are a tool router for the assistant.{'\n'}
+      <DiffLine kind="add">Decide which MCP tool to call given the catalogue.</DiffLine>
+      {'\n'}
+      <DiffLine kind="del">Pick the right MCP tool given the catalogue.</DiffLine>
+      {'\n'}
+      <DiffLine kind="add">If no tool fits, refuse — do not invent a call.</DiffLine>
+      {'\n'}
+      Reply with a single JSON object.
+    </pre>
+  ),
+};

--- a/components/ui/src/prompts-v2/atoms/DiffLine.tsx
+++ b/components/ui/src/prompts-v2/atoms/DiffLine.tsx
@@ -1,0 +1,64 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+export type DiffLineKind = 'add' | 'del';
+
+export interface DiffLineProps extends React.HTMLAttributes<HTMLSpanElement> {
+  kind: DiffLineKind;
+  /** Negative inline-margin so the line bleeds to the edges of a padded code block. */
+  bleedPadding?: number;
+}
+
+const KIND_STYLES: Record<DiffLineKind, React.CSSProperties> = {
+  add: {
+    background: 'oklch(0.96 0.04 155)',
+    borderLeft: '2px solid oklch(0.55 0.13 155)',
+    color: 'oklch(0.30 0.10 155)',
+  },
+  del: {
+    background: 'oklch(0.96 0.04 25)',
+    borderLeft: '2px solid oklch(0.55 0.15 25)',
+    color: 'oklch(0.36 0.13 25)',
+    textDecoration: 'line-through',
+    textDecorationColor: 'oklch(0.55 0.15 25)',
+  },
+};
+
+/**
+ * Inline diff line for code/message blocks. Renders a full-width band by
+ * bleeding past the parent block's horizontal padding (default 16px).
+ */
+export const DiffLine = React.forwardRef<HTMLSpanElement, DiffLineProps>(function DiffLine(
+  { kind, bleedPadding = 16, style, children, ...rest },
+  ref,
+) {
+  return (
+    <span
+      ref={ref}
+      {...rest}
+      style={{
+        display: 'inline-block',
+        width: `calc(100% + ${bleedPadding * 2}px)`,
+        marginLeft: -bleedPadding,
+        padding: `0 ${bleedPadding - 2}px 0 ${bleedPadding - 2}px`,
+        ...KIND_STYLES[kind],
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  );
+});

--- a/components/ui/src/prompts-v2/atoms/MetaPill.stories.tsx
+++ b/components/ui/src/prompts-v2/atoms/MetaPill.stories.tsx
@@ -1,0 +1,52 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { MetaPill } from './MetaPill';
+
+const meta: Meta<typeof MetaPill> = {
+  title: 'Prompts v2 / Atoms / MetaPill',
+  component: MetaPill,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof MetaPill>;
+
+export const Plain: Story = { args: { label: 'version', value: '1.8.0', mono: true } };
+
+export const Row: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+      <MetaPill label="version" value="1.8.0" mono />
+      <MetaPill label="rev" value="r34" mono />
+      <MetaPill label="model" value="openai/gpt-4.1" mono />
+      <MetaPill label="status">
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 999,
+              background: 'oklch(0.55 0.13 155)',
+            }}
+          />
+          <span style={{ fontFamily: 'var(--pl-mono)', fontSize: 12, color: 'oklch(0.40 0.12 155)' }}>
+            production
+          </span>
+        </span>
+      </MetaPill>
+    </div>
+  ),
+};

--- a/components/ui/src/prompts-v2/atoms/MetaPill.tsx
+++ b/components/ui/src/prompts-v2/atoms/MetaPill.tsx
@@ -1,0 +1,63 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+import { Mono } from './Mono';
+
+export interface MetaPillProps {
+  label: string;
+  /** Plain value rendered as text (use `mono` to render in JetBrains Mono). */
+  value?: React.ReactNode;
+  /** Override the value rendering; takes precedence over `value`. */
+  children?: React.ReactNode;
+  mono?: boolean;
+}
+
+/**
+ * Title-block meta pill — `version`, `model`, `status` etc. on the prompt
+ * detail header. Always shows an uppercase mono label and a value; pass
+ * `children` for richer content (e.g. a status dot inline with text).
+ */
+export const MetaPill: React.FC<MetaPillProps> = ({ label, value, children, mono }) => (
+  <span
+    style={{
+      display: 'inline-flex',
+      alignItems: 'baseline',
+      gap: 8,
+      padding: '5px 12px',
+      border: '1px solid var(--pl-ink-200)',
+      background: 'var(--pl-paper)',
+      borderRadius: 999,
+    }}
+  >
+    <Mono
+      size={10}
+      color="var(--pl-ink-500)"
+      style={{ letterSpacing: '0.10em', textTransform: 'uppercase' }}
+    >
+      {label}
+    </Mono>
+    {children ?? (
+      <span
+        style={{
+          fontFamily: mono ? 'var(--pl-mono)' : 'var(--pl-display)',
+          fontSize: 12.5,
+          color: 'var(--pl-ink-900)',
+        }}
+      >
+        {value}
+      </span>
+    )}
+  </span>
+);

--- a/components/ui/src/prompts-v2/atoms/MiniLogo.stories.tsx
+++ b/components/ui/src/prompts-v2/atoms/MiniLogo.stories.tsx
@@ -1,0 +1,38 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { MiniLogo } from './MiniLogo';
+
+const meta: Meta<typeof MiniLogo> = {
+  title: 'Prompts v2 / Atoms / MiniLogo',
+  component: MiniLogo,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof MiniLogo>;
+
+export const Default: Story = { args: { size: 22 } };
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 24, alignItems: 'center' }}>
+      <MiniLogo size={16} />
+      <MiniLogo size={22} />
+      <MiniLogo size={32} />
+      <MiniLogo size={48} />
+    </div>
+  ),
+};

--- a/components/ui/src/prompts-v2/atoms/MiniLogo.tsx
+++ b/components/ui/src/prompts-v2/atoms/MiniLogo.tsx
@@ -1,0 +1,48 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+export interface MiniLogoProps extends React.SVGAttributes<SVGSVGElement> {
+  size?: number;
+}
+
+/** Bracket+circle promptLM mark — used in the app sidebar and report header. */
+export const MiniLogo: React.FC<MiniLogoProps> = ({ size = 22, style, ...rest }) => (
+  <svg
+    {...rest}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    style={{ display: 'block', ...style }}
+    aria-hidden="true"
+  >
+    <path
+      d="M8 4 L4 4 L4 20 L8 20"
+      stroke="var(--pl-ink-900)"
+      strokeWidth="1.6"
+      strokeLinecap="square"
+      strokeLinejoin="miter"
+    />
+    <path
+      d="M16 4 L20 4 L20 20 L16 20"
+      stroke="var(--pl-ink-900)"
+      strokeWidth="1.6"
+      strokeLinecap="square"
+      strokeLinejoin="miter"
+    />
+    <circle cx="12" cy="12" r="3" fill="none" stroke="var(--pl-signal-deep)" strokeWidth="1.6" />
+  </svg>
+);

--- a/components/ui/src/prompts-v2/atoms/Mono.stories.tsx
+++ b/components/ui/src/prompts-v2/atoms/Mono.stories.tsx
@@ -1,0 +1,53 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { Mono } from './Mono';
+
+const meta: Meta<typeof Mono> = {
+  title: 'Prompts v2 / Atoms / Mono',
+  component: Mono,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof Mono>;
+
+export const Default: Story = { args: { children: 'prm_8f3a' } };
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16, alignItems: 'baseline' }}>
+      <Mono size={10}>10px</Mono>
+      <Mono size={12}>12px</Mono>
+      <Mono size={14}>14px</Mono>
+      <Mono size={18}>18px</Mono>
+      <Mono size={22} color="var(--pl-ink-900)">
+        22px
+      </Mono>
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Mono color="var(--pl-ink-900)">ink-900</Mono>
+      <Mono color="var(--pl-ink-700)">ink-700</Mono>
+      <Mono color="var(--pl-ink-500)">ink-500</Mono>
+      <Mono color="var(--pl-signal-deep)">signal-deep</Mono>
+      <Mono color="var(--pl-ok)">ok</Mono>
+    </div>
+  ),
+};

--- a/components/ui/src/prompts-v2/atoms/Mono.tsx
+++ b/components/ui/src/prompts-v2/atoms/Mono.tsx
@@ -1,0 +1,41 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+export interface MonoProps extends React.HTMLAttributes<HTMLSpanElement> {
+  size?: number | string;
+  color?: string;
+}
+
+export const Mono = React.forwardRef<HTMLSpanElement, MonoProps>(function Mono(
+  { size = 12, color = 'var(--pl-ink-700)', style, children, ...rest },
+  ref,
+) {
+  return (
+    <span
+      ref={ref}
+      {...rest}
+      style={{
+        fontFamily: 'var(--pl-mono)',
+        fontSize: typeof size === 'number' ? `${size}px` : size,
+        color,
+        letterSpacing: '-0.005em',
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  );
+});

--- a/components/ui/src/prompts-v2/atoms/PlaceholderToken.stories.tsx
+++ b/components/ui/src/prompts-v2/atoms/PlaceholderToken.stories.tsx
@@ -1,0 +1,55 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { PlaceholderToken } from './PlaceholderToken';
+
+const meta: Meta<typeof PlaceholderToken> = {
+  title: 'Prompts v2 / Atoms / PlaceholderToken',
+  component: PlaceholderToken,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof PlaceholderToken>;
+
+export const Default: Story = { args: { name: 'agent_name' } };
+
+export const Underline: Story = { args: { name: 'tool_catalog', underline: true } };
+
+export const InMessage: Story = {
+  render: () => (
+    <pre
+      style={{
+        margin: 0,
+        padding: 14,
+        fontFamily: 'var(--pl-mono)',
+        fontSize: 12.5,
+        lineHeight: 1.7,
+        background: 'var(--pl-paper)',
+        border: '1px solid var(--pl-ink-200)',
+        borderRadius: 8,
+        color: 'var(--pl-ink-800)',
+        whiteSpace: 'pre-wrap',
+        maxWidth: 480,
+      }}
+    >
+      {'You are '}
+      <PlaceholderToken name="agent_name" />
+      {', a careful assistant. Use the tools in '}
+      <PlaceholderToken name="tool_catalog" />
+      {'.'}
+    </pre>
+  ),
+};

--- a/components/ui/src/prompts-v2/atoms/PlaceholderToken.tsx
+++ b/components/ui/src/prompts-v2/atoms/PlaceholderToken.tsx
@@ -1,0 +1,53 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+export interface PlaceholderTokenProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Placeholder name without braces (e.g. `agent_name`); braces are added automatically. */
+  name?: string;
+  /** Render with a dashed underline used by the inline-diff view in the editor. */
+  underline?: boolean;
+}
+
+/**
+ * Styled chip for `{{placeholder}}` tokens. When `name` is provided the braces
+ * are added; otherwise children are rendered verbatim (use this for ad-hoc
+ * highlighting of an existing brace-wrapped string).
+ */
+export const PlaceholderToken = React.forwardRef<HTMLSpanElement, PlaceholderTokenProps>(
+  function PlaceholderToken({ name, underline = false, style, children, ...rest }, ref) {
+    const content = name !== undefined ? `{{${name}}}` : children;
+    return (
+      <span
+        ref={ref}
+        {...rest}
+        style={{
+          display: 'inline-block',
+          background: 'oklch(0.95 0.05 240)',
+          border: '1px solid oklch(0.85 0.08 240)',
+          color: 'var(--pl-signal-deep)',
+          padding: '0 4px',
+          borderRadius: 3,
+          fontFamily: 'var(--pl-mono)',
+          fontSize: '0.95em',
+          borderBottom: underline ? '1px dashed var(--pl-signal-deep)' : undefined,
+          ...style,
+        }}
+      >
+        {content}
+      </span>
+    );
+  },
+);

--- a/components/ui/src/prompts-v2/atoms/Sparkline.stories.tsx
+++ b/components/ui/src/prompts-v2/atoms/Sparkline.stories.tsx
@@ -1,0 +1,46 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { Sparkline } from './Sparkline';
+
+const meta: Meta<typeof Sparkline> = {
+  title: 'Prompts v2 / Atoms / Sparkline',
+  component: Sparkline,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof Sparkline>;
+
+const successRate = [0.97, 0.98, 0.97, 0.98, 0.99, 0.98, 0.99, 0.99];
+const latency = [820, 800, 810, 790, 800, 760, 740, 720];
+
+export const Default: Story = {
+  args: { values: successRate },
+};
+
+export const Filled: Story = {
+  args: { values: latency, filled: true, width: 120, height: 28, color: 'var(--pl-ok)' },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 24, alignItems: 'center' }}>
+      <Sparkline values={successRate} width={48} height={14} color="var(--pl-ok)" />
+      <Sparkline values={successRate} width={96} height={24} color="var(--pl-signal-deep)" />
+      <Sparkline values={latency} width={120} height={28} color="var(--pl-warn)" filled />
+    </div>
+  ),
+};

--- a/components/ui/src/prompts-v2/atoms/Sparkline.tsx
+++ b/components/ui/src/prompts-v2/atoms/Sparkline.tsx
@@ -1,0 +1,90 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+export interface SparklineProps {
+  values: readonly number[];
+  width?: number;
+  height?: number;
+  color?: string;
+  /** Render a translucent area fill below the line. */
+  filled?: boolean;
+  /** Render a small dot on the trailing point. */
+  trailingDot?: boolean;
+  strokeWidth?: number;
+  ariaLabel?: string;
+}
+
+const computePoints = (values: readonly number[], w: number, h: number) => {
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const range = max - min || 1;
+  const xFor = (i: number) =>
+    values.length === 1 ? w / 2 : (i / (values.length - 1)) * w;
+  const yFor = (v: number) => h - 2 - ((v - min) / range) * (h - 4);
+  return { xFor, yFor };
+};
+
+/**
+ * Lightweight inline sparkline. Two visual modes:
+ *  - default (line + trailing dot, no fill) — used by catalog row metrics
+ *  - filled=true — area-fill variant used by health cards
+ */
+export const Sparkline: React.FC<SparklineProps> = ({
+  values,
+  width = 96,
+  height = 24,
+  color = 'var(--pl-signal-deep)',
+  filled = false,
+  trailingDot = true,
+  strokeWidth = 1.4,
+  ariaLabel,
+}) => {
+  if (values.length === 0) return null;
+  const { xFor, yFor } = computePoints(values, width, height);
+  const path = values
+    .map((v, i) => `${i === 0 ? 'M' : 'L'} ${xFor(i).toFixed(2)} ${yFor(v).toFixed(2)}`)
+    .join(' ');
+  const last = values[values.length - 1];
+  return (
+    <svg
+      role={ariaLabel ? 'img' : undefined}
+      aria-label={ariaLabel}
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      style={{ display: 'block', overflow: 'visible' }}
+    >
+      {filled && (
+        <path
+          d={`${path} L ${width} ${height} L 0 ${height} Z`}
+          fill={color}
+          opacity="0.10"
+        />
+      )}
+      <path
+        d={path}
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {trailingDot && (
+        <circle cx={xFor(values.length - 1)} cy={yFor(last)} r="2" fill={color} />
+      )}
+    </svg>
+  );
+};

--- a/components/ui/src/prompts-v2/atoms/StatusDot.stories.tsx
+++ b/components/ui/src/prompts-v2/atoms/StatusDot.stories.tsx
@@ -1,0 +1,47 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatusDot } from './StatusDot';
+
+const meta: Meta<typeof StatusDot> = {
+  title: 'Prompts v2 / Atoms / StatusDot',
+  component: StatusDot,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof StatusDot>;
+
+export const All: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 24, alignItems: 'center' }}>
+      <StatusDot status="production" />
+      <StatusDot status="staging" />
+      <StatusDot status="experimental" />
+      <StatusDot status="failing" />
+    </div>
+  ),
+};
+
+export const IconOnly: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
+      <StatusDot status="production" iconOnly />
+      <StatusDot status="staging" iconOnly />
+      <StatusDot status="experimental" iconOnly />
+      <StatusDot status="failing" iconOnly />
+    </div>
+  ),
+};

--- a/components/ui/src/prompts-v2/atoms/StatusDot.tsx
+++ b/components/ui/src/prompts-v2/atoms/StatusDot.tsx
@@ -1,0 +1,67 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+export type PromptStatus = 'production' | 'staging' | 'experimental' | 'failing';
+
+export interface StatusDotProps extends React.HTMLAttributes<HTMLSpanElement> {
+  status: PromptStatus;
+  /** Hide the text label and show only the dot. */
+  iconOnly?: boolean;
+}
+
+const STATUS_MAP: Record<PromptStatus, { color: string; label: string }> = {
+  production: { color: 'var(--pl-ok)', label: 'production' },
+  staging: { color: 'var(--pl-warn)', label: 'staging' },
+  experimental: { color: 'var(--pl-ink-500)', label: 'experimental' },
+  failing: { color: 'var(--pl-fail)', label: 'failing' },
+};
+
+export const StatusDot = React.forwardRef<HTMLSpanElement, StatusDotProps>(function StatusDot(
+  { status, iconOnly = false, style, ...rest },
+  ref,
+) {
+  const s = STATUS_MAP[status];
+  return (
+    <span
+      ref={ref}
+      {...rest}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontFamily: 'var(--pl-mono)',
+        fontSize: 11,
+        color: 'var(--pl-ink-600)',
+        letterSpacing: '0.01em',
+        ...style,
+      }}
+    >
+      <span
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: 999,
+          background: s.color,
+          boxShadow:
+            status === 'production'
+              ? `0 0 0 3px color-mix(in oklch, ${s.color} 18%, transparent)`
+              : 'none',
+        }}
+      />
+      {!iconOnly && s.label}
+    </span>
+  );
+});

--- a/components/ui/src/prompts-v2/atoms/Tag.stories.tsx
+++ b/components/ui/src/prompts-v2/atoms/Tag.stories.tsx
@@ -1,0 +1,49 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tag } from './Tag';
+
+const meta: Meta<typeof Tag> = {
+  title: 'Prompts v2 / Atoms / Tag',
+  component: Tag,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof Tag>;
+
+export const Tones: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+      <Tag tone="neutral">neutral</Tag>
+      <Tag tone="signal">v2.4.1</Tag>
+      <Tag tone="ok">required</Tag>
+      <Tag tone="warn">deprecated</Tag>
+      <Tag tone="fail">failing</Tag>
+    </div>
+  ),
+};
+
+export const InContext: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <Tag tone="signal">v1.8.0</Tag>
+      <Tag>r34</Tag>
+      <Tag>chat</Tag>
+      <Tag tone="ok">✓ ok</Tag>
+      <Tag tone="fail">✕ failed</Tag>
+    </div>
+  ),
+};

--- a/components/ui/src/prompts-v2/atoms/Tag.tsx
+++ b/components/ui/src/prompts-v2/atoms/Tag.tsx
@@ -1,0 +1,79 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+export type TagTone = 'neutral' | 'signal' | 'ok' | 'warn' | 'fail';
+
+export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
+  tone?: TagTone;
+}
+
+const TONE_STYLES: Record<TagTone, { bg: string; fg: string; bd: string }> = {
+  neutral: {
+    bg: 'var(--pl-ink-100)',
+    fg: 'var(--pl-ink-700)',
+    bd: 'var(--pl-ink-200)',
+  },
+  signal: {
+    bg: 'color-mix(in oklch, var(--pl-signal) 12%, var(--pl-paper))',
+    fg: 'var(--pl-signal-ink)',
+    bd: 'color-mix(in oklch, var(--pl-signal) 30%, var(--pl-ink-200))',
+  },
+  ok: {
+    bg: 'color-mix(in oklch, var(--pl-ok) 14%, var(--pl-paper))',
+    fg: 'oklch(0.32 0.10 155)',
+    bd: 'color-mix(in oklch, var(--pl-ok) 35%, var(--pl-ink-200))',
+  },
+  warn: {
+    bg: 'color-mix(in oklch, var(--pl-warn) 18%, var(--pl-paper))',
+    fg: 'oklch(0.42 0.10 75)',
+    bd: 'color-mix(in oklch, var(--pl-warn) 40%, var(--pl-ink-200))',
+  },
+  fail: {
+    bg: 'color-mix(in oklch, var(--pl-fail) 14%, var(--pl-paper))',
+    fg: 'oklch(0.42 0.13 25)',
+    bd: 'color-mix(in oklch, var(--pl-fail) 35%, var(--pl-ink-200))',
+  },
+};
+
+export const Tag = React.forwardRef<HTMLSpanElement, TagProps>(function Tag(
+  { tone = 'neutral', style, children, ...rest },
+  ref,
+) {
+  const s = TONE_STYLES[tone];
+  return (
+    <span
+      ref={ref}
+      {...rest}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        padding: '2px 7px',
+        fontFamily: 'var(--pl-mono)',
+        fontSize: 10.5,
+        letterSpacing: '0.02em',
+        background: s.bg,
+        color: s.fg,
+        border: `1px solid ${s.bd}`,
+        borderRadius: 4,
+        lineHeight: 1.5,
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  );
+});

--- a/components/ui/src/prompts-v2/atoms/VendorMark.stories.tsx
+++ b/components/ui/src/prompts-v2/atoms/VendorMark.stories.tsx
@@ -1,0 +1,47 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { VendorMark } from './VendorMark';
+
+const meta: Meta<typeof VendorMark> = {
+  title: 'Prompts v2 / Atoms / VendorMark',
+  component: VendorMark,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof VendorMark>;
+
+export const Vendors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 24, alignItems: 'center' }}>
+      <VendorMark vendor="anthropic" />
+      <VendorMark vendor="openai" />
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
+      <VendorMark vendor="anthropic" size={11} />
+      <VendorMark vendor="anthropic" size={14} />
+      <VendorMark vendor="anthropic" size={20} />
+      <VendorMark vendor="openai" size={11} />
+      <VendorMark vendor="openai" size={14} />
+      <VendorMark vendor="openai" size={20} />
+    </div>
+  ),
+};

--- a/components/ui/src/prompts-v2/atoms/VendorMark.tsx
+++ b/components/ui/src/prompts-v2/atoms/VendorMark.tsx
@@ -1,0 +1,87 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+export type VendorId = 'anthropic' | 'openai' | string;
+
+export interface VendorMarkProps extends React.HTMLAttributes<HTMLSpanElement> {
+  vendor: VendorId;
+  size?: number;
+}
+
+/**
+ * Geometric mark for an LLM vendor — not a company logo. Draws a filled square
+ * for Anthropic and an outlined circle for OpenAI; unknown vendors fall back to
+ * the OpenAI mark so the chrome still renders.
+ */
+export const VendorMark = React.forwardRef<HTMLSpanElement, VendorMarkProps>(function VendorMark(
+  { vendor, size = 14, style, ...rest },
+  ref,
+) {
+  if (vendor === 'anthropic') {
+    return (
+      <span
+        ref={ref}
+        {...rest}
+        style={{
+          width: size,
+          height: size,
+          borderRadius: 3,
+          background: 'var(--pl-ink-900)',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          ...style,
+        }}
+      >
+        <span
+          style={{
+            width: size * 0.5,
+            height: size * 0.5,
+            borderRadius: 1,
+            background: 'var(--pl-paper)',
+          }}
+        />
+      </span>
+    );
+  }
+  return (
+    <span
+      ref={ref}
+      {...rest}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: 999,
+        border: '1.5px solid var(--pl-ink-700)',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        ...style,
+      }}
+    >
+      <span
+        style={{
+          width: size * 0.32,
+          height: size * 0.32,
+          borderRadius: 999,
+          background: 'var(--pl-ink-700)',
+        }}
+      />
+    </span>
+  );
+});

--- a/components/ui/src/prompts-v2/atoms/index.ts
+++ b/components/ui/src/prompts-v2/atoms/index.ts
@@ -1,0 +1,32 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export { Mono } from './Mono';
+export type { MonoProps } from './Mono';
+export { Tag } from './Tag';
+export type { TagProps, TagTone } from './Tag';
+export { StatusDot } from './StatusDot';
+export type { StatusDotProps, PromptStatus } from './StatusDot';
+export { VendorMark } from './VendorMark';
+export type { VendorMarkProps, VendorId } from './VendorMark';
+export { Sparkline } from './Sparkline';
+export type { SparklineProps } from './Sparkline';
+export { MiniLogo } from './MiniLogo';
+export type { MiniLogoProps } from './MiniLogo';
+export { MetaPill } from './MetaPill';
+export type { MetaPillProps } from './MetaPill';
+export { PlaceholderToken } from './PlaceholderToken';
+export type { PlaceholderTokenProps } from './PlaceholderToken';
+export { DiffLine } from './DiffLine';
+export type { DiffLineProps, DiffLineKind } from './DiffLine';

--- a/components/ui/src/prompts-v2/index.ts
+++ b/components/ui/src/prompts-v2/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './atoms';

--- a/components/ui/src/prompts-v2/tokens.css
+++ b/components/ui/src/prompts-v2/tokens.css
@@ -1,0 +1,118 @@
+/* Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* promptLM v2 design tokens — slate ink + electric signal.
+ * Loaded by both @promptlm/web-ui (via main.tsx) and the storybook
+ * preview. Fonts (Geist, JetBrains Mono) are loaded by the host app. */
+:root {
+  /* Slate / paper neutrals — cool */
+  --pl-ink-900: oklch(0.16 0.02 250);
+  --pl-ink-800: oklch(0.22 0.02 250);
+  --pl-ink-700: oklch(0.32 0.018 250);
+  --pl-ink-600: oklch(0.45 0.015 250);
+  --pl-ink-500: oklch(0.58 0.012 250);
+  --pl-ink-400: oklch(0.72 0.01 245);
+  --pl-ink-300: oklch(0.84 0.008 240);
+  --pl-ink-200: oklch(0.92 0.006 240);
+  --pl-ink-100: oklch(0.965 0.004 240);
+  --pl-paper:   oklch(0.985 0.003 240);
+  --pl-canvas:  oklch(0.975 0.005 235);
+
+  /* Signal — electric cyan/blue */
+  --pl-signal:        oklch(0.78 0.16 220);
+  --pl-signal-bright: oklch(0.86 0.18 215);
+  --pl-signal-deep:   oklch(0.55 0.18 235);
+  --pl-signal-ink:    oklch(0.32 0.14 240);
+
+  /* Functional accents — share chroma 0.13, lightness 0.68 */
+  --pl-ok:    oklch(0.74 0.13 155);
+  --pl-warn:  oklch(0.78 0.13 75);
+  --pl-fail:  oklch(0.66 0.18 25);
+
+  /* Type */
+  --pl-display: 'Geist', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --pl-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* Radii / shadows */
+  --pl-r-sm: 4px;
+  --pl-r-md: 8px;
+  --pl-r-lg: 14px;
+  --pl-shadow-sm: 0 1px 0 oklch(0.2 0.02 250 / 0.04), 0 1px 2px oklch(0.2 0.02 250 / 0.05);
+  --pl-shadow-md: 0 1px 0 oklch(0.2 0.02 250 / 0.04), 0 12px 32px -12px oklch(0.2 0.02 250 / 0.18);
+  --pl-shadow-lg: 0 1px 0 oklch(0.2 0.02 250 / 0.05), 0 28px 64px -20px oklch(0.2 0.02 250 / 0.22);
+}
+
+/* base */
+.pl {
+  font-family: var(--pl-display);
+  color: var(--pl-ink-900);
+  background: var(--pl-paper);
+  font-feature-settings: 'ss01', 'cv11';
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+.pl-mono { font-family: var(--pl-mono); font-feature-settings: 'zero', 'ss02'; letter-spacing: -0.005em; }
+
+/* hairline grid background */
+.pl-grid-bg {
+  background-image:
+    linear-gradient(to right, oklch(0.2 0.02 250 / 0.045) 1px, transparent 1px),
+    linear-gradient(to bottom, oklch(0.2 0.02 250 / 0.045) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+.pl-eyebrow {
+  font-family: var(--pl-mono);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--pl-ink-600);
+}
+
+.pl-btn {
+  font-family: var(--pl-display);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  border-radius: var(--pl-r-md);
+  padding: 10px 16px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: all .15s;
+  white-space: nowrap;
+}
+.pl-btn-primary { background: var(--pl-ink-900); color: var(--pl-paper); }
+.pl-btn-primary:hover { background: var(--pl-ink-800); }
+.pl-btn-ghost { background: transparent; color: var(--pl-ink-900); border-color: var(--pl-ink-300); }
+.pl-btn-ghost:hover { background: var(--pl-ink-100); }
+.pl-btn-signal {
+  background: var(--pl-paper);
+  color: var(--pl-ink-900);
+  border-color: var(--pl-ink-200);
+  box-shadow: inset 0 0 0 1px var(--pl-paper), var(--pl-shadow-sm);
+}
+
+.pl-card {
+  background: var(--pl-paper);
+  border: 1px solid var(--pl-ink-200);
+  border-radius: var(--pl-r-lg);
+}
+
+.pl-divider { height: 1px; background: var(--pl-ink-200); }
+
+/* signal dot pulse */
+@keyframes pl-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.85); }
+}
+.pl-pulse { animation: pl-pulse 2s ease-in-out infinite; }

--- a/components/ui/test/ui-package-smoke.mjs
+++ b/components/ui/test/ui-package-smoke.mjs
@@ -6,14 +6,23 @@ import {
   AppShellHeader,
   CloneProjectForm,
   CreateProjectForm,
+  DiffLine,
   ImportLocalProjectForm,
   InfoCard,
   InfoCardHeader,
+  MetaPill,
+  MiniLogo,
+  Mono,
+  PlaceholderToken,
   ProjectSelectionDialog,
   PromptEditorHeader,
   PromptEditorTabs,
   SectionCard,
   SideNav,
+  Sparkline,
+  StatusDot,
+  Tag,
+  VendorMark,
 } from '../dist/index.js';
 import { renderWithPromptLMTheme } from './renderWithPromptLMTheme.mjs';
 
@@ -147,9 +156,54 @@ const verifyPromptEditorExports = () => {
   assert.match(tabsMarkup, /Preview content/);
 };
 
+const verifyPromptsV2Atoms = () => {
+  const monoMarkup = renderWithPromptLMTheme(
+    React.createElement(Mono, { size: 12, color: 'var(--pl-ink-700)' }, 'prm_8f3a'),
+  );
+  const tagMarkup = renderWithPromptLMTheme(
+    React.createElement(Tag, { tone: 'signal' }, 'v1.8.0'),
+  );
+  const statusMarkup = renderWithPromptLMTheme(
+    React.createElement(StatusDot, { status: 'production' }),
+  );
+  const vendorMarkup = renderWithPromptLMTheme(
+    React.createElement(VendorMark, { vendor: 'anthropic', size: 14 }),
+  );
+  const sparkMarkup = renderWithPromptLMTheme(
+    React.createElement(Sparkline, {
+      values: [1, 2, 3, 2, 4, 5, 4, 6],
+      width: 96,
+      height: 24,
+      ariaLabel: 'success rate trend',
+    }),
+  );
+  const logoMarkup = renderWithPromptLMTheme(React.createElement(MiniLogo, { size: 22 }));
+  const pillMarkup = renderWithPromptLMTheme(
+    React.createElement(MetaPill, { label: 'version', value: '1.8.0', mono: true }),
+  );
+  const placeholderMarkup = renderWithPromptLMTheme(
+    React.createElement(PlaceholderToken, { name: 'agent_name' }),
+  );
+  const diffMarkup = renderWithPromptLMTheme(
+    React.createElement(DiffLine, { kind: 'add' }, 'added line'),
+  );
+
+  assert.match(monoMarkup, /prm_8f3a/);
+  assert.match(tagMarkup, /v1\.8\.0/);
+  assert.match(statusMarkup, /production/);
+  assert.match(vendorMarkup, /<span/);
+  assert.match(sparkMarkup, /success rate trend/);
+  assert.match(logoMarkup, /<svg/);
+  assert.match(pillMarkup, /version/);
+  assert.match(pillMarkup, /1\.8\.0/);
+  assert.match(placeholderMarkup, /\{\{agent_name\}\}/);
+  assert.match(diffMarkup, /added line/);
+};
+
 verifyLayoutExports();
 verifyInfoAndSectionCards();
 verifyPromptEditorExports();
+verifyPromptsV2Atoms();
 
 console.log('UI package smoke checks passed');
 process.exit(0);

--- a/components/ui/tsconfig.json
+++ b/components/ui/tsconfig.json
@@ -24,7 +24,9 @@
     "src/components/SectionCard/**/*.ts",
     "src/components/SectionCard/**/*.tsx",
     "src/prompt-editor/**/*.ts",
-    "src/prompt-editor/**/*.tsx"
+    "src/prompt-editor/**/*.tsx",
+    "src/prompts-v2/**/*.ts",
+    "src/prompts-v2/**/*.tsx"
   ],
   "exclude": [
     "src/**/*.stories.ts",


### PR DESCRIPTION
## Summary

First slice of the new UI design system from \`design/handoff/\`, scoped to \`@promptlm/ui\`. Adds:

- **Tokens** ([\`src/prompts-v2/tokens.css\`](components/ui/src/prompts-v2/tokens.css)) — oklch slate \`--pl-ink-*\`, electric cyan \`--pl-signal*\`, functional \`--pl-ok / --pl-warn / --pl-fail\`, Geist + JetBrains Mono families, radii, shadows, and the \`.pl\` / \`.pl-mono\` / \`.pl-eyebrow\` / \`.pl-btn*\` / \`.pl-card\` utility classes.
- **9 atom components** under \`src/prompts-v2/atoms/\`, each with a Storybook story:
  - \`Mono\`, \`Tag\` (5 tones), \`StatusDot\` (4 statuses + \`iconOnly\`), \`VendorMark\` (anthropic / openai), \`Sparkline\` (line + filled variants), \`MiniLogo\`, \`MetaPill\`, \`PlaceholderToken\` (\`{{var}}\` chip), \`DiffLine\` (add / del bands).
- **Build & exports**:
  - New \`scripts/copy-assets.mjs\` walks \`src/\` and copies CSS into \`dist/\` after \`tsc\`.
  - \`package.json\` exposes \`./prompts-v2/tokens.css\` as a subpath export.
  - \`tsconfig.json\` includes \`src/prompts-v2/**\`.
  - Top-level \`src/index.ts\` re-exports everything from \`./prompts-v2\`.
- **Storybook**:
  - \`.storybook/preview.tsx\` imports the tokens.
  - New \`.storybook/preview-head.html\` loads Geist + JetBrains Mono from Google Fonts.
- **Smoke test**: \`test/ui-package-smoke.mjs\` extended with a \`verifyPromptsV2Atoms()\` function that renders every new atom via \`react-dom/server\` — so the package boundary is exercised, not just typechecked.

## Scope guardrails

- No webui changes. Tokens are loaded only by \`@promptlm/ui\`'s own Storybook in this PR; webui will pick them up in PR 3 alongside page wiring.
- No backend / API client changes.
- Apache 2.0 headers on every new file (the pre-commit license-header hook enforces the long form).

## Why this PR is foundational

Subsequent PRs (catalog block, detail read view, AppShell v2, diff view, form re-skin, static report) all compose these atoms. Locking the visual primitives first keeps the diff per page-level PR small.

## Test plan

- [x] \`npm run build\` (in \`components/ui\`) — \`tsc\` + dist-import rewrite + asset copy.
- [x] \`npm test\` — smoke test renders each new atom and asserts the rendered markup contains expected text/SVG.
- [x] \`npm run storybook:build\` — Storybook compiles; all 9 new \`*.stories.tsx\` chunks present in \`storybook-static/assets/\`.
- [x] \`@promptlm/web-ui\` typecheck — error count unchanged from \`main\` (108 pre-existing errors in \`Dashboard.tsx\`, none introduced by this PR).
- [x] \`@promptlm/web-ui\` \`npm run build\` — passes.
- [x] Reviewer: open Storybook locally (\`npm run storybook -p 6006\` from \`components/ui\`) and visually QA the new "Prompts v2 / Atoms / *" stories.

## Notes for reviewers

- All atoms accept \`...rest\` HTML attributes and use \`React.forwardRef\` where they wrap a single element, so they compose cleanly with Radix slot patterns down the line.
- Inline styles (rather than Tailwind classes) match the source design's idiom and keep these atoms framework-agnostic — usable equally from the Vite-bundled webui and from the static-report build that will land in PR 5.
- This PR is the base of a stack: PR 2 (page blocks) will target this same integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)