### PR TITLE
fix(backend,api-client): emit boolean schema for includeRetired param (#119)

### DIFF
--- a/components/promptlm-api-client/src/generated/client/models/JsonNode.ts
+++ b/components/promptlm-api-client/src/generated/client/models/JsonNode.ts
@@ -17,10 +17,11 @@
 /* tslint:disable */
 /* eslint-disable */
 export type JsonNode = {
+    missingNode?: boolean;
     valueNode?: boolean;
+    pojo?: boolean;
     object?: boolean;
     nodeType?: JsonNode.nodeType;
-    pojo?: boolean;
     integralNumber?: boolean;
     floatingPointNumber?: boolean;
     short?: boolean;
@@ -35,7 +36,6 @@ export type JsonNode = {
     textual?: boolean;
     boolean?: boolean;
     binary?: boolean;
-    missingNode?: boolean;
     container?: boolean;
     string?: boolean;
     number?: boolean;

--- a/components/promptlm-api-client/src/generated/client/models/ProjectSpec.ts
+++ b/components/promptlm-api-client/src/generated/client/models/ProjectSpec.ts
@@ -38,13 +38,13 @@ export type ProjectSpec = {
      */
     promptCount?: number;
     /**
-     * Local filesystem path where the repository is checked out
-     */
-    localPath?: string;
-    /**
      * Remote repository URL
      */
     repositoryUrl?: string;
+    /**
+     * Local filesystem path where the repository is checked out
+     */
+    localPath?: string;
 };
 export namespace ProjectSpec {
     export enum healthStatus {

--- a/components/promptlm-api-client/src/generated/client/models/Request.ts
+++ b/components/promptlm-api-client/src/generated/client/models/Request.ts
@@ -17,8 +17,8 @@
 /* tslint:disable */
 /* eslint-disable */
 export type Request = {
-    model?: string;
     vendor?: string;
+    model?: string;
     url?: string;
     type: string;
 };

--- a/components/promptlm-api-client/src/generated/client/services/PromptSpecificationsService.ts
+++ b/components/promptlm-api-client/src/generated/client/services/PromptSpecificationsService.ts
@@ -291,7 +291,7 @@ export class PromptSpecificationsService {
      * @throws ApiError
      */
     public static getPromptGroups(
-        includeRetired?: string,
+        includeRetired?: boolean,
     ): CancelablePromise<string> {
         return __request(OpenAPI, {
             method: 'GET',

--- a/components/promptlm-api-client/src/generated/openapi.ts
+++ b/components/promptlm-api-client/src/generated/openapi.ts
@@ -409,11 +409,12 @@ export interface components {
             name?: string;
         };
         JsonNode: {
+            missingNode?: boolean;
             valueNode?: boolean;
+            pojo?: boolean;
             object?: boolean;
             /** @enum {string} */
             nodeType?: "ARRAY" | "BINARY" | "BOOLEAN" | "MISSING" | "NULL" | "NUMBER" | "OBJECT" | "POJO" | "STRING";
-            pojo?: boolean;
             integralNumber?: boolean;
             floatingPointNumber?: boolean;
             short?: boolean;
@@ -426,7 +427,6 @@ export interface components {
             textual?: boolean;
             boolean?: boolean;
             binary?: boolean;
-            missingNode?: boolean;
             container?: boolean;
             string?: boolean;
             number?: boolean;
@@ -704,8 +704,8 @@ export interface components {
             semanticHash?: string;
         };
         Request: {
-            model?: string;
             vendor?: string;
+            model?: string;
             url?: string;
             type: string;
         };
@@ -847,15 +847,15 @@ export interface components {
              */
             promptCount?: number;
             /**
-             * @description Local filesystem path where the repository is checked out
-             * @example /Users/me/repos/my-repo
-             */
-            localPath?: string;
-            /**
              * @description Remote repository URL
              * @example https://github.com/my-org/my-repo
              */
             repositoryUrl?: string;
+            /**
+             * @description Local filesystem path where the repository is checked out
+             * @example /Users/me/repos/my-repo
+             */
+            localPath?: string;
         };
         ConnectRepositoryRequest: {
             /** @description Absolute path to the repository on disk */
@@ -1556,7 +1556,7 @@ export interface operations {
         parameters: {
             query?: {
                 /** @description Include groups that only contain retired prompts */
-                includeRetired?: string;
+                includeRetired?: boolean;
             };
             header?: never;
             path?: never;

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
@@ -398,7 +398,8 @@ public class PromptSpecController {
                                   schema = @Schema(type = "array", implementation = String.class)))
     @GetMapping("/groups")
     public List<String> getPromptGroups(
-            @Parameter(description = "Include groups that only contain retired prompts") 
+            @Parameter(description = "Include groups that only contain retired prompts",
+                       schema = @Schema(type = "boolean"))
             @RequestParam(value = "includeRetired", required = false, defaultValue = "false") boolean includeRetired) {
         List<PromptSpec> prompts = promptStore.listAllPrompts(includeRetired);
 


### PR DESCRIPTION
## Summary

- Add `schema = @Schema(type = "boolean")` to the existing `@Parameter` on `PromptSpecController#getPromptGroups` so springdoc stops inferring `string` from the `defaultValue = "false"` literal.
- Regenerate api-client; `getPromptGroups(includeRetired?: boolean)` and `openapi.ts` now type the parameter correctly.
- Closes #119.

## Context

Original bug: with `@RequestParam(defaultValue = "false") boolean includeRetired`, springdoc emitted `schema: { type: "string" }` in the OpenAPI spec, which propagated into the TS client. PR #117 surfaced the issue; PR #118 mitigated it on the client side via the normalize script. This PR fixes the *source* — the spec itself.

Audit: `grep` for boolean `@RequestParam` across `components/promptlm-web-api/src/main/java` returned exactly one match (this method). No other controllers needed the same treatment.

## Diff shape

- 1 hand-edited file: `PromptSpecController.java` (+2 −1).
- Regenerated artifacts under `components/promptlm-api-client/src/generated/`. Targeted change: `includeRetired` typing in `openapi.ts` and `PromptSpecificationsService.ts`. Incidental: property-order drift inside `JsonNode` and `Request` from a fresh regenerator pass — no semantic change.

## Test plan

- [x] `mvn -pl apps/promptlm-webapp -am process-test-classes -DskipTests -Dpromptlm.webapp.ui.skip=true` regenerates the spec; `jq '.paths."/api/prompts/groups".get.parameters' …openapi.json` returns `"schema": { "type": "boolean", "default": false }`.
- [x] `npm --workspace @promptlm/api-client run normalize:openapi && … run generate:openapi && … run generate:client` produces `includeRetired?: boolean` in the regenerated TS.
- [x] `npm --workspace @promptlm/api-client run build` (tsc) — clean.
- [x] `npx tsc --noEmit -p components/promptlm-web-ui/tsconfig.app.json` — 170 pre-existing errors, identical to `main` (no regression). None reference `includeRetired`, `getPromptGroups`, `JsonNode`, or `Request`.
- [x] No web-ui consumer of `getPromptGroups` exists today (`grep -r getPromptGroups components/promptlm-web-ui` is empty), so the type-tightening cannot break a caller.

## Notes for reviewers

- **No new automated test.** There is currently no test asserting on OpenAPI schema content; a one-off assertion would set a precedent the rest of the controller surface doesn't follow. The committed regenerated TS client + tsc on every regeneration is a real regression check. A whole-spec snapshot test is a worthwhile follow-up if this becomes a recurring class of bug.
- **Skipped `validate:asyncapi`** during regeneration — it fails in this worktree with an `ajv-formats`/`ajv` runtime error unrelated to this fix. Worth filing separately. The OpenAPI-only sub-steps (`normalize:openapi`, `generate:openapi`, `generate:client`) ran cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)