### PR TITLE
feat(webui): Dashboard phase 2A — filters, time window, kbd shortcuts, tests

### DIFF
--- a/components/promptlm-web-ui/src/pages/Dashboard.helpers.ts
+++ b/components/promptlm-web-ui/src/pages/Dashboard.helpers.ts
@@ -1,0 +1,227 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { formatDistanceToNowStrict } from 'date-fns';
+import type { Execution, PromptSpec } from '@promptlm/api-client';
+
+export type FeedKind = 'release' | 'run' | 'draft' | 'create';
+
+export type FeedFilterKind = 'all' | FeedKind;
+
+export type FeedItem = {
+  key: string;
+  kind: FeedKind;
+  /** Pre-formatted relative duration ("3m", "2h", "yesterday"). */
+  when: string;
+  /** Raw timestamp in ms — used for time-window filtering. */
+  ts: number;
+  prompt: string;
+  group?: string;
+  promptId?: string;
+  to?: string;
+  from?: string;
+  summary?: string;
+  status?: 'ok' | 'fail';
+};
+
+export type OpenWorkItem = {
+  key: string;
+  kind: 'draft' | 'untested' | 'retired';
+  prompt: string;
+  promptId?: string;
+  note: string;
+  cta: string;
+  href?: string;
+};
+
+export type TimeWindow = '24h' | '7d' | 'all';
+
+export const TIME_WINDOW_LABELS: Record<TimeWindow, string> = {
+  '24h': 'last 24h',
+  '7d': 'last 7 days',
+  all: 'all time',
+};
+
+export const FEED_FILTER_LABELS: Record<FeedFilterKind, string> = {
+  all: 'all',
+  release: 'releases',
+  run: 'runs',
+  draft: 'drafts',
+  create: 'created',
+};
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export const windowToMs = (window: TimeWindow): number | null => {
+  switch (window) {
+    case '24h':
+      return ONE_DAY_MS;
+    case '7d':
+      return 7 * ONE_DAY_MS;
+    case 'all':
+      return null;
+  }
+};
+
+export const safeRelative = (iso?: string): string => {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  return formatDistanceToNowStrict(date, { addSuffix: false });
+};
+
+export const buildActivityFeed = (
+  prompts: readonly PromptSpec[],
+): FeedItem[] => {
+  const items: FeedItem[] = [];
+  for (const spec of prompts) {
+    const promptName = spec.name ?? spec.id ?? 'unnamed';
+    const promptId = spec.id ?? spec.name;
+    const group = spec.group;
+
+    if (spec.updatedAt) {
+      const ts = new Date(spec.updatedAt).getTime();
+      const isDraft = (spec.revision ?? 0) > 0;
+      const isRetired = spec.status === 'RETIRED';
+      if (!isRetired) {
+        items.push({
+          key: `${promptId}:edit`,
+          kind: isDraft ? 'draft' : 'release',
+          ts: Number.isNaN(ts) ? 0 : ts,
+          when: safeRelative(spec.updatedAt),
+          prompt: promptName,
+          promptId,
+          group,
+          to: isDraft ? undefined : spec.version,
+          summary: isDraft
+            ? `revision ${spec.revision ?? 1} · not yet released`
+            : 'released',
+        });
+      }
+    }
+
+    const executions: readonly Execution[] = spec.executions ?? [];
+    for (const [index, run] of executions.entries()) {
+      const ts = run.timestamp ? new Date(run.timestamp).getTime() : 0;
+      items.push({
+        key: `${promptId}:run:${run.id ?? run.timestamp ?? index}`,
+        kind: 'run',
+        ts: Number.isNaN(ts) ? 0 : ts,
+        when: safeRelative(run.timestamp),
+        prompt: promptName,
+        promptId,
+        group,
+        // Until #77 ships an `ok` flag on Execution we treat the presence of
+        // a captured response as success and missing response as failure.
+        status: run.response ? 'ok' : 'fail',
+        summary: 'execution recorded',
+      });
+    }
+  }
+  items.sort((a, b) => b.ts - a.ts);
+  return items;
+};
+
+export const filterFeed = (
+  items: readonly FeedItem[],
+  kind: FeedFilterKind,
+  window: TimeWindow,
+  now: number = Date.now(),
+): FeedItem[] => {
+  const cutoff = windowToMs(window);
+  return items.filter((item) => {
+    if (kind !== 'all' && item.kind !== kind) return false;
+    if (cutoff !== null && item.ts > 0 && now - item.ts > cutoff) return false;
+    return true;
+  });
+};
+
+export const buildOpenWork = (
+  prompts: readonly PromptSpec[],
+  limit = 4,
+): OpenWorkItem[] => {
+  const items: OpenWorkItem[] = [];
+  for (const spec of prompts) {
+    const promptName = spec.name ?? spec.id ?? 'unnamed';
+    const promptId = spec.id ?? spec.name;
+    const executions = spec.executions ?? [];
+    if (spec.status === 'RETIRED') continue;
+
+    if ((spec.revision ?? 0) > 0) {
+      items.push({
+        key: `${promptId}:draft`,
+        kind: 'draft',
+        prompt: promptName,
+        promptId,
+        note: `Draft on revision ${spec.revision} · not released`,
+        cta: 'Open in editor',
+        href: promptId
+          ? `/prompts/${encodeURIComponent(promptId)}/edit`
+          : undefined,
+      });
+      continue;
+    }
+
+    if (executions.length === 0) {
+      items.push({
+        key: `${promptId}:untested`,
+        kind: 'untested',
+        prompt: promptName,
+        promptId,
+        note: 'Never run · no executions captured',
+        cta: 'Open prompt',
+        href: promptId ? `/prompts/${encodeURIComponent(promptId)}` : undefined,
+      });
+    }
+  }
+  return items.slice(0, limit);
+};
+
+export const findLastRelease = (
+  prompts: readonly PromptSpec[],
+): { ref: string; when: string } | null => {
+  let best: { ts: number; spec: PromptSpec } | null = null;
+  for (const spec of prompts) {
+    if (spec.status === 'RETIRED') continue;
+    if ((spec.revision ?? 0) > 0) continue;
+    if (!spec.updatedAt) continue;
+    const ts = new Date(spec.updatedAt).getTime();
+    if (Number.isNaN(ts)) continue;
+    if (!best || ts > best.ts) {
+      best = { ts, spec };
+    }
+  }
+  if (!best) return null;
+  const name = best.spec.name ?? best.spec.id ?? 'prompt';
+  const version = best.spec.version ? ` · ${best.spec.version}` : '';
+  return {
+    ref: `${name}${version}`,
+    when: `${safeRelative(best.spec.updatedAt)} ago`,
+  };
+};
+
+export const buildGroupCounts = (
+  countByGroup: Record<string, number> | undefined,
+  fallbackPrompts: readonly PromptSpec[],
+): Array<[string, number]> => {
+  if (countByGroup) {
+    return Object.entries(countByGroup).sort((a, b) => b[1] - a[1]);
+  }
+  const fallback = new Map<string, number>();
+  for (const spec of fallbackPrompts) {
+    const key = spec.group ?? 'ungrouped';
+    fallback.set(key, (fallback.get(key) ?? 0) + 1);
+  }
+  return Array.from(fallback.entries()).sort((a, b) => b[1] - a[1]);
+};

--- a/components/promptlm-web-ui/src/pages/Dashboard.tsx
+++ b/components/promptlm-web-ui/src/pages/Dashboard.tsx
@@ -12,159 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useMemo, type CSSProperties, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
-import { formatDistanceToNowStrict } from 'date-fns';
 import { Mono } from '@promptlm/ui';
-import type { Execution, PromptSpec } from '@promptlm/api-client';
 import { useDashboardSummary, usePrompts } from '@/api/hooks';
+import {
+  FEED_FILTER_LABELS,
+  TIME_WINDOW_LABELS,
+  buildActivityFeed,
+  buildGroupCounts,
+  buildOpenWork,
+  filterFeed,
+  findLastRelease,
+  type FeedFilterKind,
+  type FeedItem,
+  type OpenWorkItem,
+  type TimeWindow,
+} from './Dashboard.helpers';
 
-type FeedItem = {
-  key: string;
-  kind: 'release' | 'run' | 'draft' | 'create';
-  when: string;
-  prompt: string;
-  group?: string;
-  promptId?: string;
-  to?: string;
-  from?: string;
-  summary?: string;
-  status?: 'ok' | 'fail';
-};
-
-type OpenWorkItem = {
-  key: string;
-  kind: 'draft' | 'untested' | 'retired';
-  prompt: string;
-  promptId?: string;
-  note: string;
-  cta: string;
-  href?: string;
-};
-
-const ACTIVITY_LIMIT = 10;
-const OPEN_WORK_LIMIT = 4;
-
-const safeRelative = (iso?: string): string => {
-  if (!iso) return '—';
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return '—';
-  return formatDistanceToNowStrict(date, { addSuffix: false });
-};
-
-const buildSortedFeed = (prompts: readonly PromptSpec[]): FeedItem[] => {
-  type Carrier = { item: FeedItem; ts: number };
-  const carriers: Carrier[] = [];
-  for (const spec of prompts) {
-    const promptName = spec.name ?? spec.id ?? 'unnamed';
-    const promptId = spec.id ?? spec.name;
-    const group = spec.group;
-
-    if (spec.updatedAt) {
-      const ts = new Date(spec.updatedAt).getTime();
-      const isDraft = (spec.revision ?? 0) > 0;
-      const isRetired = spec.status === 'RETIRED';
-      if (!isRetired) {
-        carriers.push({
-          ts: Number.isNaN(ts) ? 0 : ts,
-          item: {
-            key: `${promptId}:edit`,
-            kind: isDraft ? 'draft' : 'release',
-            when: safeRelative(spec.updatedAt),
-            prompt: promptName,
-            promptId,
-            group,
-            to: isDraft ? undefined : spec.version,
-            summary: isDraft
-              ? `revision ${spec.revision ?? 1} · not yet released`
-              : 'released',
-          },
-        });
-      }
-    }
-
-    const executions: readonly Execution[] = spec.executions ?? [];
-    for (const run of executions) {
-      const ts = run.timestamp ? new Date(run.timestamp).getTime() : 0;
-      carriers.push({
-        ts: Number.isNaN(ts) ? 0 : ts,
-        item: {
-          key: `${promptId}:run:${run.id ?? run.timestamp ?? carriers.length}`,
-          kind: 'run',
-          when: safeRelative(run.timestamp),
-          prompt: promptName,
-          promptId,
-          group,
-          status: run.response ? 'ok' : 'fail',
-          summary: 'execution recorded',
-        },
-      });
-    }
-  }
-  carriers.sort((a, b) => b.ts - a.ts);
-  return carriers.slice(0, ACTIVITY_LIMIT).map((c) => c.item);
-};
-
-const buildOpenWork = (prompts: readonly PromptSpec[]): OpenWorkItem[] => {
-  const items: OpenWorkItem[] = [];
-  for (const spec of prompts) {
-    const promptName = spec.name ?? spec.id ?? 'unnamed';
-    const promptId = spec.id ?? spec.name;
-    const executions = spec.executions ?? [];
-    const isRetired = spec.status === 'RETIRED';
-    if (isRetired) continue;
-
-    if ((spec.revision ?? 0) > 0) {
-      items.push({
-        key: `${promptId}:draft`,
-        kind: 'draft',
-        prompt: promptName,
-        promptId,
-        note: `Draft on revision ${spec.revision} · not released`,
-        cta: 'Open in editor',
-        href: promptId ? `/prompts/${encodeURIComponent(promptId)}/edit` : undefined,
-      });
-      continue;
-    }
-
-    if (executions.length === 0) {
-      items.push({
-        key: `${promptId}:untested`,
-        kind: 'untested',
-        prompt: promptName,
-        promptId,
-        note: 'Never run · no executions captured',
-        cta: 'Open prompt',
-        href: promptId ? `/prompts/${encodeURIComponent(promptId)}` : undefined,
-      });
-    }
-  }
-  return items.slice(0, OPEN_WORK_LIMIT);
-};
-
-const findLastRelease = (prompts: readonly PromptSpec[]): {
-  ref: string;
-  when: string;
-} | null => {
-  let best: { ts: number; spec: PromptSpec } | null = null;
-  for (const spec of prompts) {
-    if (spec.status === 'RETIRED') continue;
-    if ((spec.revision ?? 0) > 0) continue;
-    if (!spec.updatedAt) continue;
-    const ts = new Date(spec.updatedAt).getTime();
-    if (Number.isNaN(ts)) continue;
-    if (!best || ts > best.ts) {
-      best = { ts, spec };
-    }
-  }
-  if (!best) return null;
-  const name = best.spec.name ?? best.spec.id ?? 'prompt';
-  const version = best.spec.version ? ` · ${best.spec.version}` : '';
-  return {
-    ref: `${name}${version}`,
-    when: safeRelative(best.spec.updatedAt) + ' ago',
-  };
-};
+const ACTIVITY_VISIBLE_LIMIT = 12;
+const FEED_FILTERS: FeedFilterKind[] = ['all', 'release', 'run', 'draft'];
+const TIME_WINDOWS: TimeWindow[] = ['24h', '7d', 'all'];
 
 const eyebrowStyle: CSSProperties = {
   fontFamily: 'var(--pl-mono)',
@@ -196,7 +71,10 @@ const dotForKind = (item: FeedItem): { glyph: string; color: string } => {
   }
 };
 
-const ActivityRow = ({ item, onClick }: {
+const ActivityRow = ({
+  item,
+  onClick,
+}: {
   item: FeedItem;
   onClick?: () => void;
 }) => {
@@ -211,12 +89,9 @@ const ActivityRow = ({ item, onClick }: {
         alignItems: 'baseline',
         gap: 14,
         padding: '14px 0',
-        borderTop: '1px solid var(--pl-ink-200)',
         background: 'transparent',
         border: 'none',
-        borderTopColor: 'var(--pl-ink-200)',
-        borderTopStyle: 'solid',
-        borderTopWidth: 1,
+        borderTop: '1px solid var(--pl-ink-200)',
         width: '100%',
         textAlign: 'left',
         cursor: onClick ? 'pointer' : 'default',
@@ -259,7 +134,11 @@ const ActivityRow = ({ item, onClick }: {
           {item.kind === 'release' && item.to && (
             <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
               <span style={{ color: 'var(--pl-ink-400)', fontSize: 11 }}>→</span>
-              <Mono size={11.5} color="var(--pl-signal-deep)" style={{ fontWeight: 500 }}>
+              <Mono
+                size={11.5}
+                color="var(--pl-signal-deep)"
+                style={{ fontWeight: 500 }}
+              >
                 {item.to}
               </Mono>
             </span>
@@ -315,7 +194,55 @@ const GroupChip = ({
   </button>
 );
 
-const OpenWorkRow = ({ item, onClick }: { item: OpenWorkItem; onClick?: () => void }) => {
+const FilterButton = ({
+  label,
+  active,
+  count,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  count?: number;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-pressed={active}
+    style={{
+      background: 'transparent',
+      border: 'none',
+      padding: 0,
+      fontFamily: 'var(--pl-display)',
+      fontSize: 12.5,
+      color: active ? 'var(--pl-ink-900)' : 'var(--pl-ink-500)',
+      fontWeight: active ? 500 : 400,
+      cursor: 'pointer',
+      borderBottom: active
+        ? '1px solid var(--pl-ink-900)'
+        : '1px solid transparent',
+      paddingBottom: 1,
+      display: 'inline-flex',
+      alignItems: 'baseline',
+      gap: 5,
+    }}
+  >
+    <span>{label}</span>
+    {typeof count === 'number' && (
+      <Mono size={11} color={active ? 'var(--pl-ink-700)' : 'var(--pl-ink-400)'}>
+        {count}
+      </Mono>
+    )}
+  </button>
+);
+
+const OpenWorkRow = ({
+  item,
+  onClick,
+}: {
+  item: OpenWorkItem;
+  onClick?: () => void;
+}) => {
   const tone = (() => {
     switch (item.kind) {
       case 'draft':
@@ -394,28 +321,98 @@ const SkeletonRow = ({ width, inline }: { width: string; inline?: boolean }) => 
   />
 );
 
+const QuickActionButton = ({
+  label,
+  kbd,
+  onClick,
+}: {
+  label: string;
+  kbd: string;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      width: '100%',
+      padding: '8px 10px',
+      background: 'transparent',
+      border: '1px solid var(--pl-ink-200)',
+      borderRadius: 6,
+      cursor: 'pointer',
+      fontFamily: 'var(--pl-display)',
+      fontSize: 12.5,
+      color: 'var(--pl-ink-800)',
+      textAlign: 'left',
+    }}
+  >
+    <span>{label}</span>
+    <Mono
+      size={10.5}
+      color="var(--pl-ink-500)"
+      style={{
+        border: '1px solid var(--pl-ink-300)',
+        padding: '1px 5px',
+        borderRadius: 3,
+      }}
+    >
+      {kbd}
+    </Mono>
+  </button>
+);
+
+const isTypingTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+};
+
 export default function Dashboard() {
   const navigate = useNavigate();
-  const { data: stats, isLoading: isStatsLoading, error: statsError } = useDashboardSummary();
-  const { data: prompts, isLoading: isPromptsLoading, error: promptsError } = usePrompts();
+  const { data: stats, isLoading: isStatsLoading, error: statsError } =
+    useDashboardSummary();
+  const { data: prompts, isLoading: isPromptsLoading, error: promptsError } =
+    usePrompts();
 
   const promptList = useMemo(() => prompts ?? [], [prompts]);
 
-  const groupCounts = useMemo<Array<[string, number]>>(() => {
-    if (stats?.countByGroup) {
-      return Object.entries(stats.countByGroup).sort((a, b) => b[1] - a[1]);
-    }
-    const fallback = new Map<string, number>();
-    for (const spec of promptList) {
-      const key = spec.group ?? 'ungrouped';
-      fallback.set(key, (fallback.get(key) ?? 0) + 1);
-    }
-    return Array.from(fallback.entries()).sort((a, b) => b[1] - a[1]);
-  }, [stats, promptList]);
+  const groupCounts = useMemo(
+    () => buildGroupCounts(stats?.countByGroup, promptList),
+    [stats, promptList],
+  );
 
-  const feed = useMemo(() => buildSortedFeed(promptList), [promptList]);
+  const fullFeed = useMemo(() => buildActivityFeed(promptList), [promptList]);
   const openWork = useMemo(() => buildOpenWork(promptList), [promptList]);
   const lastRelease = useMemo(() => findLastRelease(promptList), [promptList]);
+
+  const [filterKind, setFilterKind] = useState<FeedFilterKind>('all');
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>('24h');
+
+  // Counts per kind, scoped to the active time window so the filter strip
+  // tells the user exactly how many items each chip would surface.
+  const filterCounts = useMemo(() => {
+    const counts: Record<FeedFilterKind, number> = {
+      all: 0,
+      release: 0,
+      run: 0,
+      draft: 0,
+      create: 0,
+    };
+    for (const item of filterFeed(fullFeed, 'all', timeWindow)) {
+      counts.all += 1;
+      counts[item.kind] += 1;
+    }
+    return counts;
+  }, [fullFeed, timeWindow]);
+
+  const visibleFeed = useMemo(
+    () => filterFeed(fullFeed, filterKind, timeWindow).slice(0, ACTIVITY_VISIBLE_LIMIT),
+    [fullFeed, filterKind, timeWindow],
+  );
 
   const totalPrompts = stats?.totalPrompts ?? promptList.length;
   const activePrompts =
@@ -425,7 +422,32 @@ export default function Dashboard() {
     stats?.retiredPrompts ??
     promptList.filter((p) => p.status === 'RETIRED').length;
 
+  const goToNew = useCallback(() => navigate('/prompts/new'), [navigate]);
+  const goToCatalog = useCallback(() => navigate('/prompts'), [navigate]);
+
+  // Global keyboard shortcuts: N = new prompt, P = browse catalog. Ignored
+  // while the user is typing in any input/textarea/select/contenteditable.
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isTypingTarget(event.target)) return;
+      const key = event.key.toLowerCase();
+      if (key === 'n') {
+        event.preventDefault();
+        goToNew();
+      } else if (key === 'p') {
+        event.preventDefault();
+        goToCatalog();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [goToNew, goToCatalog]);
+
   const hasError = Boolean(statsError || promptsError);
+  const showFeedSkeleton = isPromptsLoading && fullFeed.length === 0;
+  const totalFiltered = filterCounts.all;
+  const hasMore = visibleFeed.length < filterFeed(fullFeed, filterKind, timeWindow).length;
 
   return (
     <div
@@ -449,7 +471,9 @@ export default function Dashboard() {
             fontSize: 13,
           }}
         >
-          {statsError && <div>Failed to load corpus stats: {statsError.message}</div>}
+          {statsError && (
+            <div>Failed to load corpus stats: {statsError.message}</div>
+          )}
           {promptsError && <div>Failed to load prompts: {promptsError.message}</div>}
         </div>
       )}
@@ -500,7 +524,6 @@ export default function Dashboard() {
           )}
         </p>
 
-        {/* Group strip — jump to filtered catalog. One-shot orientation, not a permanent rail. */}
         <div
           style={{
             display: 'flex',
@@ -540,38 +563,60 @@ export default function Dashboard() {
           alignItems: 'start',
         }}
       >
-        {/* Center — activity feed */}
         <section>
           <div
             style={{
               display: 'flex',
               alignItems: 'baseline',
               justifyContent: 'space-between',
+              gap: 14,
               marginBottom: 6,
+              flexWrap: 'wrap',
             }}
           >
-            <Eyebrow>recent activity</Eyebrow>
-            <a
-              href="/prompts"
-              style={{
-                fontSize: 12.5,
-                color: 'var(--pl-ink-600)',
-                textDecoration: 'none',
-                borderBottom: '1px solid var(--pl-ink-300)',
-                paddingBottom: 1,
-              }}
-            >
-              All prompts →
-            </a>
+            <div style={{ display: 'inline-flex', alignItems: 'baseline', gap: 12 }}>
+              <Eyebrow>recent activity · {TIME_WINDOW_LABELS[timeWindow]}</Eyebrow>
+            </div>
+            <div style={{ display: 'inline-flex', alignItems: 'baseline', gap: 14 }}>
+              {TIME_WINDOWS.map((win) => (
+                <FilterButton
+                  key={win}
+                  label={TIME_WINDOW_LABELS[win]}
+                  active={timeWindow === win}
+                  onClick={() => setTimeWindow(win)}
+                />
+              ))}
+            </div>
           </div>
-          {isPromptsLoading && feed.length === 0 ? (
+
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: 16,
+              padding: '4px 0 10px',
+              flexWrap: 'wrap',
+            }}
+          >
+            {FEED_FILTERS.map((kind) => (
+              <FilterButton
+                key={kind}
+                label={FEED_FILTER_LABELS[kind]}
+                active={filterKind === kind}
+                count={filterCounts[kind]}
+                onClick={() => setFilterKind(kind)}
+              />
+            ))}
+          </div>
+
+          {showFeedSkeleton ? (
             <div style={{ paddingTop: 8 }}>
               <SkeletonRow width="55%" />
               <SkeletonRow width="70%" />
               <SkeletonRow width="60%" />
               <SkeletonRow width="65%" />
             </div>
-          ) : feed.length === 0 ? (
+          ) : visibleFeed.length === 0 ? (
             <div
               style={{
                 marginTop: 16,
@@ -583,12 +628,13 @@ export default function Dashboard() {
                 lineHeight: 1.6,
               }}
             >
-              No activity yet. Create a prompt or run an existing one to see it
-              show up here.
+              {totalFiltered === 0 && filterKind === 'all'
+                ? 'No activity in this window. Widen the time range or run a prompt to see it here.'
+                : `No ${FEED_FILTER_LABELS[filterKind]} in this window.`}
             </div>
           ) : (
             <div>
-              {feed.map((item) => (
+              {visibleFeed.map((item) => (
                 <ActivityRow
                   key={item.key}
                   item={item}
@@ -599,11 +645,35 @@ export default function Dashboard() {
                   }
                 />
               ))}
+              {hasMore && (
+                <div
+                  style={{
+                    borderTop: '1px solid var(--pl-ink-200)',
+                    padding: '14px 0',
+                    textAlign: 'center',
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setTimeWindow('all')}
+                    style={{
+                      background: 'transparent',
+                      border: 'none',
+                      padding: 0,
+                      fontFamily: 'var(--pl-display)',
+                      fontSize: 12.5,
+                      color: 'var(--pl-ink-600)',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    View older activity →
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </section>
 
-        {/* Right rail — open work */}
         <aside style={{ position: 'sticky', top: 28 }}>
           <Eyebrow>open work</Eyebrow>
           <p
@@ -633,11 +703,7 @@ export default function Dashboard() {
                 <OpenWorkRow
                   key={item.key}
                   item={item}
-                  onClick={
-                    item.href
-                      ? () => navigate(item.href!)
-                      : undefined
-                  }
+                  onClick={item.href ? () => navigate(item.href!) : undefined}
                 />
               ))
             )}
@@ -646,71 +712,16 @@ export default function Dashboard() {
           <div style={{ height: 1, background: 'var(--pl-ink-200)', margin: '20px 0' }} />
 
           <Eyebrow>quick actions</Eyebrow>
-          <div style={{ marginTop: 10, display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <button
-              type="button"
-              onClick={() => navigate('/prompts/new')}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                width: '100%',
-                padding: '8px 10px',
-                background: 'transparent',
-                border: '1px solid var(--pl-ink-200)',
-                borderRadius: 6,
-                cursor: 'pointer',
-                fontFamily: 'var(--pl-display)',
-                fontSize: 12.5,
-                color: 'var(--pl-ink-800)',
-                textAlign: 'left',
-              }}
-            >
-              <span>New prompt</span>
-              <Mono
-                size={10.5}
-                color="var(--pl-ink-500)"
-                style={{
-                  border: '1px solid var(--pl-ink-300)',
-                  padding: '1px 5px',
-                  borderRadius: 3,
-                }}
-              >
-                N
-              </Mono>
-            </button>
-            <button
-              type="button"
-              onClick={() => navigate('/prompts')}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                width: '100%',
-                padding: '8px 10px',
-                background: 'transparent',
-                border: '1px solid var(--pl-ink-200)',
-                borderRadius: 6,
-                cursor: 'pointer',
-                fontFamily: 'var(--pl-display)',
-                fontSize: 12.5,
-                color: 'var(--pl-ink-800)',
-                textAlign: 'left',
-              }}
-            >
-              <span>Browse catalog</span>
-              <Mono
-                size={10.5}
-                color="var(--pl-ink-500)"
-                style={{
-                  border: '1px solid var(--pl-ink-300)',
-                  padding: '1px 5px',
-                  borderRadius: 3,
-                }}
-              >
-                P
-              </Mono>
-            </button>
+          <div
+            style={{
+              marginTop: 10,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 6,
+            }}
+          >
+            <QuickActionButton label="New prompt" kbd="N" onClick={goToNew} />
+            <QuickActionButton label="Browse catalog" kbd="P" onClick={goToCatalog} />
           </div>
         </aside>
       </div>

--- a/components/promptlm-web-ui/src/pages/__tests__/Dashboard.helpers.test.ts
+++ b/components/promptlm-web-ui/src/pages/__tests__/Dashboard.helpers.test.ts
@@ -1,0 +1,223 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+import type { PromptSpec } from '@promptlm/api-client';
+import {
+  buildActivityFeed,
+  buildGroupCounts,
+  buildOpenWork,
+  filterFeed,
+  findLastRelease,
+} from '../Dashboard.helpers';
+
+const NOW = new Date('2026-05-06T12:00:00Z').getTime();
+const minutesAgo = (m: number) => new Date(NOW - m * 60_000).toISOString();
+const hoursAgo = (h: number) => new Date(NOW - h * 60 * 60_000).toISOString();
+const daysAgo = (d: number) => new Date(NOW - d * 24 * 60 * 60_000).toISOString();
+
+const mkSpec = (overrides: Partial<PromptSpec> = {}): PromptSpec => ({
+  id: overrides.id ?? overrides.name ?? 'test-prompt',
+  name: overrides.name ?? overrides.id ?? 'test-prompt',
+  group: 'test',
+  status: 'ACTIVE',
+  revision: 0,
+  ...overrides,
+});
+
+describe('buildActivityFeed', () => {
+  it('emits a release row for an active spec with no draft revision', () => {
+    const items = buildActivityFeed([
+      mkSpec({ name: 'p1', updatedAt: hoursAgo(1), version: '1.2.0' }),
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: 'release',
+      prompt: 'p1',
+      to: '1.2.0',
+      summary: 'released',
+    });
+  });
+
+  it('emits a draft row when revision > 0', () => {
+    const items = buildActivityFeed([
+      mkSpec({ name: 'p2', updatedAt: hoursAgo(2), revision: 3 }),
+    ]);
+    expect(items[0].kind).toBe('draft');
+    expect(items[0].to).toBeUndefined();
+    expect(items[0].summary).toContain('revision 3');
+  });
+
+  it('skips retired prompts entirely', () => {
+    const items = buildActivityFeed([
+      mkSpec({ name: 'old', status: 'RETIRED', updatedAt: hoursAgo(1) }),
+    ]);
+    expect(items).toHaveLength(0);
+  });
+
+  it('emits run rows for executions and infers ok/fail from response presence', () => {
+    const items = buildActivityFeed([
+      mkSpec({
+        name: 'r1',
+        updatedAt: hoursAgo(5),
+        executions: [
+          { id: 'e-ok', timestamp: minutesAgo(10), response: { id: 'x' } as never },
+          { id: 'e-fail', timestamp: minutesAgo(20) },
+        ],
+      }),
+    ]);
+    const runs = items.filter((i) => i.kind === 'run');
+    expect(runs).toHaveLength(2);
+    const byId = Object.fromEntries(runs.map((r) => [r.key.split(':').pop(), r.status]));
+    expect(byId['e-ok']).toBe('ok');
+    expect(byId['e-fail']).toBe('fail');
+  });
+
+  it('sorts items newest first across all kinds', () => {
+    const items = buildActivityFeed([
+      mkSpec({
+        name: 'mix',
+        updatedAt: hoursAgo(3),
+        version: '1.0.0',
+        executions: [
+          { id: 'old', timestamp: hoursAgo(10), response: { id: 'r' } as never },
+          { id: 'new', timestamp: minutesAgo(5), response: { id: 'r' } as never },
+        ],
+      }),
+    ]);
+    expect(items.map((i) => i.key.split(':').pop())).toEqual(['new', 'edit', 'old']);
+  });
+});
+
+describe('filterFeed', () => {
+  const fixture = buildActivityFeed([
+    mkSpec({
+      name: 'a',
+      updatedAt: minutesAgo(30),
+      version: '1.0.0',
+      executions: [
+        { id: 'r-recent', timestamp: minutesAgo(15), response: { id: 'x' } as never },
+        { id: 'r-old', timestamp: daysAgo(3), response: { id: 'x' } as never },
+      ],
+    }),
+    mkSpec({ name: 'b', updatedAt: daysAgo(10), revision: 2 }),
+  ]);
+
+  it('filters by kind', () => {
+    const releases = filterFeed(fixture, 'release', 'all', NOW);
+    expect(releases.every((i) => i.kind === 'release')).toBe(true);
+    expect(releases).toHaveLength(1);
+  });
+
+  it('filters by 24h window', () => {
+    const within24h = filterFeed(fixture, 'all', '24h', NOW);
+    // Drops the 3-day-old run and the 10-day-old draft
+    expect(within24h.map((i) => i.key.includes('r-recent') || i.key.includes('a:edit'))).toEqual([
+      true,
+      true,
+    ]);
+  });
+
+  it('returns everything when window is "all"', () => {
+    const everything = filterFeed(fixture, 'all', 'all', NOW);
+    expect(everything).toHaveLength(fixture.length);
+  });
+
+  it('combines kind + window filters', () => {
+    const recentRuns = filterFeed(fixture, 'run', '24h', NOW);
+    expect(recentRuns).toHaveLength(1);
+    expect(recentRuns[0].key).toContain('r-recent');
+  });
+});
+
+describe('buildOpenWork', () => {
+  it('classifies revision > 0 as a draft with edit link', () => {
+    const items = buildOpenWork([
+      mkSpec({ id: 'd1', name: 'd1', revision: 1 }),
+    ]);
+    expect(items[0]).toMatchObject({
+      kind: 'draft',
+      cta: 'Open in editor',
+      href: '/prompts/d1/edit',
+    });
+  });
+
+  it('classifies a released prompt with no executions as untested', () => {
+    const items = buildOpenWork([
+      mkSpec({ id: 'u1', name: 'u1', revision: 0, executions: [] }),
+    ]);
+    expect(items[0]).toMatchObject({
+      kind: 'untested',
+      cta: 'Open prompt',
+      href: '/prompts/u1',
+    });
+  });
+
+  it('skips retired prompts and respects the limit', () => {
+    const items = buildOpenWork(
+      [
+        mkSpec({ id: 'r1', status: 'RETIRED', revision: 5 }),
+        ...Array.from({ length: 8 }, (_, i) =>
+          mkSpec({ id: `u${i}`, name: `u${i}`, revision: 0, executions: [] }),
+        ),
+      ],
+      3,
+    );
+    expect(items).toHaveLength(3);
+    expect(items.every((i) => i.kind === 'untested')).toBe(true);
+  });
+});
+
+describe('findLastRelease', () => {
+  it('picks the most recently updated released (non-draft, non-retired) prompt', () => {
+    const last = findLastRelease([
+      mkSpec({ name: 'old', updatedAt: daysAgo(5), version: '1.0.0' }),
+      mkSpec({ name: 'newest', updatedAt: hoursAgo(1), version: '2.0.0' }),
+      mkSpec({ name: 'draft', updatedAt: minutesAgo(10), revision: 1 }),
+      mkSpec({ name: 'retired', updatedAt: minutesAgo(5), status: 'RETIRED' }),
+    ]);
+    expect(last?.ref).toContain('newest');
+    expect(last?.ref).toContain('2.0.0');
+  });
+
+  it('returns null when there are no releasable prompts', () => {
+    expect(findLastRelease([mkSpec({ revision: 1 })])).toBeNull();
+    expect(findLastRelease([])).toBeNull();
+  });
+});
+
+describe('buildGroupCounts', () => {
+  it('uses countByGroup when present, sorted descending', () => {
+    const counts = buildGroupCounts({ rag: 5, support: 2, agents: 8 }, []);
+    expect(counts).toEqual([
+      ['agents', 8],
+      ['rag', 5],
+      ['support', 2],
+    ]);
+  });
+
+  it('falls back to deriving counts from prompts when stats absent', () => {
+    const counts = buildGroupCounts(undefined, [
+      mkSpec({ id: '1', group: 'rag' }),
+      mkSpec({ id: '2', group: 'rag' }),
+      mkSpec({ id: '3', group: 'support' }),
+      mkSpec({ id: '4', group: undefined }),
+    ]);
+    expect(counts).toEqual([
+      ['rag', 2],
+      ['support', 1],
+      ['ungrouped', 1],
+    ]);
+  });
+});

--- a/components/promptlm-web-ui/src/pages/__tests__/Dashboard.test.tsx
+++ b/components/promptlm-web-ui/src/pages/__tests__/Dashboard.test.tsx
@@ -1,0 +1,163 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import type { PromptSpec, PromptStats } from '@promptlm/api-client';
+
+const mocks = vi.hoisted(() => ({
+  useDashboardSummary: vi.fn(),
+  usePrompts: vi.fn(),
+  useNavigate: vi.fn(() => () => undefined),
+}));
+
+vi.mock('@/api/hooks', () => ({
+  useDashboardSummary: mocks.useDashboardSummary,
+  usePrompts: mocks.usePrompts,
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: mocks.useNavigate,
+}));
+
+const asyncState = <T,>(overrides: {
+  data?: T;
+  isLoading?: boolean;
+  error?: Error;
+} = {}) => ({
+  data: overrides.data,
+  isLoading: overrides.isLoading ?? false,
+  error: overrides.error,
+  refresh: () => undefined,
+});
+
+import Dashboard from '../Dashboard';
+
+describe('Dashboard', () => {
+  afterEach(() => {
+    mocks.useDashboardSummary.mockReset();
+    mocks.usePrompts.mockReset();
+  });
+
+  it('renders the empty state when there are no prompts', () => {
+    mocks.useDashboardSummary.mockReturnValue(asyncState<PromptStats>({}));
+    mocks.usePrompts.mockReturnValue(asyncState<PromptSpec[]>({ data: [] }));
+
+    const html = renderToString(<Dashboard />);
+
+    expect(html).toContain('What changed');
+    expect(html).toContain('No activity in this window');
+    expect(html).toContain('Nothing open right now');
+    expect(html).toContain('New prompt');
+    expect(html).toContain('Browse catalog');
+  });
+
+  it('renders the inline error banner when both hooks fail', () => {
+    mocks.useDashboardSummary.mockReturnValue(
+      asyncState<PromptStats>({ error: new Error('stats down') }),
+    );
+    mocks.usePrompts.mockReturnValue(
+      asyncState<PromptSpec[]>({ error: new Error('prompts down') }),
+    );
+
+    const html = renderToString(<Dashboard />);
+
+    // React's renderToString interleaves <!-- --> markers between adjacent
+    // text nodes, so check the prefix and the dynamic message separately.
+    expect(html).toContain('Failed to load corpus stats:');
+    expect(html).toContain('stats down');
+    expect(html).toContain('Failed to load prompts:');
+    expect(html).toContain('prompts down');
+  });
+
+  it('renders activity rows and group chips from real data', () => {
+    mocks.useDashboardSummary.mockReturnValue(
+      asyncState<PromptStats>({
+        data: {
+          totalPrompts: 2,
+          activePrompts: 2,
+          retiredPrompts: 0,
+          countByGroup: { rag: 1, support: 1 },
+        },
+      }),
+    );
+    mocks.usePrompts.mockReturnValue(
+      asyncState<PromptSpec[]>({
+        data: [
+          {
+            id: 'doc-rag-answer',
+            name: 'doc-rag-answer',
+            group: 'rag',
+            status: 'ACTIVE',
+            revision: 0,
+            version: '1.8.0',
+            updatedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+            executions: [],
+          },
+          {
+            id: 'support-triage',
+            name: 'support-triage',
+            group: 'support',
+            status: 'ACTIVE',
+            revision: 0,
+            version: '2.4.1',
+            updatedAt: new Date(Date.now() - 60 * 60_000).toISOString(),
+            executions: [],
+          },
+        ],
+      }),
+    );
+
+    const html = renderToString(<Dashboard />);
+
+    expect(html).toContain('doc-rag-answer');
+    expect(html).toContain('1.8.0');
+    expect(html).toContain('support-triage');
+    expect(html).toContain('rag');
+    expect(html).toContain('support');
+    // Filter chips are rendered with counts
+    expect(html).toContain('releases');
+    expect(html).toContain('runs');
+    expect(html).toContain('drafts');
+    // Time-window selector
+    expect(html).toContain('last 24h');
+    expect(html).toContain('last 7 days');
+  });
+
+  it('flags untested released prompts in the open-work rail', () => {
+    mocks.useDashboardSummary.mockReturnValue(asyncState<PromptStats>({}));
+    mocks.usePrompts.mockReturnValue(
+      asyncState<PromptSpec[]>({
+        data: [
+          {
+            id: 'never-run',
+            name: 'never-run',
+            group: 'content',
+            status: 'ACTIVE',
+            revision: 0,
+            updatedAt: new Date().toISOString(),
+            executions: [],
+          },
+        ],
+      }),
+    );
+
+    const html = renderToString(<Dashboard />);
+
+    expect(html).toContain('never-run');
+    expect(html).toContain('Never run · no executions captured');
+    expect(html).toContain('Open prompt');
+  });
+});


### PR DESCRIPTION
Phase 2A polish for the activity-first Dashboard surface — tracked by [#104](https://github.com/promptLM/promptlm-app/issues/104), stacks on [#103](https://github.com/promptLM/promptlm-app/pull/103). All work is independent of the backend deps (#76 / #77 / #100) so it ships without waiting on them.

## What landed

**Filter chips** on the activity feed: \`all / releases / runs / drafts\`. Counts are scoped to the active time window so each chip tells you exactly how many items it would surface.

**Time-window selector**: \`last 24h\` (default) / \`last 7 days\` / \`all time\`. The activity eyebrow updates with the active window. \"View older activity →\" footer appears when the current window has more matches than the visible cap (12) and jumps straight to \"all time\".

**Empty-state copy** reflects the active filter (\"No releases in this window.\") instead of the generic \"no activity yet\".

**Global keyboard shortcuts**: \`N\` → \`/prompts/new\`, \`P\` → \`/prompts\`. Listener ignores chord keys (cmd/ctrl/alt) and any focused input / textarea / select / contenteditable, so it never steals from the catalog filter or any future search box. Verified live in preview.

## Refactor

Pure derivation logic moved to \`Dashboard.helpers.ts\`:
- \`buildActivityFeed\` — emits release / draft / run rows, infers ok/fail from response presence (until #77)
- \`filterFeed\` — kind + window filter, parameterized \`now\` for testability
- \`buildOpenWork\` — drafts (\`revision > 0\`) + untested (empty \`executions\`)
- \`findLastRelease\`, \`buildGroupCounts\` (with fallback to deriving from prompts when stats absent)

\`FeedItem\` now carries a raw \`ts: number\` for time-window math; relative formatting stays in \`when\`. \`buildActivityFeed\` no longer slices — the component owns the visible cap so filters don't lose items behind the cutoff.

## Tests

+20 cases. **81/81 passing** locally (was 61).

\`Dashboard.helpers.test.ts\` covers feed building (release / draft / run / retired paths, ok/fail derivation, cross-prompt sort order), \`filterFeed\` combinations, open-work classification + limit, last-release picker, and the group-count fallback when stats are absent.

\`Dashboard.test.tsx\` smoke-renders the four states (empty / error / populated / untested) and asserts the filter chip + time-window labels + open-work CTA copy land in the output.

## Verification

- [x] \`npm --workspace @promptlm/web-ui run build\` clean
- [x] \`npm --workspace @promptlm/web-ui test --silent\` 81/81
- [x] Live preview against real backend: filter chips show real counts (\`all 1 / releases 1 / runs 0 / drafts 0\`), time-window switcher works, \`P\` keyboard shortcut navigates to \`/prompts\`
- [ ] Acceptance test sweep (none exist for \`/\`)

## Stacks on / order

This PR's base is \`feat/dashboard-activity-first\` (PR #103), not \`main\` — merge #103 first, then this. After both land, \`#104\` phase 2A is complete and the remaining checklist there is the backend-blocked phase 2B work.

## Out of scope (still on #104)

- Real run metrics (\`durationMs\`, \`tokensIn/Out\`, real \`ok\` flag) — needs #77
- Real version transitions (\`v1.7.4 → v1.8.0\`) — needs #76
- Past-commit runs in the feed — needs #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)