### PR TITLE
ci: split acceptance tests into a separate gated workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,21 +59,6 @@ jobs:
       - name: Run Framework Tests
         run: mvn -B test
 
-      - name: Run Acceptance Tests
-        run: mvn -B -f acceptance-tests/pom.xml -Dpromptlm.bootstrap.skip=true test
-
-      - name: Upload Acceptance Test Artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: acceptance-tests-${{ github.sha }}
-          if-no-files-found: warn
-          path: |
-            acceptance-tests/target/surefire-reports/**
-            acceptance-tests/target/screenshots/**
-            acceptance-tests/target/traces/**
-          retention-days: 1
-
       - name: Build Repository Template
         run: mvn -B -pl components/repository-template package
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,144 @@
+#
+# Copyright 2025 promptLM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Acceptance Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly full run against the default branch at 03:00 UTC.
+    - cron: '0 3 * * *'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  decide:
+    name: Decide whether to run acceptance
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            critical:
+              - 'pom.xml'
+              - '**/pom.xml'
+              - 'acceptance-tests/**'
+              - 'components/repository-template/**'
+              - '.github/workflows/acceptance.yml'
+              - '.github/workflows/CI.yml'
+
+      - name: Decide
+        id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-acceptance') }}
+          PATHS_MATCH: ${{ steps.filter.outputs.critical }}
+        run: |
+          run=false
+          reason=""
+          case "$EVENT" in
+            workflow_dispatch)
+              run=true; reason="manual dispatch"
+              ;;
+            schedule)
+              run=true; reason="nightly schedule"
+              ;;
+            pull_request)
+              if [[ "$ACTION" == "labeled" ]]; then
+                if [[ "$LABEL_NAME" == "run-acceptance" ]]; then
+                  run=true; reason="run-acceptance label added"
+                else
+                  reason="unrelated label '$LABEL_NAME' — skipping"
+                fi
+              else
+                if [[ "$HAS_LABEL" == "true" ]]; then
+                  run=true; reason="run-acceptance label present"
+                elif [[ "$PATHS_MATCH" == "true" ]]; then
+                  run=true; reason="critical paths changed"
+                else
+                  reason="no critical paths and no label — skipping"
+                fi
+              fi
+              ;;
+            *)
+              reason="unsupported event '$EVENT'"
+              ;;
+          esac
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Acceptance gate::run=$run ($reason)"
+
+  acceptance:
+    name: Acceptance Tests
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      REPO_REMOTE_URL: ${{ secrets.REPO_REMOTE_URL }}
+      REPO_REMOTE_USERNAME: ${{ secrets.REPO_REMOTE_USERNAME }}
+      REPO_REMOTE_TOKEN: ${{ secrets.REPO_REMOTE_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Build promptLM Framework
+        run: mvn -B -DskipTests install
+
+      - name: Run Acceptance Tests
+        run: mvn -B -f acceptance-tests/pom.xml -Dpromptlm.bootstrap.skip=true test
+
+      - name: Upload Acceptance Test Artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: acceptance-tests-${{ github.sha }}
+          if-no-files-found: warn
+          path: |
+            acceptance-tests/target/surefire-reports/**
+            acceptance-tests/target/screenshots/**
+            acceptance-tests/target/traces/**
+          retention-days: 1


### PR DESCRIPTION
Closes #101.

## What

Moves the acceptance-test step out of `CI.yml` into a new `acceptance.yml`. The old workflow keeps everything else (license headers, framework build, unit tests, repository-template build, artifact uploads on main pushes) — that's the fast path on every PR and main push.

The new `acceptance.yml` runs only when something likely to break the suite has changed:

- **Path auto-trigger** — `pom.xml`, `**/pom.xml`, `acceptance-tests/**`, `components/repository-template/**`, both workflow files
- **Label** — adding `run-acceptance` to a PR triggers it (and `synchronize` re-runs it while the label is present)
- **Nightly** — cron `0 3 * * *` against `main`
- **Manual** — `workflow_dispatch`

A small `decide` job evaluates the trigger context and short-circuits if no path matched and no label is present.

## Why

Analysis of the last 50 CI runs (≈2 weeks):
- Acceptance is **~58% of every CI job** (`6:19` of `10:47` on a recent successful run).
- 50 runs in 2 weeks → **~5 GitHub-Actions hours biweekly** spent only on acceptance.
- Of 38 failures across the window, 16 were in acceptance — almost all on dependabot PRs touching `pom.xml`, which the new path filter still catches.

Full breakdown lives in #101.

## What this changes for contributors

- Most PRs (UI/docs/refactors): only Tier 1 runs, ~4 minutes.
- Dependency bumps (dependabot, manual `pom.xml` edits): acceptance still auto-runs.
- Touching `apps/**` or `components/**` (other than `repository-template`)? Add the `run-acceptance` label when you want acceptance to gate the merge.
- Forgot? The nightly `main` run will catch it within 24 h.

## Branch protection (manual follow-up)

After this merges, update branch protection:
- Required: `promptLM Framework CI / build` (unchanged).
- **Not** required: `Acceptance Tests / acceptance` — it's gated on triggers and won't always run. Reviewers can require the label on risky PRs as a social rule.

## Test plan

- [x] CI on this PR runs the trimmed `CI.yml` and stays green in <5 min
- [x] `acceptance.yml` is triggered on this PR (the `decide` job should run; `acceptance` should run because `.github/workflows/CI.yml` and `.github/workflows/acceptance.yml` matched the path filter)
- [x] Confirm the nightly cron is registered (Actions → Acceptance Tests → schedule)
- [ ] Add a follow-up dependabot PR touching `pom.xml` only and confirm acceptance auto-runs
- [ ] Add a docs-only PR (no code) and confirm acceptance is skipped (decide should output `run=false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)