### PR TITLE
chore(api-client): strip servers[] in normalize-openapi to stop port churn

### DIFF
--- a/components/promptlm-api-client/scripts/normalize-openapi.mjs
+++ b/components/promptlm-api-client/scripts/normalize-openapi.mjs
@@ -15,7 +15,7 @@
 /**
  * Normalises the springdoc-generated OpenAPI spec before client generation.
  *
- * Two distinct passes:
+ * Three distinct passes:
  *
  * 1. Strip "default-default" markers anywhere in the spec.
  *    springdoc emits `default: ""` (and `default: false`, `default: 0`,
@@ -36,6 +36,16 @@
  *    typed as `string` in the generated client. Defaults on parameter schemas
  *    are documentation-only and not part of the wire contract, so we drop
  *    them unconditionally.
+ *
+ * 3. Strip the top-level `servers` block.
+ *    The OpenAPI spec is dumped from a webapp booted on a random port allocated
+ *    by `build-helper-maven-plugin`'s `reserve-network-port` goal. springdoc
+ *    bakes that random URL into `servers[]`, and `openapi-typescript-codegen`
+ *    then bakes it into the generated client's `OpenAPI.BASE` constant, so the
+ *    port number flips on every regen and clutters the diff. The runtime URL
+ *    is supplied by the caller (relative URLs against the webapp's actual
+ *    origin), so the `servers[]` block is build-environment leakage rather
+ *    than wire contract; we drop it.
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -119,6 +129,20 @@ export const stripParameterSchemaDefaults = (spec) => {
   }
 };
 
+/**
+ * Drop the top-level `servers` block. springdoc populates it with the
+ * random-port URL the webapp was booted on for the spec dump, which causes
+ * unrelated diff churn in the regenerated client (`OpenAPI.BASE`) on every
+ * build. The runtime client's BASE is supplied by callers (relative URLs
+ * against the webapp's actual origin), so the block is documentation noise
+ * rather than wire contract.
+ */
+export const stripServers = (spec) => {
+  if (spec && typeof spec === 'object' && 'servers' in spec) {
+    delete spec.servers;
+  }
+};
+
 // Only run the side-effecting body when invoked as a script (not when
 // imported from the test file).
 const isMain = process.argv[1] && resolve(process.argv[1]) === __filename;
@@ -140,6 +164,7 @@ if (isMain) {
   const spec = JSON.parse(raw);
   stripEmptyDefaults(spec);
   stripParameterSchemaDefaults(spec);
+  stripServers(spec);
   writeFileSync(specPath, JSON.stringify(spec, null, 2) + '\n');
   console.log(`Normalised spec at ${specPath}`);
 }

--- a/components/promptlm-api-client/scripts/normalize-openapi.test.mjs
+++ b/components/promptlm-api-client/scripts/normalize-openapi.test.mjs
@@ -26,6 +26,7 @@ import {
   isNoopDefault,
   stripEmptyDefaults,
   stripParameterSchemaDefaults,
+  stripServers,
 } from './normalize-openapi.mjs';
 
 describe('isNoopDefault', () => {
@@ -255,5 +256,43 @@ describe('stripParameterSchemaDefaults', () => {
     const spec = { components: {} };
     stripParameterSchemaDefaults(spec);
     assert.ok(spec);
+  });
+});
+
+describe('stripServers', () => {
+  it('removes a populated servers block', () => {
+    const spec = {
+      openapi: '3.1.0',
+      servers: [{ url: 'http://localhost:50864', description: 'Generated server url' }],
+      paths: {},
+    };
+    stripServers(spec);
+    assert.equal('servers' in spec, false);
+  });
+
+  it('removes an empty servers block', () => {
+    const spec = { servers: [] };
+    stripServers(spec);
+    assert.equal('servers' in spec, false);
+  });
+
+  it('is a no-op when servers is absent', () => {
+    const spec = { openapi: '3.1.0', paths: {} };
+    stripServers(spec);
+    assert.deepEqual(spec, { openapi: '3.1.0', paths: {} });
+  });
+
+  it('does not touch nested servers (e.g. per-path overrides) — only the top-level field', () => {
+    const spec = {
+      servers: [{ url: 'http://localhost:50864' }],
+      paths: {
+        '/api/things': {
+          servers: [{ url: 'http://other.example.com' }],
+        },
+      },
+    };
+    stripServers(spec);
+    assert.equal('servers' in spec, false);
+    assert.deepEqual(spec.paths['/api/things'].servers, [{ url: 'http://other.example.com' }]);
   });
 });

--- a/components/promptlm-api-client/src/generated/client/core/OpenAPI.ts
+++ b/components/promptlm-api-client/src/generated/client/core/OpenAPI.ts
@@ -34,7 +34,7 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    BASE: 'http://localhost:56906',
+    BASE: '',
     VERSION: '0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',

--- a/components/promptlm-api-client/src/generated/client/models/JsonNode.ts
+++ b/components/promptlm-api-client/src/generated/client/models/JsonNode.ts
@@ -18,8 +18,8 @@
 /* eslint-disable */
 export type JsonNode = {
     missingNode?: boolean;
-    valueNode?: boolean;
     pojo?: boolean;
+    valueNode?: boolean;
     object?: boolean;
     nodeType?: JsonNode.nodeType;
     integralNumber?: boolean;
@@ -36,9 +36,9 @@ export type JsonNode = {
     textual?: boolean;
     boolean?: boolean;
     binary?: boolean;
+    number?: boolean;
     container?: boolean;
     string?: boolean;
-    number?: boolean;
     array?: boolean;
     empty?: boolean;
     null?: boolean;

--- a/components/promptlm-api-client/src/generated/openapi.ts
+++ b/components/promptlm-api-client/src/generated/openapi.ts
@@ -410,8 +410,8 @@ export interface components {
         };
         JsonNode: {
             missingNode?: boolean;
-            valueNode?: boolean;
             pojo?: boolean;
+            valueNode?: boolean;
             object?: boolean;
             /** @enum {string} */
             nodeType?: "ARRAY" | "BINARY" | "BOOLEAN" | "MISSING" | "NULL" | "NUMBER" | "OBJECT" | "POJO" | "STRING";
@@ -427,9 +427,9 @@ export interface components {
             textual?: boolean;
             boolean?: boolean;
             binary?: boolean;
+            number?: boolean;
             container?: boolean;
             string?: boolean;
-            number?: boolean;
             array?: boolean;
             empty?: boolean;
             null?: boolean;


### PR DESCRIPTION
## Summary

- Drop the top-level `servers` block from the springdoc-generated OpenAPI spec inside `normalize-openapi.mjs` (a third pass next to the existing `stripEmptyDefaults` and `stripParameterSchemaDefaults`).
- Result: `OpenAPI.BASE` in the regenerated client lands as `''` instead of a random `http://localhost:<port>` URL.

## Why

`apps/promptlm-webapp/pom.xml` uses `build-helper-maven-plugin`'s `reserve-network-port` to pick a free port at build time, then boots the webapp on that port to dump the OpenAPI JSON. The random URL flows into the spec's `servers[]` and is baked into the generated client by `openapi-typescript-codegen` as the value of `OpenAPI.BASE`.

This causes diff churn on every PR that regenerates the api-client (e.g. `OpenAPI.BASE` flipped 53197 → 63195 → 50864 → 56906 across recent merges), even when nothing else about the contract changed. Reviewers have to mentally filter "the port number changed" out of every diff.

The runtime `BASE` is supplied by callers (relative URLs against the webapp's actual origin), so the `servers[]` block is build-environment leakage, not wire contract.

## Test plan

- [x] `node --test components/promptlm-api-client/scripts/normalize-openapi.test.mjs` — 31 tests pass (4 new for `stripServers` cover populated / empty / absent / nested-paths-preserved).
- [x] `mvn -B -pl apps/promptlm-webapp -am install -DskipTests` — webapp build clean; OpenAPI JSON regenerates with no `servers` key.
- [x] `npm --workspace @promptlm/api-client run generate && npm --workspace @promptlm/api-client run build` — tsc clean.
- [x] Confirmed `components/promptlm-api-client/src/generated/client/core/OpenAPI.ts` now shows `BASE: ''` (was `BASE: 'http://localhost:<random>'`).

## Diff scope

5 files: the script, its test, and 3 regenerated artifacts (`OpenAPI.ts`, `openapi.ts`, `JsonNode.ts`). +70 / −6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)