### PR TITLE
feat(webui,ui): thin v2 reskin of the prompt editor chrome

### DIFF
--- a/components/promptlm-web-ui/src/features/prompt-editor/PromptEditorPage.tsx
+++ b/components/promptlm-web-ui/src/features/prompt-editor/PromptEditorPage.tsx
@@ -29,25 +29,27 @@ import { flushSync } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 
 import type {
+  EditorTopBarMessage,
   MessageContentSelection,
-  PromptEditorBannerMessage,
   PromptEditorEvaluationResult,
   PromptEditorExecution,
   PromptEditorTab,
   PromptEditorToolConfig,
 } from '@promptlm/ui';
 import {
+  EditorTopBar,
   EvaluationPlanCard,
   EvaluationResultsCard,
   LastExecutionCard,
   MessagesCard,
   MetadataCard,
   ModelConfigurationCard,
-  PromptEditorHeader,
   PromptEditorTabsLayout,
   PromptPreviewCard,
   ToolConfigsCard,
 } from '@promptlm/ui';
+
+import { featureFlags } from '@/lib/featureFlags';
 
 import { toDisplayError } from '@api-common/apiError';
 import type { PromptSpec } from '@promptlm/api-client';
@@ -190,7 +192,11 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
   const [toolConfigs, setToolConfigs] = useState<PromptEditorToolConfig[]>([]);
   const [messageSelection, setMessageSelection] = useState<MessageContentSelection | null>(null);
 
-  const isEvaluationCapabilityEnabled = Boolean(capabilities.data?.features?.includes('evals'));
+  // Evals are gated by the runtime capability AND the v2 feature flag. Until
+  // the commercial rollout (issue #80) the flag stays off so the eval-related
+  // surfaces (plan, results) don't render even on capable backends.
+  const isEvaluationCapabilityEnabled =
+    featureFlags.evals && Boolean(capabilities.data?.features?.includes('evals'));
 
   const evaluationEnabledForValidation = isEvaluationCapabilityEnabled ? editor.state.evaluationEnabled : false;
 
@@ -564,8 +570,8 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
     editor.addEvaluation();
   }, [editor, isEvaluationCapabilityEnabled]);
 
-  const headerMessages = useMemo<PromptEditorBannerMessage[]>(() => {
-    const messages: PromptEditorBannerMessage[] = [];
+  const headerMessages = useMemo<EditorTopBarMessage[]>(() => {
+    const messages: EditorTopBarMessage[] = [];
 
     if (!data.activeProjectId && !data.isActiveProjectLoading) {
       messages.push({
@@ -644,8 +650,22 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
     );
   }
 
+  const editorTitle =
+    mode === 'create' ? 'new prompt' : editor.state.draft.name || 'edit prompt';
+
   return (
-    <Box component="form" onSubmit={handleSubmit} noValidate>
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      noValidate
+      sx={{
+        background: 'var(--pl-canvas)',
+        flex: 1,
+        minHeight: 0,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
       <Snackbar
         open={toast.open}
         autoHideDuration={3000}
@@ -657,31 +677,23 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
         </Alert>
       </Snackbar>
 
-      <Stack spacing={3}>
-        <PromptEditorHeader
-          mode={mode}
-          title={mode === 'create' ? 'Create prompt' : editor.state.draft.name || 'Edit prompt'}
-          description={
-            mode === 'create'
-              ? 'Compose a prompt draft and save it into the active project.'
-              : editor.state.draft.description || 'Review, test, and release the current prompt draft.'
-          }
-          isBusy={isBusy}
-          isReleasing={isReleasing}
-          messages={headerMessages}
-          onBack={() => navigate('/prompts')}
-          onCreate={() => {
-            void saveDraft();
-          }}
-          onEdit={() => {
-            void saveDraft();
-          }}
-          onRelease={handleRelease}
-          createLabel="Save prompt"
-          editLabel="Save prompt"
-          releaseLabel="Release"
-        />
+      <EditorTopBar
+        mode={mode}
+        breadcrumb={['prompts', editorTitle]}
+        isBusy={isBusy}
+        isSaving={data.isSaving}
+        isReleasing={isReleasing}
+        messages={headerMessages}
+        saveLabel="Save prompt"
+        releaseLabel="Release"
+        onSave={() => {
+          void saveDraft();
+        }}
+        onRelease={mode === 'edit' ? handleRelease : undefined}
+        onBack={() => navigate('/prompts')}
+      />
 
+      <Stack spacing={3} sx={{ p: 4 }}>
         <PromptEditorTabsLayout
           tabs={tabs}
           activeTab={activeTab}
@@ -853,7 +865,7 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
                 />
               ) : null}
 
-              {evaluationResults.length > 0 ? (
+              {featureFlags.evals && evaluationResults.length > 0 ? (
                 <EvaluationResultsCard results={evaluationResults} />
               ) : null}
             </Stack>

--- a/components/promptlm-web-ui/src/pages/__tests__/PromptEdit.test.tsx
+++ b/components/promptlm-web-ui/src/pages/__tests__/PromptEdit.test.tsx
@@ -32,9 +32,9 @@ vi.mock('@/features/prompt-editor/PromptEditorPage', () => ({
   },
 }));
 
-import PromptDetail from '../PromptDetail';
+import PromptEdit from '../PromptEdit';
 
-describe('PromptDetail', () => {
+describe('PromptEdit', () => {
   beforeEach(() => {
     mocks.useParamsMock.mockReset();
     mocks.promptEditorPageMock.mockReset();
@@ -43,7 +43,7 @@ describe('PromptDetail', () => {
   it('renders the unified prompt editor in edit mode with route prompt id', () => {
     mocks.useParamsMock.mockReturnValue({ id: 'prompt-42' });
 
-    renderToString(React.createElement(PromptDetail));
+    renderToString(React.createElement(PromptEdit));
 
     expect(mocks.promptEditorPageMock).toHaveBeenCalledTimes(1);
     expect(mocks.promptEditorPageMock).toHaveBeenCalledWith(
@@ -57,7 +57,7 @@ describe('PromptDetail', () => {
   it('passes null prompt id when the route param is missing', () => {
     mocks.useParamsMock.mockReturnValue({});
 
-    renderToString(React.createElement(PromptDetail));
+    renderToString(React.createElement(PromptEdit));
 
     expect(mocks.promptEditorPageMock).toHaveBeenCalledTimes(1);
     expect(mocks.promptEditorPageMock).toHaveBeenCalledWith(

--- a/components/ui/src/prompts-v2/editor/EditorTopBar.stories.tsx
+++ b/components/ui/src/prompts-v2/editor/EditorTopBar.stories.tsx
@@ -1,0 +1,80 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { EditorTopBar } from './EditorTopBar';
+
+const meta: Meta<typeof EditorTopBar> = {
+  title: 'Prompts v2 / Editor / EditorTopBar',
+  component: EditorTopBar,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof EditorTopBar>;
+
+const baseBreadcrumb = ['acme · prod', 'prompts', 'doc-rag-answer'];
+
+export const EditMode: Story = {
+  render: () => (
+    <EditorTopBar
+      mode="edit"
+      breadcrumb={baseBreadcrumb}
+      onSave={() => undefined}
+      onRelease={() => undefined}
+      onBack={() => undefined}
+    />
+  ),
+};
+
+export const CreateMode: Story = {
+  render: () => (
+    <EditorTopBar
+      mode="create"
+      breadcrumb={['acme · prod', 'prompts', 'new prompt']}
+      saveLabel="Create prompt"
+      onSave={() => undefined}
+      onBack={() => undefined}
+    />
+  ),
+};
+
+export const Saving: Story = {
+  render: () => (
+    <EditorTopBar
+      mode="edit"
+      breadcrumb={baseBreadcrumb}
+      isSaving
+      onSave={() => undefined}
+      onRelease={() => undefined}
+      onBack={() => undefined}
+    />
+  ),
+};
+
+export const WithMessages: Story = {
+  render: () => (
+    <EditorTopBar
+      mode="edit"
+      breadcrumb={baseBreadcrumb}
+      messages={[
+        { severity: 'info', text: 'Repository URL inferred from active project.' },
+        { severity: 'error', text: 'Could not save: name already exists in this group.' },
+      ]}
+      onSave={() => undefined}
+      onRelease={() => undefined}
+      onBack={() => undefined}
+    />
+  ),
+};

--- a/components/ui/src/prompts-v2/editor/EditorTopBar.tsx
+++ b/components/ui/src/prompts-v2/editor/EditorTopBar.tsx
@@ -1,0 +1,176 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+import { Mono } from '../atoms';
+
+export type EditorMode = 'create' | 'edit';
+
+export interface EditorTopBarMessage {
+  severity: 'info' | 'success' | 'warning' | 'error';
+  text: string;
+}
+
+export interface EditorTopBarProps {
+  mode: EditorMode;
+  /** Breadcrumb segments leading to the prompt; last is rendered emphasised. */
+  breadcrumb: readonly string[];
+  /** Disable the save action (busy / pending requests). */
+  isBusy?: boolean;
+  /** Save button is in-flight. */
+  isSaving?: boolean;
+  /** Release button is in-flight. */
+  isReleasing?: boolean;
+  /** Inline messages rendered under the breadcrumb (errors, info). */
+  messages?: readonly EditorTopBarMessage[];
+  /** Save action label override (defaults to "Save prompt"). */
+  saveLabel?: string;
+  /** Release action label override (defaults to "Release"). */
+  releaseLabel?: string;
+  onSave: () => void;
+  /** Optional release action; omitted in create mode. */
+  onRelease?: () => void;
+  onBack?: () => void;
+}
+
+const SEVERITY_TONES: Record<EditorTopBarMessage['severity'], { bg: string; bd: string; fg: string }> = {
+  info: {
+    bg: 'color-mix(in oklch, var(--pl-signal) 8%, var(--pl-paper))',
+    bd: 'color-mix(in oklch, var(--pl-signal) 30%, var(--pl-ink-200))',
+    fg: 'var(--pl-signal-ink)',
+  },
+  success: {
+    bg: 'color-mix(in oklch, var(--pl-ok) 10%, var(--pl-paper))',
+    bd: 'color-mix(in oklch, var(--pl-ok) 35%, var(--pl-ink-200))',
+    fg: 'oklch(0.32 0.10 155)',
+  },
+  warning: {
+    bg: 'color-mix(in oklch, var(--pl-warn) 14%, var(--pl-paper))',
+    bd: 'color-mix(in oklch, var(--pl-warn) 40%, var(--pl-ink-200))',
+    fg: 'oklch(0.42 0.10 75)',
+  },
+  error: {
+    bg: 'color-mix(in oklch, var(--pl-fail) 10%, var(--pl-paper))',
+    bd: 'color-mix(in oklch, var(--pl-fail) 35%, var(--pl-ink-200))',
+    fg: 'oklch(0.42 0.13 25)',
+  },
+};
+
+/**
+ * Sticky topbar for the prompt editor. Mirrors the visual language of
+ * `CatalogTopBar` so the editor doesn't feel like a different app — same
+ * 52px height, same hairline border, same breadcrumb treatment. Inline
+ * messages slot below the breadcrumb at the same height as the buttons.
+ */
+export const EditorTopBar: React.FC<EditorTopBarProps> = ({
+  mode,
+  breadcrumb,
+  isBusy = false,
+  isSaving = false,
+  isReleasing = false,
+  messages = [],
+  saveLabel = 'Save prompt',
+  releaseLabel = 'Release',
+  onSave,
+  onRelease,
+  onBack,
+}) => {
+  const last = breadcrumb[breadcrumb.length - 1];
+  const lead = breadcrumb.slice(0, -1);
+  return (
+    <div
+      style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 10,
+        background: 'var(--pl-paper)',
+        borderBottom: '1px solid var(--pl-ink-200)',
+      }}
+    >
+      <header
+        style={{
+          height: 52,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 16,
+          padding: '0 24px',
+        }}
+      >
+        <Mono size={11} color="var(--pl-ink-500)" style={{ letterSpacing: '0.06em' }}>
+          {lead.length > 0 && <>{lead.join(' · ')} / </>}
+          <span style={{ color: 'var(--pl-ink-800)' }}>{last}</span>
+        </Mono>
+
+        <div style={{ flex: 1 }} />
+
+        {onBack && (
+          <button
+            type="button"
+            className="pl-btn pl-btn-ghost"
+            style={{ height: 32, padding: '0 12px', fontSize: 13 }}
+            onClick={onBack}
+          >
+            Back
+          </button>
+        )}
+        <button
+          type="button"
+          className="pl-btn pl-btn-primary"
+          style={{ height: 32, padding: '0 14px', fontSize: 13 }}
+          onClick={onSave}
+          disabled={isBusy || isSaving}
+        >
+          {isSaving ? 'Saving…' : saveLabel}
+        </button>
+        {mode === 'edit' && onRelease && (
+          <button
+            type="button"
+            className="pl-btn pl-btn-ghost"
+            style={{ height: 32, padding: '0 12px', fontSize: 13 }}
+            onClick={onRelease}
+            disabled={isBusy || isReleasing}
+          >
+            {isReleasing ? 'Releasing…' : releaseLabel}
+          </button>
+        )}
+      </header>
+
+      {messages.length > 0 && (
+        <div
+          role="status"
+          style={{ padding: '0 24px 12px', display: 'flex', flexDirection: 'column', gap: 6 }}
+        >
+          {messages.map((m, i) => {
+            const tone = SEVERITY_TONES[m.severity];
+            return (
+              <div
+                key={`${m.severity}-${i}`}
+                style={{
+                  fontSize: 12.5,
+                  padding: '6px 10px',
+                  borderRadius: 6,
+                  background: tone.bg,
+                  border: `1px solid ${tone.bd}`,
+                  color: tone.fg,
+                }}
+              >
+                {m.text}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/ui/src/prompts-v2/editor/index.ts
+++ b/components/ui/src/prompts-v2/editor/index.ts
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './atoms';
-export * from './catalog';
-export * from './detail';
-export * from './editor';
-export * from './shell';
+export { EditorTopBar } from './EditorTopBar';
+export type {
+  EditorTopBarProps,
+  EditorTopBarMessage,
+  EditorMode,
+} from './EditorTopBar';


### PR DESCRIPTION
## Summary

Wraps `PromptEditorPage` in v2 vocabulary **at the chrome level only** — top bar, page background, and feature-flag-gated eval sections — without re-implementing the form cards. The designer is delivering a new form spec; deeper editor reskinning is deferred so we don't pile up throwaway work, but the editor now visually belongs to the same app as the catalog and read view.

### `@promptlm/ui` — new editor module
- **`src/prompts-v2/editor/EditorTopBar.tsx`** — sticky topbar matching the `CatalogTopBar` look (52px height, hairline border, `--pl-paper` background). Mode-aware: shows **Save** in both modes plus **Release** in edit. Renders inline messages (info / warning / error) under the breadcrumb at the same severity tones used elsewhere in prompts-v2. Storybook story covers create / edit / saving / messages.
- prompts-v2 barrel + tsconfig: editor module exposed alongside atoms / catalog / detail / shell.

### webui — `PromptEditorPage` swap
- Replaces the MUI `PromptEditorHeader` with `EditorTopBar`, retypes `headerMessages` to `EditorTopBarMessage` (same shape), and wraps the outer form in `--pl-canvas` so the page sits flush with the sidebar.
- `isEvaluationCapabilityEnabled` now AND-gates the runtime capability with `featureFlags.evals` (#80) so the eval Plan + Results cards stay hidden in v1 even if the backend reports support.
- Form internals (`MetadataCard`, `ModelConfigurationCard`, `MessagesCard`, `PlaceholderManager`, `ToolConfigsCard`) remain MUI for now — they will be replaced when the designer's form draft lands.

### Test rename fix (carry-over from #84)
`PromptEdit.test.tsx` still imported `PromptDetail` and described it under that name — a leftover from the squash of #84 where the rename landed but the content fix was dropped. Updated to import `PromptEdit` and `describe('PromptEdit')`; test now exercises the actual edit-route wrapper.

## Why thin, not full

Re-implementing `MetadataCard`, `ModelConfigurationCard`, `MessagesCard`, `PlaceholderManager`, and `ToolConfigsCard` in v2 vocabulary is **~1000+ lines of throwaway code** — the designer is delivering a new form spec. Going further now would mean inventing layout / UX decisions (should metadata move into the top bar? does request-config become a sticky right rail? do messages get inline diff in edit mode?) that belong with the designer.

The thin reskin gets the editor visually consistent with the rest of the v2 app *now* with minimum waste. Inner form cards look like a slightly out-of-place island below the v2 top bar — acceptable, transitional. When the designer delivers, we replace the inner cards in one focused PR rather than rebuild + rebuild.

## Test plan

- [x] `npm run build` (`components/ui` + `components/promptlm-web-ui`) — both clean.
- [x] `npm test` (webui) — **65/65** tests green across 15 files; `PromptEdit.test.tsx` now passes after the import/describe fix.
- [x] `npx tsc --noEmit` (webui) — error count unchanged from `main` (**108 pre-existing**, none new).
- [x] Visual smoke against `npm run dev` at `/prompts/new`: v2 sticky top bar (`prompts / new prompt` breadcrumb + Back + Save) above the existing MUI cards on a `--pl-canvas` background. No eval sections rendered. Sidebar's "Prompts" item active.
- [x] Reviewer with backend running: walk catalog → click prompt → land on read view → click "Edit" → land on editor at `/prompts/:id/edit`; confirm Save / Release / Back wire correctly and inline error messages render via the top bar (e.g. trigger by clearing the active project).

## Notes for reviewers

- The toast-on-save flow (MUI `Snackbar`) is unchanged — it's orthogonal to the top bar messages.
- `PromptEditorTabsLayout` (Editor / Preview / Test / History) still renders below the top bar; it's MUI but coexists OK.
- `EditorTopBar` is also useful from outside the editor (e.g. an "edit settings" page in the future). It's therefore generic — accepts any breadcrumb, not "prompt-shaped" props.
- This PR stacks on top of #82, #83, and #84 (all merged into `feat/new-ui-design`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)