### PR TITLE
fix(ui,test): restore acceptance-test data-testids on v2 components

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
@@ -142,10 +142,9 @@ public class HappyPathUserJourneyTest {
         navigateToApplication();
         ensureRepositoryVariablesConfigured();
 
-        // Click on "Add" button to open dropdown menu
-        page.getByTestId("add-button").click();
-
-        // Click on "New Prompt" in the dropdown menu
+        // v2 UX: there is no global "Add" dropdown — the New prompt button lives in
+        // the catalog top bar. Navigate to /prompts and click it directly.
+        navigateToPath("/prompts");
         page.getByTestId("create-prompt-button").click();
 
         // Verify we're in the prompt editor via unique heading test id
@@ -228,7 +227,10 @@ public class HappyPathUserJourneyTest {
         gitea.resetRepositoryActionsState(repositoryOwner, REPO_NAME);
         gitea.logRepositoryActionsDiagnostics(repositoryOwner, REPO_NAME);
 
+        // v2 UX: clicking a catalog row opens the read view; the editor lives at
+        // /prompts/:id/edit. Click "Edit" to reach the editor, then Release.
         page.getByTestId("prompt-card-%s-action".formatted(PROMPT_NAME)).click();
+        page.getByTestId("prompt-edit-action").click();
         page.getByTestId("prompt-editor-release-action").click();
         navigateToPath("/prompts");
         takeScreenshot("here.png");

--- a/components/promptlm-web-ui/src/features/prompt-editor/PromptEditorPage.tsx
+++ b/components/promptlm-web-ui/src/features/prompt-editor/PromptEditorPage.tsx
@@ -836,7 +836,6 @@ export const PromptEditorPage: React.FC<PromptEditorPageProps> = ({ mode, prompt
                             color="secondary"
                             onClick={() => void handleRelease()}
                             disabled={isReleasing}
-                            data-testid="prompt-editor-release-action"
                           >
                             {isReleasing ? 'Publishing…' : 'Release'}
                           </Button>

--- a/components/promptlm-web-ui/src/pages/PromptDetail.tsx
+++ b/components/promptlm-web-ui/src/pages/PromptDetail.tsx
@@ -50,6 +50,7 @@ const TopBar = ({ name, editTo }: { name: string; editTo: string }) => (
     <Link
       to={editTo}
       className="pl-btn pl-btn-primary"
+      data-testid="prompt-edit-action"
       style={{
         height: 32,
         padding: '0 14px',

--- a/components/ui/src/prompts-v2/catalog/CatalogRow.tsx
+++ b/components/ui/src/prompts-v2/catalog/CatalogRow.tsx
@@ -64,6 +64,7 @@ export const CatalogRow: React.FC<CatalogRowProps> = ({
             }
           : undefined
       }
+      data-testid={`prompt-card-${p.name}-action`}
       style={{
         display: 'grid',
         gridTemplateColumns: CATALOG_GRID_COLUMNS,

--- a/components/ui/src/prompts-v2/catalog/CatalogTopBar.tsx
+++ b/components/ui/src/prompts-v2/catalog/CatalogTopBar.tsx
@@ -123,6 +123,7 @@ export const CatalogTopBar: React.FC<CatalogTopBarProps> = ({
           className="pl-btn pl-btn-primary"
           style={{ height: 32, padding: '0 14px', fontSize: 13 }}
           onClick={onNewPrompt}
+          data-testid="create-prompt-button"
         >
           <span style={{ fontFamily: MONO, fontSize: 14, marginTop: -1 }}>+</span> New prompt
         </button>

--- a/components/ui/src/prompts-v2/editor/EditorTopBar.tsx
+++ b/components/ui/src/prompts-v2/editor/EditorTopBar.tsx
@@ -109,7 +109,9 @@ export const EditorTopBar: React.FC<EditorTopBarProps> = ({
       >
         <Mono size={11} color="var(--pl-ink-500)" style={{ letterSpacing: '0.06em' }}>
           {lead.length > 0 && <>{lead.join(' · ')} / </>}
-          <span style={{ color: 'var(--pl-ink-800)' }}>{last}</span>
+          <span style={{ color: 'var(--pl-ink-800)' }} data-testid="prompt-editor-heading">
+            {last}
+          </span>
         </Mono>
 
         <div style={{ flex: 1 }} />
@@ -130,6 +132,9 @@ export const EditorTopBar: React.FC<EditorTopBarProps> = ({
           style={{ height: 32, padding: '0 14px', fontSize: 13 }}
           onClick={onSave}
           disabled={isBusy || isSaving}
+          data-testid={
+            mode === 'create' ? 'prompt-editor-create-action' : 'prompt-editor-edit-action'
+          }
         >
           {isSaving ? 'Saving…' : saveLabel}
         </button>
@@ -140,6 +145,7 @@ export const EditorTopBar: React.FC<EditorTopBarProps> = ({
             style={{ height: 32, padding: '0 12px', fontSize: 13 }}
             onClick={onRelease}
             disabled={isBusy || isReleasing}
+            data-testid="prompt-editor-release-action"
           >
             {isReleasing ? 'Releasing…' : releaseLabel}
           </button>


### PR DESCRIPTION
## Summary

Two acceptance tests started timing out after the v2 redesign landed:

```
HappyPathUserJourneyTest.shouldCreateNewPrompt — timed out after 5 min
HappyPathUserJourneyTest.releasePrompt — timed out waiting for spec
```

Diagnosis: their `data-testid` selectors point at elements that PRs #82–#86 deleted or replaced. I verified this by booting the dev server and probing the DOM with Playwright (via Claude Preview) at each route the test walks through. Then re-attached the testids to their v2 landing sites and adapted the test to the two genuine UX changes.

## Root cause map

| Selector | What it pointed at | What changed | Fix |
|---|---|---|---|
| `add-button` | Legacy `Header` Create dropdown trigger | Header removed in #84 | Test: drop dropdown click — v2 has a single `New prompt` button |
| `create-prompt-button` | Legacy dropdown menu item | Header removed in #84 | UI: add testid to `CatalogTopBar`'s `New prompt` button |
| `prompt-editor-heading` | MUI `PromptEditorHeader` `<h4>` | Header replaced in #85 | UI: add testid to `EditorTopBar` breadcrumb tail |
| `prompt-card-{name}-action` | Legacy `PromptCard` link | Catalog uses `CatalogRow` now | UI: add testid to `CatalogRow` container |
| `prompt-editor-release-action` (the canonical one) | MUI `PromptEditorHeader` Release button | Header replaced in #85 | UI: add testid to `EditorTopBar` Release button |
| `prompt-editor-release-action` (duplicate) | Response paper Release button (only renders post-run) | Still present, would clash with the EditorTopBar one once both render | UI: remove the testid from the Response paper — `EditorTopBar` is canonical |

Plus one true UX change: clicking a catalog row now lands on the read-only `PromptDetail` view, not the editor (#84). The test was reaching the editor in one click before; now it needs an explicit `Edit` click first. Added `data-testid="prompt-edit-action"` to that link and updated the test.

## UI changes

```
CatalogTopBar.tsx     New prompt:         data-testid="create-prompt-button"
CatalogRow.tsx        Row container:      data-testid="prompt-card-{name}-action"
EditorTopBar.tsx      Breadcrumb tail:    data-testid="prompt-editor-heading"
                      Save (create mode): data-testid="prompt-editor-create-action"
                      Save (edit mode):   data-testid="prompt-editor-edit-action"
                      Release:            data-testid="prompt-editor-release-action"
PromptDetail.tsx      Edit link:          data-testid="prompt-edit-action"
PromptEditorPage.tsx  Removed duplicate prompt-editor-release-action from the
                      Response paper (lived inside the post-run conditional;
                      caused strict-mode locator violations once EditorTopBar
                      rendered the same testid).
```

## Test changes (acceptance test only)

```
shouldCreateNewPrompt
  - page.getByTestId("add-button").click();
  - page.getByTestId("create-prompt-button").click();
  + navigateToPath("/prompts");
  + page.getByTestId("create-prompt-button").click();

releasePrompt
    page.getByTestId("prompt-card-%s-action".formatted(PROMPT_NAME)).click();
  + page.getByTestId("prompt-edit-action").click();
    page.getByTestId("prompt-editor-release-action").click();
```

## Playwright verification

Booted `npm run dev` and walked the test's exact paths. Each selector resolves to **exactly one** element on its expected route:

| Route | Probe | Count |
|---|---|---|
| `/prompts` | `create-prompt-button` | 1 |
| `/prompts` | `prompt-card-{n}-action` (DIV) | 1 per visible row |
| `/prompts/:id` | `prompt-edit-action` | 1 |
| `/prompts/:id/edit` | `prompt-editor-heading` | 1 |
| `/prompts/:id/edit` | `prompt-editor-edit-action` | 1 |
| `/prompts/:id/edit` | `prompt-editor-create-action` | 0 ✓ |
| `/prompts/:id/edit` | `prompt-editor-release-action` | 1 |
| `/prompts/:id/edit` | `save-prompt-button`, `prompt-name-input`, `prompt-group-input` | 1 each |
| `/prompts/new` | `prompt-editor-create-action` | 1 |
| `/prompts/new` | `prompt-editor-edit-action`, `prompt-editor-release-action` | 0 each ✓ |

Strict-mode locator violations are eliminated — no testid resolves to multiple elements simultaneously.

## Test plan

- [x] `@promptlm/ui` build clean.
- [x] `@promptlm/web-ui` build clean.
- [x] DOM probe via Playwright at each route the failing tests visit.
- [ ] Reviewer: re-run `mvn -pl acceptance-tests verify` (or whichever target the CI used) — `shouldCreateNewPrompt` and `releasePrompt` should now go end-to-end. `shouldValidateRequiredFields` was unaffected by the redesign and should remain green.

## Notes

- This is a hotfix branch off `feat/new-ui-design` (the redesign integration branch). It should land before that branch merges to `main`.
- I considered keeping a hidden `add-button` element on every page for backwards compatibility but rejected it: the v2 UX explicitly removed the dropdown, and the test should follow the real flow rather than mask it. The two-line test update encodes the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)