### PR TITLE
build(deps): bump spring-ai-bom from 2.0.0-M4 to 2.0.0-M5

### DIFF
--- a/components/promptlm-execution-springai/src/main/java/dev/promptlm/execution/openai/OpenAiVendorClient.java
+++ b/components/promptlm-execution-springai/src/main/java/dev/promptlm/execution/openai/OpenAiVendorClient.java
@@ -22,15 +22,16 @@ import dev.promptlm.execution.util.PromptSpecUtils;
 import dev.promptlm.domain.promptspec.ChatCompletionRequest;
 import dev.promptlm.domain.promptspec.ChatCompletionResponse;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import com.openai.models.ChatModel;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Locale;
@@ -40,7 +41,7 @@ import java.util.stream.Stream;
 
 /**
  * OpenAI vendor integration backed by Spring AI, supporting all models enumerated in
- * {@link OpenAiApi.ChatModel} plus a set of additional well-known aliases.
+ * {@link com.openai.models.ChatModel} plus a set of additional well-known aliases.
  */
 @Component
 public class OpenAiVendorClient implements SpringAiVendorClient {
@@ -76,25 +77,29 @@ public class OpenAiVendorClient implements SpringAiVendorClient {
     private static final Set<String> SUPPORTED_MODEL_ALIASES;
 
     static {
-        LinkedHashSet<String> catalog = Arrays.stream(OpenAiApi.ChatModel.values())
-                .map(OpenAiApi.ChatModel::getValue)
-                .map(String::trim)
-                .filter(value -> !value.isEmpty())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+        LinkedHashSet<String> catalog = new LinkedHashSet<>();
+        LinkedHashSet<String> aliases = new LinkedHashSet<>();
+        for (Field field : ChatModel.class.getDeclaredFields()) {
+            if (Modifier.isStatic(field.getModifiers())
+                    && ChatModel.class.isAssignableFrom(field.getType())) {
+                try {
+                    ChatModel model = (ChatModel) field.get(null);
+                    String modelId = model.asString();
+                    if (modelId != null && !modelId.isBlank()) {
+                        catalog.add(modelId.trim());
+                        aliases.add(normalizeModel(modelId));
+                        aliases.add(normalizeModel(field.getName()));
+                        aliases.add(normalizeModel(field.getName().replace('_', '-')));
+                    }
+                } catch (IllegalAccessException ignored) {
+                }
+            }
+        }
         catalog.addAll(ADDITIONAL_CATALOG_MODELS);
         CATALOG_MODELS = Collections.unmodifiableSet(catalog);
 
-        LinkedHashSet<String> aliases = Stream.concat(
-                        Arrays.stream(OpenAiApi.ChatModel.values())
-                                .flatMap(model -> Stream.of(
-                                        model.getValue(),
-                                        model.getName(),
-                                        model.name(),
-                                        model.name().replace('_', '-'))
-                                        .map(OpenAiVendorClient::normalizeModel)),
-                        ADDITIONAL_MODEL_ALIASES.stream())
-                .filter(alias -> !alias.isEmpty())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+        aliases.addAll(ADDITIONAL_MODEL_ALIASES);
+        aliases.removeIf(String::isEmpty);
         SUPPORTED_MODEL_ALIASES = Collections.unmodifiableSet(aliases);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <spring-boot.version>4.0.6</spring-boot.version>
-        <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <spring-ai.version>2.0.0-M5</spring-ai.version>
         <native.maven.plugin.version>0.11.5</native.maven.plugin.version>
         <spring-modulith.version>2.0.6</spring-modulith.version>
         <spring-boot-maven-plugin.version>4.0.6</spring-boot-maven-plugin.version>


### PR DESCRIPTION
Closes #109. Supersedes #70.

## Summary

- Bumps `org.springframework.ai:spring-ai-bom` from `2.0.0-M4` to `2.0.0-M5` (the same bump dependabot proposed in #70).
- Migrates `OpenAiVendorClient` to the new openai-java-SDK-backed model catalog. M5 reorganized the OpenAI module: it now ships `com.openai.models.ChatModel` from the official `openai-java` SDK and removed `org.springframework.ai.openai.api.OpenAiApi` (and with it `OpenAiApi.ChatModel`).
- The migration uses the same reflective static-field scan that `AnthropicVendorClient` already uses to enumerate `com.anthropic.models.messages.Model`. Field names yield aliases; `ChatModel.asString()` yields catalog ids.

## API surface touched

- `org.springframework.ai.openai.api.OpenAiApi.ChatModel` (removed in M5) → `com.openai.models.ChatModel` (provided transitively by `spring-ai-openai`).

That's the only consumer-facing breakage. Spring AI usage in this repo is contained to `components/promptlm-execution-springai`; the `Anthropic*`, `ChatClient`, `ChatResponse`, `Prompt`, `OpenAiChatModel`, `OpenAiChatOptions` APIs we use are unchanged in M5.

## Test plan

- [x] `./mvnw -pl components/promptlm-execution-springai -am clean compile` succeeds
- [x] `./mvnw -pl components/promptlm-execution-springai -am test` — all 2 tests pass (`PromptSpecUtilsTest`, `AnthropicVendorClientTest`)
- [x] `./mvnw -pl components/promptlm-web-api -am clean compile` succeeds (full reactor down to web-api)
- [ ] CI green on this PR
- [ ] Maintainer closes #70 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)