### PR TITLE
feat(backend,api-client): repo-history API for Test tab's older runs (#100)

### DIFF
--- a/components/promptlm-api-client/src/generated/client/index.ts
+++ b/components/promptlm-api-client/src/generated/client/index.ts
@@ -48,6 +48,7 @@ export type { PromptSpecCreationRequest } from './models/PromptSpecCreationReque
 export type { PromptSpecRequest } from './models/PromptSpecRequest';
 export type { PromptSpecRequestParameters } from './models/PromptSpecRequestParameters';
 export type { PromptStats } from './models/PromptStats';
+export type { RepoHistoryPage } from './models/RepoHistoryPage';
 export { RepositoryOwner } from './models/RepositoryOwner';
 export type { Request } from './models/Request';
 export type { Response } from './models/Response';

--- a/components/promptlm-api-client/src/generated/client/models/JsonNode.ts
+++ b/components/promptlm-api-client/src/generated/client/models/JsonNode.ts
@@ -17,19 +17,15 @@
 /* tslint:disable */
 /* eslint-disable */
 export type JsonNode = {
-    pojo?: boolean;
-    int?: boolean;
-    long?: boolean;
-    float?: boolean;
-    null?: boolean;
-    array?: boolean;
-    empty?: boolean;
-    number?: boolean;
-    missingNode?: boolean;
     valueNode?: boolean;
     object?: boolean;
     nodeType?: JsonNode.nodeType;
+    pojo?: boolean;
+    integralNumber?: boolean;
+    floatingPointNumber?: boolean;
     short?: boolean;
+    int?: boolean;
+    long?: boolean;
     double?: boolean;
     bigDecimal?: boolean;
     bigInteger?: boolean;
@@ -39,10 +35,14 @@ export type JsonNode = {
     textual?: boolean;
     boolean?: boolean;
     binary?: boolean;
-    integralNumber?: boolean;
-    floatingPointNumber?: boolean;
+    missingNode?: boolean;
     container?: boolean;
     string?: boolean;
+    number?: boolean;
+    array?: boolean;
+    empty?: boolean;
+    null?: boolean;
+    float?: boolean;
     embeddedValue?: boolean;
 };
 export namespace JsonNode {

--- a/components/promptlm-api-client/src/generated/client/models/RepoHistoryPage.ts
+++ b/components/promptlm-api-client/src/generated/client/models/RepoHistoryPage.ts
@@ -16,41 +16,30 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { Execution } from './Execution';
 /**
- * Project specification for a prompt store repository
+ * Page of historic executions returned by the repo-history endpoint
  */
-export type ProjectSpec = {
-    id?: string;
-    name?: string;
-    description?: string;
-    healthStatus?: ProjectSpec.healthStatus;
-    healthMessage?: string;
+export type RepoHistoryPage = {
     /**
-     * Timestamp when the project was created
+     * Executions on the current page, newest first
      */
-    createdAt?: string;
+    items?: Array<Execution>;
     /**
-     * Timestamp when the project was last updated
+     * 1-indexed page number
      */
-    updatedAt?: string;
+    page?: number;
     /**
-     * Number of prompt specs in this project
+     * Number of items requested per page
      */
-    promptCount?: number;
+    pageSize?: number;
     /**
-     * Local filesystem path where the repository is checked out
+     * Total number of items matching the filter across all pages
      */
-    localPath?: string;
+    total?: number;
     /**
-     * Remote repository URL
+     * True when at least one further page is available
      */
-    repositoryUrl?: string;
+    hasMore?: boolean;
 };
-export namespace ProjectSpec {
-    export enum healthStatus {
-        HEALTHY = 'HEALTHY',
-        BROKEN_LOCAL = 'BROKEN_LOCAL',
-        BROKEN_REMOTE = 'BROKEN_REMOTE',
-    }
-}
 

--- a/components/promptlm-api-client/src/generated/client/models/Request.ts
+++ b/components/promptlm-api-client/src/generated/client/models/Request.ts
@@ -17,9 +17,9 @@
 /* tslint:disable */
 /* eslint-disable */
 export type Request = {
-    url?: string;
     model?: string;
     vendor?: string;
+    url?: string;
     type: string;
 };
 

--- a/components/promptlm-api-client/src/generated/client/services/PromptSpecificationsService.ts
+++ b/components/promptlm-api-client/src/generated/client/services/PromptSpecificationsService.ts
@@ -20,6 +20,7 @@ import type { ExecutePromptRequest } from '../models/ExecutePromptRequest';
 import type { PromptSpec } from '../models/PromptSpec';
 import type { PromptSpecCreationRequest } from '../models/PromptSpecCreationRequest';
 import type { PromptStats } from '../models/PromptStats';
+import type { RepoHistoryPage } from '../models/RepoHistoryPage';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -219,6 +220,42 @@ export class PromptSpecificationsService {
             errors: {
                 400: `Invalid prompt specification`,
                 500: `Error executing the prompt`,
+            },
+        });
+    }
+    /**
+     * Get older executions for a prompt
+     * Returns executions captured against earlier revisions of the prompt (those not in the current latest version's executions list). Sorted newest first. Filters: revision, status (ok|fail). Paginated.
+     * @param promptSpecId ID of the prompt specification (group/name composite)
+     * @param revision Filter to executions with this revision identifier
+     * @param status Filter by outcome: 'ok' or 'fail'
+     * @param page 1-indexed page number; values < 1 are clamped to 1
+     * @param pageSize Page size; clamped to [1, 200]; non-positive values yield the default of 50
+     * @returns RepoHistoryPage Page of historic executions
+     * @throws ApiError
+     */
+    public static getRepoHistory(
+        promptSpecId: string,
+        revision?: string,
+        status?: string,
+        page?: string,
+        pageSize?: string,
+    ): CancelablePromise<RepoHistoryPage> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/prompts/{promptSpecId}/history',
+            path: {
+                'promptSpecId': promptSpecId,
+            },
+            query: {
+                'revision': revision,
+                'status': status,
+                'page': page,
+                'pageSize': pageSize,
+            },
+            errors: {
+                400: `Invalid query parameters`,
+                404: `Prompt specification not found`,
             },
         });
     }

--- a/components/promptlm-api-client/src/generated/openapi.ts
+++ b/components/promptlm-api-client/src/generated/openapi.ts
@@ -274,6 +274,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/prompts/{promptSpecId}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get older executions for a prompt
+         * @description Returns executions captured against earlier revisions of the prompt (those not in the current latest version's executions list). Sorted newest first. Filters: revision, status (ok|fail). Paginated.
+         */
+        get: operations["getRepoHistory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/prompts/template": {
         parameters: {
             query?: never;
@@ -389,20 +409,16 @@ export interface components {
             name?: string;
         };
         JsonNode: {
-            pojo?: boolean;
-            int?: boolean;
-            long?: boolean;
-            float?: boolean;
-            null?: boolean;
-            array?: boolean;
-            empty?: boolean;
-            number?: boolean;
-            missingNode?: boolean;
             valueNode?: boolean;
             object?: boolean;
             /** @enum {string} */
             nodeType?: "ARRAY" | "BINARY" | "BOOLEAN" | "MISSING" | "NULL" | "NUMBER" | "OBJECT" | "POJO" | "STRING";
+            pojo?: boolean;
+            integralNumber?: boolean;
+            floatingPointNumber?: boolean;
             short?: boolean;
+            int?: boolean;
+            long?: boolean;
             double?: boolean;
             bigDecimal?: boolean;
             bigInteger?: boolean;
@@ -410,10 +426,14 @@ export interface components {
             textual?: boolean;
             boolean?: boolean;
             binary?: boolean;
-            integralNumber?: boolean;
-            floatingPointNumber?: boolean;
+            missingNode?: boolean;
             container?: boolean;
             string?: boolean;
+            number?: boolean;
+            array?: boolean;
+            empty?: boolean;
+            null?: boolean;
+            float?: boolean;
             embeddedValue?: boolean;
         };
         /** @description Request payload for creating or updating a prompt specification */
@@ -684,9 +704,9 @@ export interface components {
             semanticHash?: string;
         };
         Request: {
-            url?: string;
             model?: string;
             vendor?: string;
+            url?: string;
             type: string;
         };
         Placeholder: {
@@ -827,15 +847,15 @@ export interface components {
              */
             promptCount?: number;
             /**
-             * @description Remote repository URL
-             * @example https://github.com/my-org/my-repo
-             */
-            repositoryUrl?: string;
-            /**
              * @description Local filesystem path where the repository is checked out
              * @example /Users/me/repos/my-repo
              */
             localPath?: string;
+            /**
+             * @description Remote repository URL
+             * @example https://github.com/my-org/my-repo
+             */
+            repositoryUrl?: string;
         };
         ConnectRepositoryRequest: {
             /** @description Absolute path to the repository on disk */
@@ -850,6 +870,34 @@ export interface components {
             displayName?: string;
             /** @enum {string} */
             type?: "USER" | "ORGANIZATION";
+        };
+        /** @description Page of historic executions returned by the repo-history endpoint */
+        RepoHistoryPage: {
+            /** @description Executions on the current page, newest first */
+            items?: components["schemas"]["Execution"][];
+            /**
+             * Format: int32
+             * @description 1-indexed page number
+             * @example 1
+             */
+            page?: number;
+            /**
+             * Format: int32
+             * @description Number of items requested per page
+             * @example 50
+             */
+            pageSize?: number;
+            /**
+             * Format: int32
+             * @description Total number of items matching the filter across all pages
+             * @example 127
+             */
+            total?: number;
+            /**
+             * @description True when at least one further page is available
+             * @example true
+             */
+            hasMore?: boolean;
         };
         PromptStats: {
             /** Format: int32 */
@@ -1410,6 +1458,56 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProjectSpec"][];
+                };
+            };
+        };
+    };
+    getRepoHistory: {
+        parameters: {
+            query?: {
+                /** @description Filter to executions with this revision identifier */
+                revision?: string;
+                /** @description Filter by outcome: 'ok' or 'fail' */
+                status?: string;
+                /** @description 1-indexed page number; values < 1 are clamped to 1 */
+                page?: string;
+                /** @description Page size; clamped to [1, 200]; non-positive values yield the default of 50 */
+                pageSize?: string;
+            };
+            header?: never;
+            path: {
+                /** @description ID of the prompt specification (group/name composite) */
+                promptSpecId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Page of historic executions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoHistoryPage"];
+                };
+            };
+            /** @description Invalid query parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RepoHistoryPage"];
+                };
+            };
+            /** @description Prompt specification not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RepoHistoryPage"];
                 };
             };
         };

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
@@ -576,6 +576,81 @@ public class PromptSpecController {
         }
     }
 
+    /**
+     * Repo-history endpoint backing the Test tab's "View history →" flyover.
+     *
+     * <p>Returns executions captured against revisions of the prompt other than the current
+     * latest, paginated and filterable by revision and outcome. Same-revision-but-shape-divergent
+     * executions on the latest version are intentionally not returned: per issue #100, the live
+     * executions strip applies request-shape diffing client-side.
+     */
+    @Operation(summary = "Get older executions for a prompt",
+               description = "Returns executions captured against earlier revisions of the prompt "
+                       + "(those not in the current latest version's executions list). Sorted newest "
+                       + "first. Filters: revision, status (ok|fail). Paginated.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Page of historic executions",
+                    content = @Content(mediaType = "application/json",
+                                      schema = @Schema(implementation = RepoHistoryPage.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid query parameters"),
+        @ApiResponse(responseCode = "404", description = "Prompt specification not found")
+    })
+    @GetMapping("/{promptSpecId}/history")
+    public ResponseEntity<RepoHistoryPage> getRepoHistory(
+            @Parameter(description = "ID of the prompt specification (group/name composite)")
+            @PathVariable("promptSpecId") String promptSpecId,
+            @Parameter(description = "Filter to executions with this revision identifier")
+            @RequestParam(value = "revision", required = false) String revision,
+            @Parameter(description = "Filter by outcome: 'ok' or 'fail'")
+            @RequestParam(value = "status", required = false) String status,
+            @Parameter(description = "1-indexed page number; values < 1 are clamped to 1")
+            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+            @Parameter(description = "Page size; clamped to [1, 200]; non-positive values yield the default of 50")
+            @RequestParam(value = "pageSize", required = false, defaultValue = "50") int pageSize) {
+
+        Optional<PromptSpec> latestVersion = promptStore.getLatestVersion(promptSpecId);
+        if (latestVersion.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        RepoHistoryFilter filter = parseHistoryFilter(revision, status);
+        List<PromptSpec> versions = promptStore.listVersions(promptSpecId);
+        RepoHistoryPage historyPage = RepoHistoryAssembler.assemble(
+                latestVersion.get(), versions, filter, page, pageSize);
+        return ResponseEntity.ok(historyPage);
+    }
+
+    @Hidden
+    @GetMapping("/{group}/{name}/history")
+    public ResponseEntity<RepoHistoryPage> getRepoHistoryByGroupAndName(
+            @PathVariable("group") String group,
+            @PathVariable("name") String name,
+            @RequestParam(value = "revision", required = false) String revision,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+            @RequestParam(value = "pageSize", required = false, defaultValue = "50") int pageSize) {
+        return getRepoHistory(group + "/" + name, revision, status, page, pageSize);
+    }
+
+    private static RepoHistoryFilter parseHistoryFilter(String revision, String status) {
+        Optional<String> revisionFilter = StringUtils.hasText(revision)
+                ? Optional.of(revision)
+                : Optional.empty();
+        Optional<Boolean> statusFilter;
+        if (!StringUtils.hasText(status)) {
+            statusFilter = Optional.empty();
+        } else {
+            String normalised = status.trim().toLowerCase(java.util.Locale.ROOT);
+            switch (normalised) {
+                case "ok" -> statusFilter = Optional.of(Boolean.TRUE);
+                case "fail" -> statusFilter = Optional.of(Boolean.FALSE);
+                default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "status must be 'ok' or 'fail'");
+            }
+        }
+        return new RepoHistoryFilter(revisionFilter, statusFilter);
+    }
+
     private Instant resolveActiveProjectLastUpdatedFromGitMetadata(ProjectSpec activeProject) {
         Path normalizedRepoDir = activeProject.getRepoDir().toAbsolutePath().normalize();
 

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/RepoHistoryAssembler.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/RepoHistoryAssembler.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.web;
+
+import dev.promptlm.domain.promptspec.Execution;
+import dev.promptlm.domain.promptspec.PromptSpec;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Pure-data assembler that turns the version history of a single
+ * {@link PromptSpec} into a paged {@link RepoHistoryPage} of older
+ * executions — i.e. executions captured against revisions other than
+ * the latest version's revision.
+ *
+ * <p>Same-revision-but-shape-divergent executions on the latest
+ * version are <em>not</em> returned: per issue #100, the live
+ * executions strip applies request-shape diffing client-side, and the
+ * server only surfaces what the strip can't already show.
+ */
+public final class RepoHistoryAssembler {
+
+    public static final int DEFAULT_PAGE_SIZE = 50;
+    public static final int MAX_PAGE_SIZE = 200;
+
+    private RepoHistoryAssembler() {
+    }
+
+    /**
+     * Assemble a page of older executions.
+     *
+     * @param latest    the current latest version of the prompt — its executions are excluded
+     * @param versions  every version returned by {@code PromptStore.listVersions(id)}, in any order
+     * @param filter    revision and status filters
+     * @param page      1-indexed page number; values &lt; 1 are clamped to 1
+     * @param pageSize  values are clamped to [1, {@value #MAX_PAGE_SIZE}]
+     */
+    public static RepoHistoryPage assemble(
+            PromptSpec latest,
+            List<PromptSpec> versions,
+            RepoHistoryFilter filter,
+            int page,
+            int pageSize) {
+
+        Objects.requireNonNull(latest, "latest");
+        Objects.requireNonNull(versions, "versions");
+        Objects.requireNonNull(filter, "filter");
+
+        int safePage = Math.max(page, 1);
+        int safePageSize = clampPageSize(pageSize);
+
+        List<Execution> older = collectOlderExecutions(versions, latest);
+        applyFilters(older, filter);
+        older.sort(Comparator.comparing(Execution::getTimestamp,
+                Comparator.nullsLast(Comparator.reverseOrder())));
+
+        int total = older.size();
+        int fromIndex = Math.min((safePage - 1) * safePageSize, total);
+        int toIndex = Math.min(fromIndex + safePageSize, total);
+        List<Execution> items = new ArrayList<>(older.subList(fromIndex, toIndex));
+        boolean hasMore = toIndex < total;
+
+        return new RepoHistoryPage(items, safePage, safePageSize, total, hasMore);
+    }
+
+    /** Clamp a requested page size into the allowed range, defaulting empty / non-positive values. */
+    public static int clampPageSize(int requested) {
+        if (requested <= 0) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.min(requested, MAX_PAGE_SIZE);
+    }
+
+    private static List<Execution> collectOlderExecutions(List<PromptSpec> versions, PromptSpec latest) {
+        List<Execution> collected = new ArrayList<>();
+        for (PromptSpec version : versions) {
+            if (version == null || isSameVersion(version, latest)) {
+                continue;
+            }
+            List<Execution> executions = version.getExecutions();
+            if (executions == null) {
+                continue;
+            }
+            for (Execution execution : executions) {
+                if (execution != null) {
+                    collected.add(execution);
+                }
+            }
+        }
+        return collected;
+    }
+
+    /**
+     * Two {@link PromptSpec}s represent the same stored version when they share
+     * id, version string, and revision number. Reference equality is the common
+     * case (the latest spec is usually the same instance returned by the store
+     * for that version), but {@code listVersions} may return fresh instances.
+     */
+    private static boolean isSameVersion(PromptSpec a, PromptSpec b) {
+        if (a == b) {
+            return true;
+        }
+        return Objects.equals(a.getId(), b.getId())
+                && Objects.equals(a.getVersion(), b.getVersion())
+                && a.getRevision() == b.getRevision();
+    }
+
+    private static void applyFilters(List<Execution> executions, RepoHistoryFilter filter) {
+        filter.revision().ifPresent(rev ->
+                executions.removeIf(e -> !rev.equals(e.getRevision())));
+        filter.statusOk().ifPresent(ok ->
+                executions.removeIf(e -> e.okOrDefault() != ok));
+    }
+}

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/RepoHistoryFilter.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/RepoHistoryFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.web;
+
+import java.util.Optional;
+
+/**
+ * Filter parameters for the repo-history endpoint. {@code revision} narrows the
+ * result to a single spec revision; {@code statusOk} narrows to successful
+ * ({@code true}) or failed ({@code false}) executions. {@link Optional#empty()}
+ * means the filter is not applied.
+ */
+public record RepoHistoryFilter(Optional<String> revision, Optional<Boolean> statusOk) {
+
+    public static RepoHistoryFilter none() {
+        return new RepoHistoryFilter(Optional.empty(), Optional.empty());
+    }
+}

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/RepoHistoryPage.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/RepoHistoryPage.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.web;
+
+import dev.promptlm.domain.promptspec.Execution;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Page of executions returned by the repo-history endpoint, sorted newest
+ * first. {@code total} is the total count across all pages for the current
+ * filter; {@code hasMore} is {@code true} when at least one further page is
+ * available.
+ */
+@Schema(description = "Page of historic executions returned by the repo-history endpoint")
+public record RepoHistoryPage(
+        @ArraySchema(schema = @Schema(implementation = Execution.class),
+                arraySchema = @Schema(description = "Executions on the current page, newest first"))
+        List<Execution> items,
+
+        @Schema(description = "1-indexed page number", example = "1")
+        int page,
+
+        @Schema(description = "Number of items requested per page", example = "50")
+        int pageSize,
+
+        @Schema(description = "Total number of items matching the filter across all pages", example = "127")
+        int total,
+
+        @Schema(description = "True when at least one further page is available", example = "true")
+        boolean hasMore
+) {
+}

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
@@ -23,6 +23,7 @@ import dev.promptlm.domain.AppContext;
 import dev.promptlm.domain.projectspec.ProjectSpec;
 import dev.promptlm.domain.promptspec.ChatCompletionRequest;
 import dev.promptlm.domain.promptspec.ChatCompletionResponse;
+import dev.promptlm.domain.promptspec.Execution;
 import dev.promptlm.domain.promptspec.PromptEvaluationDefinition;
 import dev.promptlm.domain.promptspec.PromptSpec;
 import dev.promptlm.domain.promptspec.ReleaseMetadata;
@@ -677,6 +678,203 @@ class PromptSpecControllerWebMvcTest {
                 .andExpect(status().isConflict());
 
         verify(promptLifecycleFacade, times(2)).createPromptSpec(any(PromptSpec.class));
+    }
+
+    @Test
+    void getRepoHistoryReturnsOlderRevisionExecutionsSortedNewestFirst() throws Exception {
+        String promptId = "support/welcome";
+        Execution older1 = newExecution("old-1", "r1", true, Instant.parse("2026-04-01T00:00:00Z"));
+        Execution older2 = newExecution("old-2", "r1", true, Instant.parse("2026-04-02T00:00:00Z"));
+        Execution latestRun = newExecution("latest-1", "r2", true, Instant.parse("2026-04-10T00:00:00Z"));
+        PromptSpec olderVersion = repoHistoryFixture(promptId, "0.1.0", 1, List.of(older1, older2));
+        PromptSpec latestVersion = repoHistoryFixture(promptId, "0.2.0", 2, List.of(latestRun));
+
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(latestVersion));
+        when(promptStore.listVersions(promptId)).thenReturn(List.of(olderVersion, latestVersion));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}/history", promptId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.items.length()").value(2))
+                .andExpect(jsonPath("$.items[0].id").value("old-2"))
+                .andExpect(jsonPath("$.items[1].id").value("old-1"))
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.page").value(1))
+                .andExpect(jsonPath("$.pageSize").value(50))
+                .andExpect(jsonPath("$.hasMore").value(false));
+    }
+
+    @Test
+    void getRepoHistoryReturnsEmptyEnvelopeForSingleVersionPrompt() throws Exception {
+        String promptId = "support/welcome";
+        PromptSpec onlyVersion = repoHistoryFixture(promptId, "0.1.0", 1,
+                List.of(newExecution("only", "r1", true, Instant.parse("2026-04-01T00:00:00Z"))));
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(onlyVersion));
+        when(promptStore.listVersions(promptId)).thenReturn(List.of(onlyVersion));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}/history", promptId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(0))
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.hasMore").value(false));
+    }
+
+    @Test
+    void getRepoHistoryClampsNonPositivePageToFirstPage() throws Exception {
+        String promptId = "support/welcome";
+        Execution older1 = newExecution("old-1", "r1", true, Instant.parse("2026-04-01T00:00:00Z"));
+        Execution older2 = newExecution("old-2", "r1", true, Instant.parse("2026-04-02T00:00:00Z"));
+        PromptSpec older = repoHistoryFixture(promptId, "0.1.0", 1, List.of(older1, older2));
+        PromptSpec latestVersion = repoHistoryFixture(promptId, "0.2.0", 2, List.of());
+
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(latestVersion));
+        when(promptStore.listVersions(promptId)).thenReturn(List.of(older, latestVersion));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}/history", promptId).queryParam("page", "-3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page").value(1))
+                .andExpect(jsonPath("$.items.length()").value(2));
+    }
+
+    @Test
+    void getRepoHistoryByGroupAndNameAliasDelegatesToCanonicalEndpoint() throws Exception {
+        String promptId = "support/welcome";
+        Execution older = newExecution("old-1", "r1", true, Instant.parse("2026-04-01T00:00:00Z"));
+        PromptSpec olderVersion = repoHistoryFixture(promptId, "0.1.0", 1, List.of(older));
+        PromptSpec latestVersion = repoHistoryFixture(promptId, "0.2.0", 2, List.of());
+
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(latestVersion));
+        when(promptStore.listVersions(promptId)).thenReturn(List.of(olderVersion, latestVersion));
+
+        mockMvc.perform(get("/api/prompts/{group}/{name}/history", "support", "welcome"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].id").value("old-1"));
+    }
+
+    @Test
+    void getRepoHistoryReturnsNotFoundForUnknownPrompt() throws Exception {
+        when(promptStore.getLatestVersion("missing")).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}/history", "missing"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getRepoHistoryFiltersByRevision() throws Exception {
+        String promptId = "support/welcome";
+        Execution r1a = newExecution("r1a", "r1", true, Instant.parse("2026-04-01T00:00:00Z"));
+        Execution r1b = newExecution("r1b", "r1", true, Instant.parse("2026-04-02T00:00:00Z"));
+        Execution r2a = newExecution("r2a", "r2", true, Instant.parse("2026-04-03T00:00:00Z"));
+        PromptSpec v1 = repoHistoryFixture(promptId, "0.1.0", 1, List.of(r1a, r1b));
+        PromptSpec v2 = repoHistoryFixture(promptId, "0.2.0", 2, List.of(r2a));
+        PromptSpec latestVersion = repoHistoryFixture(promptId, "0.3.0", 3, List.of());
+
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(latestVersion));
+        when(promptStore.listVersions(promptId)).thenReturn(List.of(v1, v2, latestVersion));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}/history", promptId).queryParam("revision", "r1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(2))
+                .andExpect(jsonPath("$.items[0].id").value("r1b"))
+                .andExpect(jsonPath("$.items[1].id").value("r1a"));
+    }
+
+    @Test
+    void getRepoHistoryFiltersByStatus() throws Exception {
+        String promptId = "support/welcome";
+        Execution ok = newExecution("ok", "r1", true, Instant.parse("2026-04-01T00:00:00Z"));
+        Execution fail = newExecution("fail", "r1", false, Instant.parse("2026-04-02T00:00:00Z"));
+        PromptSpec older = repoHistoryFixture(promptId, "0.1.0", 1, List.of(ok, fail));
+        PromptSpec latestVersion = repoHistoryFixture(promptId, "0.2.0", 2, List.of());
+
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(latestVersion));
+        when(promptStore.listVersions(promptId)).thenReturn(List.of(older, latestVersion));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}/history", promptId).queryParam("status", "fail"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].id").value("fail"));
+    }
+
+    @Test
+    void getRepoHistoryRespectsPageSizeAndPaginates() throws Exception {
+        String promptId = "support/welcome";
+        java.util.List<Execution> seventyFive = new java.util.ArrayList<>();
+        for (int i = 0; i < 75; i++) {
+            seventyFive.add(newExecution("e-" + i, "r1", true,
+                    Instant.parse("2026-04-01T00:00:00Z").plusSeconds(i)));
+        }
+        PromptSpec older = repoHistoryFixture(promptId, "0.1.0", 1, seventyFive);
+        PromptSpec latestVersion = repoHistoryFixture(promptId, "0.2.0", 2, List.of());
+
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(latestVersion));
+        when(promptStore.listVersions(promptId)).thenReturn(List.of(older, latestVersion));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}/history", promptId)
+                        .queryParam("page", "1").queryParam("pageSize", "50"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(50))
+                .andExpect(jsonPath("$.total").value(75))
+                .andExpect(jsonPath("$.hasMore").value(true));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}/history", promptId)
+                        .queryParam("page", "2").queryParam("pageSize", "50"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(25))
+                .andExpect(jsonPath("$.hasMore").value(false));
+    }
+
+    @Test
+    void getRepoHistoryRejectsUnknownStatus() throws Exception {
+        String promptId = "support/welcome";
+        PromptSpec latestVersion = repoHistoryFixture(promptId, "0.1.0", 1, List.of());
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(latestVersion));
+        when(promptStore.listVersions(promptId)).thenReturn(List.of(latestVersion));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}/history", promptId).queryParam("status", "maybe"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getRepoHistoryClampsExcessivePageSizeToMaximum() throws Exception {
+        String promptId = "support/welcome";
+        Execution sample = newExecution("e", "r1", true, Instant.parse("2026-04-01T00:00:00Z"));
+        PromptSpec older = repoHistoryFixture(promptId, "0.1.0", 1, List.of(sample));
+        PromptSpec latestVersion = repoHistoryFixture(promptId, "0.2.0", 2, List.of());
+
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(latestVersion));
+        when(promptStore.listVersions(promptId)).thenReturn(List.of(older, latestVersion));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}/history", promptId).queryParam("pageSize", "500"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pageSize").value(RepoHistoryAssembler.MAX_PAGE_SIZE));
+    }
+
+    private static PromptSpec repoHistoryFixture(String id, String version, int revision, List<Execution> executions) {
+        return PromptSpec.builder()
+                .withGroup("support")
+                .withName("welcome")
+                .withVersion(version)
+                .withRevision(revision)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder()
+                        .withVendor("openai")
+                        .withModel("gpt-4o")
+                        .withMessages(List.of())
+                        .build())
+                .withExecutions(executions)
+                .build()
+                .withId(id);
+    }
+
+    private static Execution newExecution(String id, String revision, boolean ok, Instant timestamp) {
+        Execution e = new Execution();
+        e.setId(id);
+        e.setRevision(revision);
+        e.setOk(ok);
+        e.setTimestamp(timestamp);
+        return e;
     }
 
     private Path initializeRepositoryWithPromptCommit(Path tempDir, Instant commitInstant) throws Exception {

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/RepoHistoryAssemblerTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/RepoHistoryAssemblerTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.web;
+
+import dev.promptlm.domain.promptspec.ChatCompletionRequest;
+import dev.promptlm.domain.promptspec.Execution;
+import dev.promptlm.domain.promptspec.PromptSpec;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RepoHistoryAssemblerTest {
+
+    @Test
+    void assembleReturnsEmptyPageWhenOnlyLatestVersionExists() {
+        PromptSpec latest = version(2, "r2", List.of(execution("e1", "r2", true)));
+
+        RepoHistoryPage page = RepoHistoryAssembler.assemble(
+                latest, List.of(latest), RepoHistoryFilter.none(), 1, 50);
+
+        assertThat(page.items()).isEmpty();
+        assertThat(page.total()).isZero();
+        assertThat(page.hasMore()).isFalse();
+        assertThat(page.page()).isEqualTo(1);
+        assertThat(page.pageSize()).isEqualTo(50);
+    }
+
+    @Test
+    void assembleExcludesLatestVersionsExecutions() {
+        Execution oldRun = execution("old-1", "r1", true);
+        Execution latestRun = execution("latest-1", "r2", true);
+        PromptSpec older = version(1, "r1", List.of(oldRun));
+        PromptSpec latest = version(2, "r2", List.of(latestRun));
+
+        RepoHistoryPage page = RepoHistoryAssembler.assemble(
+                latest, List.of(older, latest), RepoHistoryFilter.none(), 1, 50);
+
+        assertThat(page.items()).extracting(Execution::getId).containsExactly("old-1");
+    }
+
+    @Test
+    void assembleSortsExecutionsNewestFirstWithNullsLast() {
+        Execution withTs = execution("with-ts", "r1", true, Instant.parse("2026-04-01T00:00:00Z"));
+        Execution newer = execution("newer", "r1", true, Instant.parse("2026-04-02T00:00:00Z"));
+        Execution noTs = execution("no-ts", "r1", true, null);
+        PromptSpec older = version(1, "r1", List.of(withTs, noTs, newer));
+        PromptSpec latest = version(2, "r2", List.of());
+
+        RepoHistoryPage page = RepoHistoryAssembler.assemble(
+                latest, List.of(older, latest), RepoHistoryFilter.none(), 1, 50);
+
+        assertThat(page.items()).extracting(Execution::getId)
+                .containsExactly("newer", "with-ts", "no-ts");
+    }
+
+    @Test
+    void assembleFiltersByRevision() {
+        Execution r1 = execution("e1", "r1", true);
+        Execution r2 = execution("e2", "r2", true);
+        Execution otherR1 = execution("e3", "r1", true);
+        PromptSpec v1 = version(1, "r1", List.of(r1, otherR1));
+        PromptSpec v2 = version(2, "r2", List.of(r2));
+        PromptSpec latest = version(3, "r3", List.of());
+
+        RepoHistoryPage page = RepoHistoryAssembler.assemble(
+                latest, List.of(v1, v2, latest),
+                new RepoHistoryFilter(Optional.of("r1"), Optional.empty()),
+                1, 50);
+
+        assertThat(page.items()).extracting(Execution::getId).containsExactlyInAnyOrder("e1", "e3");
+        assertThat(page.total()).isEqualTo(2);
+    }
+
+    @Test
+    void assembleFiltersByStatusOk() {
+        Execution ok1 = execution("ok-1", "r1", true);
+        Execution fail1 = execution("fail-1", "r1", false);
+        Execution ok2 = execution("ok-2", "r1", true);
+        PromptSpec older = version(1, "r1", List.of(ok1, fail1, ok2));
+        PromptSpec latest = version(2, "r2", List.of());
+
+        RepoHistoryPage okPage = RepoHistoryAssembler.assemble(
+                latest, List.of(older, latest),
+                new RepoHistoryFilter(Optional.empty(), Optional.of(true)),
+                1, 50);
+
+        assertThat(okPage.items()).extracting(Execution::getId).containsExactlyInAnyOrder("ok-1", "ok-2");
+
+        RepoHistoryPage failPage = RepoHistoryAssembler.assemble(
+                latest, List.of(older, latest),
+                new RepoHistoryFilter(Optional.empty(), Optional.of(false)),
+                1, 50);
+
+        assertThat(failPage.items()).extracting(Execution::getId).containsExactly("fail-1");
+    }
+
+    @Test
+    void assembleTreatsNullOkAsSuccessForFilteringPurposes() {
+        Execution legacy = execution("legacy", "r1", null);
+        PromptSpec older = version(1, "r1", List.of(legacy));
+        PromptSpec latest = version(2, "r2", List.of());
+
+        RepoHistoryPage okPage = RepoHistoryAssembler.assemble(
+                latest, List.of(older, latest),
+                new RepoHistoryFilter(Optional.empty(), Optional.of(true)),
+                1, 50);
+
+        assertThat(okPage.items()).extracting(Execution::getId).containsExactly("legacy");
+    }
+
+    @Test
+    void assembleHonoursPaginationAtBoundaries() {
+        List<Execution> seventyFive = new java.util.ArrayList<>();
+        for (int i = 0; i < 75; i++) {
+            seventyFive.add(execution("e-" + i, "r1", true,
+                    Instant.parse("2026-04-01T00:00:00Z").plusSeconds(i)));
+        }
+        PromptSpec older = version(1, "r1", seventyFive);
+        PromptSpec latest = version(2, "r2", List.of());
+        List<PromptSpec> versions = List.of(older, latest);
+
+        RepoHistoryPage first = RepoHistoryAssembler.assemble(
+                latest, versions, RepoHistoryFilter.none(), 1, 50);
+        assertThat(first.items()).hasSize(50);
+        assertThat(first.total()).isEqualTo(75);
+        assertThat(first.hasMore()).isTrue();
+
+        RepoHistoryPage second = RepoHistoryAssembler.assemble(
+                latest, versions, RepoHistoryFilter.none(), 2, 50);
+        assertThat(second.items()).hasSize(25);
+        assertThat(second.hasMore()).isFalse();
+
+        RepoHistoryPage beyond = RepoHistoryAssembler.assemble(
+                latest, versions, RepoHistoryFilter.none(), 3, 50);
+        assertThat(beyond.items()).isEmpty();
+        assertThat(beyond.total()).isEqualTo(75);
+        assertThat(beyond.hasMore()).isFalse();
+    }
+
+    @Test
+    void assembleClampsPageSizeAboveMaximum() {
+        PromptSpec older = version(1, "r1", List.of(execution("e", "r1", true)));
+        PromptSpec latest = version(2, "r2", List.of());
+
+        RepoHistoryPage page = RepoHistoryAssembler.assemble(
+                latest, List.of(older, latest), RepoHistoryFilter.none(), 1, 999);
+
+        assertThat(page.pageSize()).isEqualTo(RepoHistoryAssembler.MAX_PAGE_SIZE);
+    }
+
+    @Test
+    void assembleAppliesDefaultPageSizeForNonPositiveValues() {
+        PromptSpec older = version(1, "r1", List.of(execution("e", "r1", true)));
+        PromptSpec latest = version(2, "r2", List.of());
+
+        RepoHistoryPage page = RepoHistoryAssembler.assemble(
+                latest, List.of(older, latest), RepoHistoryFilter.none(), 1, 0);
+
+        assertThat(page.pageSize()).isEqualTo(RepoHistoryAssembler.DEFAULT_PAGE_SIZE);
+    }
+
+    @Test
+    void assembleTreatsPageBelowOneAsFirstPage() {
+        Execution e = execution("e", "r1", true);
+        PromptSpec older = version(1, "r1", List.of(e));
+        PromptSpec latest = version(2, "r2", List.of());
+
+        RepoHistoryPage page = RepoHistoryAssembler.assemble(
+                latest, List.of(older, latest), RepoHistoryFilter.none(), -3, 50);
+
+        assertThat(page.page()).isEqualTo(1);
+        assertThat(page.items()).extracting(Execution::getId).containsExactly("e");
+    }
+
+    @Test
+    void assembleSkipsNullVersionsAndExecutionsDefensively() {
+        Execution kept = execution("kept", "r1", true);
+        PromptSpec olderWithNullExec = PromptSpec.builder()
+                .withGroup("support").withName("welcome").withVersion("1")
+                .withRevision(1).withDescription("desc")
+                .withRequest(emptyRequest())
+                .withExecutions(java.util.Arrays.asList(null, kept))
+                .build();
+        PromptSpec latest = version(2, "r2", List.of());
+        java.util.List<PromptSpec> versions = java.util.Arrays.asList(null, olderWithNullExec, latest);
+
+        RepoHistoryPage page = RepoHistoryAssembler.assemble(
+                latest, versions, RepoHistoryFilter.none(), 1, 50);
+
+        assertThat(page.items()).extracting(Execution::getId).containsExactly("kept");
+    }
+
+    @Test
+    @Tag("performance-smoke")
+    void assemblePerformanceSmokeForLargeDataset() {
+        int count = 10_000;
+        List<Execution> many = new java.util.ArrayList<>(count);
+        Instant base = Instant.parse("2026-01-01T00:00:00Z");
+        for (int i = 0; i < count; i++) {
+            many.add(execution("e-" + i, "r1", i % 2 == 0, base.plusSeconds(i)));
+        }
+        PromptSpec older = version(1, "r1", many);
+        PromptSpec latest = version(2, "r2", List.of());
+
+        long start = System.nanoTime();
+        RepoHistoryPage page = RepoHistoryAssembler.assemble(
+                latest, List.of(older, latest),
+                new RepoHistoryFilter(Optional.empty(), Optional.of(true)),
+                1, 50);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+        assertThat(page.items()).hasSize(50);
+        assertThat(page.total()).isEqualTo(count / 2);
+        assertThat(elapsedMs).as("assemble should complete within 1s for 10k executions").isLessThan(1_000);
+    }
+
+    private static PromptSpec version(int revision, String versionString, List<Execution> executions) {
+        return PromptSpec.builder()
+                .withGroup("support")
+                .withName("welcome")
+                .withVersion(versionString)
+                .withRevision(revision)
+                .withDescription("desc")
+                .withRequest(emptyRequest())
+                .withExecutions(executions)
+                .build();
+    }
+
+    private static ChatCompletionRequest emptyRequest() {
+        return ChatCompletionRequest.builder()
+                .withVendor("openai")
+                .withModel("gpt-4o")
+                .withMessages(List.of())
+                .build();
+    }
+
+    private static Execution execution(String id, String revision, Boolean ok) {
+        return execution(id, revision, ok, Instant.parse("2026-04-01T00:00:00Z"));
+    }
+
+    private static Execution execution(String id, String revision, Boolean ok, Instant timestamp) {
+        Execution e = new Execution();
+        e.setId(id);
+        e.setRevision(revision);
+        e.setOk(ok);
+        e.setTimestamp(timestamp);
+        return e;
+    }
+}


### PR DESCRIPTION
## Summary

Closes the backend half of #100. Adds `GET /api/prompts/{promptSpecId}/history` (operationId `getRepoHistory`) to surface older executions of a prompt — the runs the live `executions[]` strip filters out because they were captured against earlier revisions. The TS api-client regenerates with a typed `PromptSpecificationsService.getRepoHistory` and a `RepoHistoryPage` model.

- New endpoint is page-based (default 50, max 200, 1-indexed), filterable by `revision` and `status=ok|fail`, sorted newest first.
- Hidden alias `/{group}/{name}/history` mirrors the release endpoints.
- v1 "older" = executions on every version returned by `PromptStore.listVersions(id)` minus the latest version's executions. Same-revision-but-shape-divergent runs remain the live strip's responsibility (matches the issue's "Out of scope" clause).

Cross-rename history, revision-range filters, and cursor-based pagination remain v2 follow-ups. Webapp wiring (badge removal) is owned by #98.

## Test plan

- [x] `mvn -B -ntp -pl components/promptlm-web-api test` — 61/61 green (12 new assembler unit tests, 10 new WebMvc tests covering happy path, empty, 404, revision/status filters, pagination edges, page<1 clamp, pageSize clamp, bad-status 400, hidden alias, large-dataset performance smoke @Tag("performance-smoke")).
- [x] `mvn -B -ntp -pl apps/promptlm-webapp -am package -DskipTests` — produces `target/generated/openapi/promptlm-webapp-openapi.json` containing the new path with the expected operationId, parameters, and `RepoHistoryPage` response schema.
- [x] `npm run contracts:generate && npm run contracts:build` — clean.
- [x] `npm --workspace @promptlm/api-client test` — 27/27 (normalize-openapi tests).

## Notes for reviewers

- Generated TS files include benign codegen field-order drift in `JsonNode.ts`, `ProjectSpec.ts`, `Request.ts` (springdoc/Jackson reflection ordering is non-deterministic) — kept rather than reverted since they reflect the current spec.
- Reverted ephemeral-port churn in `OpenAPI.ts` (`BASE` flips between random localhost ports each regen). Recommended follow-up: neutralise the port to `''` in `normalize-openapi.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)