### PR TITLE
chore(api-client): broaden openapi normalize defaults stripping

### DIFF
--- a/components/promptlm-api-client/package.json
+++ b/components/promptlm-api-client/package.json
@@ -17,6 +17,7 @@
     "normalize:openapi": "node ./scripts/normalize-openapi.mjs",
     "generate:openapi": "openapi-typescript ../../apps/promptlm-webapp/target/generated/openapi/promptlm-webapp-openapi.json --output ./src/generated/openapi.ts",
     "generate:client": "openapi -i ../../apps/promptlm-webapp/target/generated/openapi/promptlm-webapp-openapi.json -o ./src/generated/client --client fetch",
+    "test": "node --test scripts/*.test.mjs",
     "build": "tsc -p tsconfig.json"
   },
   "devDependencies": {

--- a/components/promptlm-api-client/scripts/normalize-openapi.mjs
+++ b/components/promptlm-api-client/scripts/normalize-openapi.mjs
@@ -15,13 +15,27 @@
 /**
  * Normalises the springdoc-generated OpenAPI spec before client generation.
  *
- * springdoc emits "default": "" on every property carrying an @Schema annotation,
- * which openapi-typescript interprets as "this property has a default, therefore
- * it is required". That promotes every annotated PromptSpec field to required in
- * the generated TypeScript types, which does not reflect the wire contract.
+ * Two distinct passes:
  *
- * This pass strips empty-string defaults so the generated client only marks fields
- * required when the backend actually says so via @Schema(requiredMode = REQUIRED).
+ * 1. Strip "default-default" markers anywhere in the spec.
+ *    springdoc emits `default: ""` (and `default: false`, `default: 0`,
+ *    `default: null`, `default: []`, `default: {}`) on every property carrying
+ *    an `@Schema` annotation, regardless of whether the underlying Java field
+ *    has an actual default. openapi-typescript interprets any `default` as
+ *    "this property has a default, therefore it is required", which promotes
+ *    spuriously-defaulted fields to required in the generated TypeScript types
+ *    and does not reflect the wire contract. We strip these "no-op" defaults
+ *    while preserving meaningful ones (e.g. `default: "active"`,
+ *    `default: 5`, `default: true`).
+ *
+ * 2. Strip every `default` from `paths.*.*.parameters[*].schema`.
+ *    springdoc emits `@RequestParam(defaultValue = "...")` verbatim into the
+ *    parameter schema as a string default, which `openapi-typescript-codegen`
+ *    uses to infer the parameter's TS type — overriding the declared schema
+ *    type. e.g. a boolean query param with `defaultValue = "false"` ends up
+ *    typed as `string` in the generated client. Defaults on parameter schemas
+ *    are documentation-only and not part of the wire contract, so we drop
+ *    them unconditionally.
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -33,13 +47,43 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const specPath = resolve(__dirname, '..', '..', '..', 'apps', 'promptlm-webapp', 'target', 'generated', 'openapi', 'promptlm-webapp-openapi.json');
 
-const stripEmptyDefaults = (node) => {
+/**
+ * Returns true if `value` is one of the springdoc "no-op" defaults that we
+ * want to strip — i.e. it carries no real semantic information.
+ *
+ * Non-trivial defaults (truthy primitives, non-empty arrays/objects) are
+ * preserved because they may genuinely document backend behaviour.
+ */
+export const isNoopDefault = (value) => {
+  if (value === '' || value === false || value === 0 || value === null) {
+    return true;
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return true;
+  }
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
+  ) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Recursively walk `node`, deleting any `default` key whose value matches
+ * `isNoopDefault`. Exported under the original name for backwards
+ * compatibility with anything that may have imported it.
+ */
+export const stripEmptyDefaults = (node) => {
   if (Array.isArray(node)) {
     node.forEach(stripEmptyDefaults);
     return;
   }
   if (node && typeof node === 'object') {
-    if ('default' in node && node.default === '') {
+    if ('default' in node && isNoopDefault(node.default)) {
       delete node.default;
     }
     for (const value of Object.values(node)) {
@@ -48,8 +92,54 @@ const stripEmptyDefaults = (node) => {
   }
 };
 
-const raw = readFileSync(specPath, 'utf8');
-const spec = JSON.parse(raw);
-stripEmptyDefaults(spec);
-writeFileSync(specPath, JSON.stringify(spec, null, 2) + '\n');
-console.log(`Normalised spec at ${specPath}`);
+/**
+ * Walk every parameter under `paths.*.*.parameters[*]` and drop any `default`
+ * from its `schema`, regardless of value. Defaults on parameter schemas are
+ * documentation hints, not contract, and confuse openapi-typescript-codegen.
+ */
+export const stripParameterSchemaDefaults = (spec) => {
+  const paths = spec && spec.paths;
+  if (!paths || typeof paths !== 'object') {
+    return;
+  }
+  for (const pathItem of Object.values(paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+    for (const operation of Object.values(pathItem)) {
+      if (!operation || typeof operation !== 'object') continue;
+      const params = operation.parameters;
+      if (!Array.isArray(params)) continue;
+      for (const param of params) {
+        if (param && typeof param === 'object' && param.schema && typeof param.schema === 'object') {
+          if ('default' in param.schema) {
+            delete param.schema.default;
+          }
+        }
+      }
+    }
+  }
+};
+
+// Only run the side-effecting body when invoked as a script (not when
+// imported from the test file).
+const isMain = process.argv[1] && resolve(process.argv[1]) === __filename;
+
+if (isMain) {
+  let raw;
+  try {
+    raw = readFileSync(specPath, 'utf8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      console.error(`Error: OpenAPI spec not found at ${specPath}.`);
+      console.error(
+        'Run `./mvnw -pl apps/promptlm-webapp -am install -DskipTests` from components/promptlm-core to generate it first.',
+      );
+      process.exit(1);
+    }
+    throw err;
+  }
+  const spec = JSON.parse(raw);
+  stripEmptyDefaults(spec);
+  stripParameterSchemaDefaults(spec);
+  writeFileSync(specPath, JSON.stringify(spec, null, 2) + '\n');
+  console.log(`Normalised spec at ${specPath}`);
+}

--- a/components/promptlm-api-client/scripts/normalize-openapi.test.mjs
+++ b/components/promptlm-api-client/scripts/normalize-openapi.test.mjs
@@ -1,0 +1,259 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Unit tests for normalize-openapi.mjs. Uses node:test / node:assert so we
+ * don't add a new test framework dependency to this package.
+ *
+ * Run with: `node --test scripts/normalize-openapi.test.mjs`
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isNoopDefault,
+  stripEmptyDefaults,
+  stripParameterSchemaDefaults,
+} from './normalize-openapi.mjs';
+
+describe('isNoopDefault', () => {
+  it('treats empty string as noop', () => {
+    assert.equal(isNoopDefault(''), true);
+  });
+  it('treats false as noop', () => {
+    assert.equal(isNoopDefault(false), true);
+  });
+  it('treats 0 as noop', () => {
+    assert.equal(isNoopDefault(0), true);
+  });
+  it('treats null as noop', () => {
+    assert.equal(isNoopDefault(null), true);
+  });
+  it('treats empty array as noop', () => {
+    assert.equal(isNoopDefault([]), true);
+  });
+  it('treats empty object as noop', () => {
+    assert.equal(isNoopDefault({}), true);
+  });
+  it('preserves non-empty string', () => {
+    assert.equal(isNoopDefault('active'), false);
+  });
+  it('preserves non-zero number', () => {
+    assert.equal(isNoopDefault(5), false);
+  });
+  it('preserves true', () => {
+    assert.equal(isNoopDefault(true), false);
+  });
+  it('preserves non-empty array', () => {
+    assert.equal(isNoopDefault([1]), false);
+  });
+  it('preserves non-empty object', () => {
+    assert.equal(isNoopDefault({ a: 1 }), false);
+  });
+});
+
+describe('stripEmptyDefaults', () => {
+  it('strips default: ""', () => {
+    const node = { type: 'string', default: '' };
+    stripEmptyDefaults(node);
+    assert.deepEqual(node, { type: 'string' });
+  });
+
+  it('strips default: false', () => {
+    const node = { type: 'boolean', default: false };
+    stripEmptyDefaults(node);
+    assert.deepEqual(node, { type: 'boolean' });
+  });
+
+  it('strips default: 0', () => {
+    const node = { type: 'integer', default: 0 };
+    stripEmptyDefaults(node);
+    assert.deepEqual(node, { type: 'integer' });
+  });
+
+  it('strips default: null', () => {
+    const node = { type: 'string', default: null };
+    stripEmptyDefaults(node);
+    assert.deepEqual(node, { type: 'string' });
+  });
+
+  it('strips default: []', () => {
+    const node = { type: 'array', default: [] };
+    stripEmptyDefaults(node);
+    assert.deepEqual(node, { type: 'array' });
+  });
+
+  it('strips default: {}', () => {
+    const node = { type: 'object', default: {} };
+    stripEmptyDefaults(node);
+    assert.deepEqual(node, { type: 'object' });
+  });
+
+  it('preserves default: "active"', () => {
+    const node = { type: 'string', default: 'active' };
+    stripEmptyDefaults(node);
+    assert.deepEqual(node, { type: 'string', default: 'active' });
+  });
+
+  it('preserves default: 5', () => {
+    const node = { type: 'integer', default: 5 };
+    stripEmptyDefaults(node);
+    assert.deepEqual(node, { type: 'integer', default: 5 });
+  });
+
+  it('preserves default: true', () => {
+    const node = { type: 'boolean', default: true };
+    stripEmptyDefaults(node);
+    assert.deepEqual(node, { type: 'boolean', default: true });
+  });
+
+  it('recurses into nested objects', () => {
+    const spec = {
+      components: {
+        schemas: {
+          Foo: {
+            type: 'object',
+            properties: {
+              bar: { type: 'string', default: '' },
+              baz: { type: 'integer', default: 5 },
+              nested: {
+                type: 'object',
+                properties: {
+                  flag: { type: 'boolean', default: false },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    stripEmptyDefaults(spec);
+    assert.deepEqual(spec.components.schemas.Foo.properties.bar, { type: 'string' });
+    assert.deepEqual(spec.components.schemas.Foo.properties.baz, { type: 'integer', default: 5 });
+    assert.deepEqual(
+      spec.components.schemas.Foo.properties.nested.properties.flag,
+      { type: 'boolean' },
+    );
+  });
+
+  it('recurses into arrays', () => {
+    const node = {
+      anyOf: [
+        { type: 'string', default: '' },
+        { type: 'integer', default: 0 },
+        { type: 'string', default: 'keep-me' },
+      ],
+    };
+    stripEmptyDefaults(node);
+    assert.deepEqual(node.anyOf, [
+      { type: 'string' },
+      { type: 'integer' },
+      { type: 'string', default: 'keep-me' },
+    ]);
+  });
+});
+
+describe('stripParameterSchemaDefaults', () => {
+  it('strips default from a parameter schema regardless of value', () => {
+    const spec = {
+      paths: {
+        '/api/prompts/groups': {
+          get: {
+            parameters: [
+              {
+                name: 'includeRetired',
+                in: 'query',
+                schema: { type: 'string', default: 'false' },
+              },
+            ],
+          },
+        },
+      },
+    };
+    stripParameterSchemaDefaults(spec);
+    assert.deepEqual(spec.paths['/api/prompts/groups'].get.parameters[0].schema, {
+      type: 'string',
+    });
+  });
+
+  it('strips even truthy/non-empty defaults on parameter schemas', () => {
+    const spec = {
+      paths: {
+        '/api/things': {
+          get: {
+            parameters: [
+              { name: 'limit', in: 'query', schema: { type: 'integer', default: 10 } },
+              { name: 'mode', in: 'query', schema: { type: 'string', default: 'active' } },
+            ],
+          },
+        },
+      },
+    };
+    stripParameterSchemaDefaults(spec);
+    assert.deepEqual(spec.paths['/api/things'].get.parameters[0].schema, { type: 'integer' });
+    assert.deepEqual(spec.paths['/api/things'].get.parameters[1].schema, { type: 'string' });
+  });
+
+  it('does not touch defaults inside requestBody or component schemas', () => {
+    const spec = {
+      paths: {
+        '/api/things': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { type: 'object', properties: { name: { type: 'string', default: 'keep' } } },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Thing: {
+            type: 'object',
+            properties: { state: { type: 'string', default: 'active' } },
+          },
+        },
+      },
+    };
+    stripParameterSchemaDefaults(spec);
+    assert.equal(
+      spec.paths['/api/things'].post.requestBody.content['application/json'].schema.properties.name.default,
+      'keep',
+    );
+    assert.equal(spec.components.schemas.Thing.properties.state.default, 'active');
+  });
+
+  it('handles paths with no parameters', () => {
+    const spec = {
+      paths: {
+        '/api/health': {
+          get: { responses: { '200': { description: 'ok' } } },
+        },
+      },
+    };
+    // Should not throw.
+    stripParameterSchemaDefaults(spec);
+    assert.ok(spec);
+  });
+
+  it('handles a spec with no paths', () => {
+    const spec = { components: {} };
+    stripParameterSchemaDefaults(spec);
+    assert.ok(spec);
+  });
+});

--- a/components/promptlm-api-client/src/generated/openapi.ts
+++ b/components/promptlm-api-client/src/generated/openapi.ts
@@ -416,10 +416,7 @@ export interface components {
             string?: boolean;
             embeddedValue?: boolean;
         };
-        /**
-         * @description Request payload for creating or updating a prompt specification
-         * @default null
-         */
+        /** @description Request payload for creating or updating a prompt specification */
         PromptSpecCreationRequest: {
             /**
              * @description Unique identifier of the prompt being created or updated
@@ -485,10 +482,7 @@ export interface components {
              */
             repositoryUrl?: string;
         };
-        /**
-         * @description LLM request payload and runtime parameters
-         * @default null
-         */
+        /** @description LLM request payload and runtime parameters */
         PromptSpecRequest: {
             /**
              * @description Type discriminator for the request
@@ -517,10 +511,7 @@ export interface components {
              */
             model_snapshot?: string;
         };
-        /**
-         * @description Fine-grained model inference controls
-         * @default null
-         */
+        /** @description Fine-grained model inference controls */
         PromptSpecRequestParameters: {
             /**
              * Format: double
@@ -547,16 +538,10 @@ export interface components {
              * @description Penalty for introducing new topics
              */
             presencePenalty?: number;
-            /**
-             * @description Whether to stream partial responses as they are generated
-             * @default false
-             */
-            stream: boolean;
+            /** @description Whether to stream partial responses as they are generated */
+            stream?: boolean;
         };
-        /**
-         * @description Describes the primary vendor and model configuration for a prompt
-         * @default null
-         */
+        /** @description Describes the primary vendor and model configuration for a prompt */
         VendorAndModel: {
             /**
              * @description LLM vendor identifier
@@ -613,10 +598,7 @@ export interface components {
             type?: "images/generations";
             imageUrl?: string;
         });
-        /**
-         * @description Prompt specification persisted in the prompt store
-         * @default null
-         */
+        /** @description Prompt specification persisted in the prompt store */
         PromptSpec: {
             specVersion?: string;
             /** Format: uuid */
@@ -726,10 +708,7 @@ export interface components {
             reasoning?: string;
             comments?: string;
         };
-        /**
-         * @description Single recorded execution of a PromptSpec
-         * @default null
-         */
+        /** @description Single recorded execution of a PromptSpec */
         Execution: {
             id?: string;
             /** Format: date-time */
@@ -777,10 +756,9 @@ export interface components {
             author?: string;
             /**
              * @description Outcome of the run; true when the run succeeded
-             * @default false
              * @example true
              */
-            ok: boolean;
+            ok?: boolean;
             /** @description Failure message captured when ok is false */
             error?: string;
         };
@@ -805,10 +783,7 @@ export interface components {
         EvaluationSpec: {
             evaluations?: components["schemas"]["Evaluation"][];
         };
-        /**
-         * @description Collection of placeholders and their default values
-         * @default null
-         */
+        /** @description Collection of placeholders and their default values */
         Placeholders: {
             startPattern?: string;
             endPattern?: string;
@@ -827,10 +802,7 @@ export interface components {
                 [key: string]: string;
             };
         };
-        /**
-         * @description Project specification for a prompt store repository
-         * @default null
-         */
+        /** @description Project specification for a prompt store repository */
         ProjectSpec: {
             /** Format: uuid */
             id?: string;
@@ -894,10 +866,7 @@ export interface components {
             /** Format: date-time */
             lastUpdated?: string;
         };
-        /**
-         * @description Model entry in the catalog.
-         * @default null
-         */
+        /** @description Model entry in the catalog. */
         ModelCatalogModel: {
             /**
              * @description Model identifier
@@ -914,30 +883,18 @@ export interface components {
              * @example config
              */
             source?: string;
-            /**
-             * @description Whether the model supports chat/completion style requests
-             * @default false
-             */
-            supportsChat: boolean;
-            /**
-             * @description Whether additional configuration is required before use
-             * @default false
-             */
-            requiresConfig: boolean;
+            /** @description Whether the model supports chat/completion style requests */
+            supportsChat?: boolean;
+            /** @description Whether additional configuration is required before use */
+            requiresConfig?: boolean;
             /** @description Optional target route for gateway aliases */
             target?: string;
         };
-        /**
-         * @description Model catalog response containing available vendors and models.
-         * @default null
-         */
+        /** @description Model catalog response containing available vendors and models. */
         ModelCatalogResponse: {
             vendors?: components["schemas"]["ModelCatalogVendor"][];
         };
-        /**
-         * @description Vendor entry in the model catalog.
-         * @default null
-         */
+        /** @description Vendor entry in the model catalog. */
         ModelCatalogVendor: {
             /**
              * @description Vendor identifier
@@ -949,18 +906,12 @@ export interface components {
              * @example OpenAI
              */
             displayName?: string;
-            /**
-             * @description Whether the vendor is active/available
-             * @default false
-             */
-            active: boolean;
+            /** @description Whether the vendor is active/available */
+            active?: boolean;
             /** @description Models provided by the vendor */
             models?: components["schemas"]["ModelCatalogModel"][];
         };
-        /**
-         * @description Feature flags advertised by the server
-         * @default null
-         */
+        /** @description Feature flags advertised by the server */
         Capabilities: {
             /**
              * @description Enabled capability identifiers


### PR DESCRIPTION
Follow-up to [#117](https://github.com/promptLM/promptlm-app/pull/117) review feedback. The normalize script that #117 introduced only stripped `default: ""`, leaving the same TS-generator confusion for `default: false`/`0`/`null` and for any default on a parameter schema. This extends the script to handle those cases and adds unit tests.

## Summary

`components/promptlm-api-client/scripts/normalize-openapi.mjs` now runs two passes before client generation:

1. **`stripEmptyDefaults`** — strips `default` whose value is a springdoc "no-op default": `""`, `false`, `0`, `null`, `[]`, `{}`. Non-trivial defaults (`"active"`, `5`, `true`, …) are preserved.
2. **`stripParameterSchemaDefaults`** — drops every `default` under `paths.*.*.parameters[*].schema`, regardless of value. Defaults on parameter schemas are documentation hints; openapi-typescript-codegen otherwise infers param TS type from the default literal.

Plus:
- Better ENOENT message pointing at the maven prereq when the spec is missing
- `node:test` unit tests covering both predicates (no new test framework dependency — `npm test` runs them via `node --test`)
- Re-ran `npm run generate` against the current spec

## Effect on generated client

`src/generated/openapi.ts`: `PromptSpecRequestParameters.stream` and `Execution.ok` are no longer falsely marked required (they were promoted by `default: false`). Several `@default null` description-line annotations dropped.

web-ui tsc errors: **107 (post-#117 baseline) → 106**. The remaining errors are consumer drift unrelated to springdoc default markers.

## Reviewer note: `includeRetired` regression is only partially addressed

The review flagged that `getPromptGroups` regressed from `boolean` to `string`. Stripping parameter-schema defaults is necessary but **not sufficient** — the springdoc spec itself declares `schema: { type: "string" }` for that param at the source:

```json
{
  "name": "includeRetired", "in": "query",
  "schema": { "type": "string" }
}
```

The underlying handler is `@RequestParam(defaultValue = "false") boolean includeRetired`, so springdoc is losing the boolean type. Likely needs an explicit `@Parameter(schema = @Schema(type = "boolean"))` on the controller method. Reasoning for not bundling that fix here: it's a separate root cause, no current consumer imports `getPromptGroups` (so it didn't surface in tsc), and it warrants its own focused change. Tracking via a comment on the PR if you want — happy to spin a follow-up.

## Test plan

- [x] `npm test` in `components/promptlm-api-client` — 27/27 pass (`node --test`)
- [x] `npm run generate` — produces the regenerated client in this PR
- [x] `tsc -p tsconfig.app.json` in `components/promptlm-web-ui` — 106 errors (down from 107)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)