### PR TITLE
test(acceptance): verify dev-run + release execution persistence (#141)

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
@@ -24,6 +24,9 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.WaitForSelectorState;
 import dev.promptlm.domain.ObjectMapperFactory;
 import dev.promptlm.domain.promptspec.ChatCompletionRequest;
+import dev.promptlm.domain.promptspec.ChatCompletionResponse;
+import dev.promptlm.domain.promptspec.Execution;
+import dev.promptlm.domain.promptspec.ExecutionKind;
 import dev.promptlm.domain.promptspec.PromptSpec;
 import dev.promptlm.test.support.ArtifactoryStorageHelper;
 import dev.promptlm.test.support.GiteaRepositoryHelper;
@@ -228,6 +231,48 @@ public class HappyPathUserJourneyTest {
     }
 
     @Test
+    @Order(25)
+    @DisplayName("Run prompt from editor and persist a MANUAL execution (#140)")
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void runPromptPersistsManualExecution() {
+        // Reach the editor for the prompt created in @Order(20). The catalog row
+        // opens the read view; "Edit" navigates to /prompts/:id/edit.
+        navigateToApplication();
+        navigateToPath("/prompts");
+        page.getByTestId("prompt-card-%s-action".formatted(PROMPT_NAME)).click();
+        page.getByTestId("prompt-edit-action").click();
+        page.getByTestId("prompt-editor-heading").waitFor();
+
+        // Click Run and wait for the execute response so we know the panel has
+        // had a chance to update. The acceptance Spring profile installs
+        // AcceptanceTestStubGateway, so the call returns a deterministic
+        // response without needing an LLM API key.
+        page.waitForResponse(
+                response -> response.url().contains("/execute")
+                        && "POST".equalsIgnoreCase(response.request().method()),
+                () -> page.getByTestId("prompt-editor-run-action").click());
+
+        // UI surface: the run response container should render with the stub
+        // content. We assert non-empty rather than the literal stub string so
+        // the test stays decoupled from the stub's exact payload format.
+        Locator runResponse = page.getByTestId("prompt-editor-run-response");
+        runResponse.waitFor();
+        assertThat(runResponse.textContent()).isNotBlank();
+
+        // YAML surface: the dev run should append a MANUAL Execution with the
+        // response content. Refetch the development-branch YAML and assert.
+        PromptSpec afterRun = waitForPromptSpec("development", Duration.ofMinutes(2));
+        assertThat(afterRun.getExecutions())
+                .as("dev-run must append at least one Execution to spec.executions[]")
+                .isNotNull()
+                .isNotEmpty();
+        Execution latest = afterRun.getExecutions().get(0);
+        assertThat(latest.kindOrManual()).isEqualTo(ExecutionKind.MANUAL);
+        assertThat(latest.getResponse()).isInstanceOf(ChatCompletionResponse.class);
+        assertThat(((ChatCompletionResponse) latest.getResponse()).getContent()).isNotBlank();
+    }
+
+    @Test
     @Order(30)
     @DisplayName("release prompt")
     @Timeout(value = 10, unit = TimeUnit.MINUTES)
@@ -267,6 +312,20 @@ public class HappyPathUserJourneyTest {
 
         // Verify deployed prompt in Gitea
         verifyPromptVersion("main", expectedReleaseVersion);
+
+        // Per #140: the pre-release-execute gate runs the spec server-side before
+        // promotion and appends a PRE_RELEASE Execution to spec.executions[]. The
+        // released YAML on main must carry that record with the stub's response.
+        PromptSpec releasedSpec = waitForPromptSpec("main", expectedReleaseVersion, Duration.ofMinutes(2));
+        assertThat(releasedSpec.getExecutions())
+                .as("released YAML must contain executions[] from the pre-release-execute gate")
+                .isNotNull()
+                .isNotEmpty();
+        assertThat(releasedSpec.getExecutions())
+                .anyMatch(execution -> execution.kindOrManual() == ExecutionKind.PRE_RELEASE
+                        && execution.getResponse() instanceof ChatCompletionResponse chat
+                        && chat.getContent() != null
+                        && !chat.getContent().isBlank());
     }
 
     @Test

--- a/acceptance-tests/src/test/java/dev/promptlm/test/TestApplicationManager.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/TestApplicationManager.java
@@ -73,6 +73,10 @@ public abstract class TestApplicationManager {
         if (applicationProcess == null) {
             serverPort = findPort();
             Map<String, String> systemProperties = new LinkedHashMap<>();
+            // Activate the 'acceptance' profile so the AcceptanceTestStubGateway is registered
+            // and the dev-run / pre-release-execute paths return a deterministic response
+            // without needing a real LLM API key.
+            systemProperties.put("spring.profiles.active", "acceptance");
             if (giteaUrl != null) {
                 systemProperties.put("gitea.url", giteaUrl);
                 systemProperties.put("REPO_REMOTE_URL", giteaUrl + "/api/v1");

--- a/apps/promptlm-webapp/src/main/java/dev/promptlm/webapp/AcceptanceTestStubGateway.java
+++ b/apps/promptlm-webapp/src/main/java/dev/promptlm/webapp/AcceptanceTestStubGateway.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.webapp;
+
+import dev.promptlm.domain.promptspec.ChatCompletionResponse;
+import dev.promptlm.execution.PromptGateway;
+import dev.promptlm.execution.gateway.GatewayRequest;
+import dev.promptlm.execution.gateway.GatewayResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Deterministic {@link PromptGateway} for the {@code acceptance} Spring profile. Returns a
+ * canned {@link ChatCompletionResponse} for any vendor/model without making a network
+ * call, so end-to-end tests can exercise the dev-run and pre-release-execute paths
+ * without an LLM API key.
+ *
+ * <p>Activated by {@code -Dspring.profiles.active=acceptance} when the acceptance test
+ * suite forks the webapp jar. {@link Order#value()} is {@link Ordered#HIGHEST_PRECEDENCE}
+ * so this gateway is selected first by {@code PromptSpecExecutorRegistry#findExecutor},
+ * shadowing the real vendor gateways.
+ */
+@Component
+@Profile("acceptance")
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class AcceptanceTestStubGateway implements PromptGateway {
+
+    /** Canned content returned for every request. Stable so tests can assert on it. */
+    public static final String STUB_RESPONSE_CONTENT = "stub-response";
+
+    @Override
+    public boolean supports(String vendor, String model) {
+        return true;
+    }
+
+    @Override
+    public GatewayResponse execute(GatewayRequest request) {
+        return GatewayResponse.of(new ChatCompletionResponse(50L, null, STUB_RESPONSE_CONTENT));
+    }
+}

--- a/components/ui/src/prompts-v2/form/PromptFormPage.tsx
+++ b/components/ui/src/prompts-v2/form/PromptFormPage.tsx
@@ -272,7 +272,11 @@ const StickyHeader: React.FC<{
         {errors.hasErrors ? <>! {totalErrors} errors</> : '✓ ready to save'}
       </FormMono>
       {onEditorRun && (
-        <GhostButton onClick={onEditorRun} disabled={isBusy || isEditorRunning}>
+        <GhostButton
+          onClick={onEditorRun}
+          disabled={isBusy || isEditorRunning}
+          testId="prompt-editor-run-action"
+        >
           <span style={{ fontFamily: 'var(--pl-mono)', fontSize: 11, marginRight: 5 }}>▷</span>
           {isEditorRunning ? 'Running…' : 'Run'}
         </GhostButton>

--- a/components/ui/src/prompts-v2/form/RunResponsePanel.tsx
+++ b/components/ui/src/prompts-v2/form/RunResponsePanel.tsx
@@ -240,18 +240,21 @@ export const RunResponsePanel: React.FC<RunResponsePanelProps> = ({
                 <FormMono size={10.5} color="var(--pl-ink-500)">{lastRun.tout} tok</FormMono>
               </div>
 
-              <div style={{
-                padding: '12px 14px',
-                background: 'var(--pl-canvas)',
-                border: '1px solid var(--pl-ink-200)',
-                borderRadius: 6,
-                fontFamily: 'var(--pl-display)',
-                fontSize: 13,
-                lineHeight: 1.6,
-                color: 'var(--pl-ink-900)',
-                whiteSpace: 'pre-wrap',
-                wordBreak: 'break-word',
-              }}>
+              <div
+                data-testid="prompt-editor-run-response"
+                style={{
+                  padding: '12px 14px',
+                  background: 'var(--pl-canvas)',
+                  border: '1px solid var(--pl-ink-200)',
+                  borderRadius: 6,
+                  fontFamily: 'var(--pl-display)',
+                  fontSize: 13,
+                  lineHeight: 1.6,
+                  color: 'var(--pl-ink-900)',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                }}
+              >
                 {lastRun.response
                   ? renderResponseText(lastRun.response)
                   : <FormMono size={11} color={lastRun.ok ? 'var(--pl-ink-500)' : 'oklch(0.45 0.13 25)'}>


### PR DESCRIPTION
## Summary

Closes [#141](https://github.com/promptLM/promptlm-app/issues/141). Adds end-to-end acceptance coverage for the [#140](https://github.com/promptLM/promptlm-app/issues/140) behavior change (dev-run executions persisted to \`spec.executions[]\`) — the layer that was deferred when #140 shipped.

## What changes

### Test-mode stub gateway

- New \`AcceptanceTestStubGateway\` in \`apps/promptlm-webapp/src/main\`, activated by \`@Profile(\"acceptance\")\` and \`Ordered.HIGHEST_PRECEDENCE\`.
- Returns a deterministic \`ChatCompletionResponse\` (\"stub-response\") for any vendor/model without a network call. Lets both the dev-run path and the pre-release-execute gate succeed without any LLM credentials.

### Profile activation

- \`TestApplicationManager.startApplicationWithGitea\` forks the webapp jar with \`-Dspring.profiles.active=acceptance\`.

### Testid hooks

- \`prompt-editor-run-action\` on the Run button (\`PromptFormPage.tsx\`)
- \`prompt-editor-run-response\` on the response container (\`RunResponsePanel.tsx\`)

These were intentionally omitted from #140 to keep scope tight; this PR re-adds them with their consumer (HappyPath) in the same commit.

### HappyPath additions

**\`@Order(25)\` — Run prompt and verify response:**
- Navigate to the editor for the prompt created in \`@Order(20)\`
- Click Run, wait for \`/execute\` POST response
- Assert \`prompt-editor-run-response\` renders non-empty
- Refetch development-branch YAML, assert \`executions[0].kind == MANUAL\` with non-blank \`response.content\`

**\`@Order(30)\` — augmented release verification:**
- After the existing release flow, refetch main-branch YAML at the released version
- Assert \`executions[]\` contains a \`PRE_RELEASE\` entry with non-blank \`response.content\` (proves the pre-release-execute gate wrote its record through the stub)

## Verification

- ✅ \`mvn test\` on \`apps/promptlm-webapp\` (3/3): existing tests unaffected — \`@Profile(\"acceptance\")\` keeps the stub out of the default profile.
- ✅ \`mvn test-compile\` on \`acceptance-tests\`: clean.
- ✅ \`tsc --noEmit\` on web-ui: clean.
- ⏳ HappyPath E2E: not run locally (Docker socket setup + per-memory test flakiness). Relying on CI to exercise the new assertions.

## Test plan

- [ ] CI HappyPath run completes with the two new assertions green
- [ ] Existing release flow unaffected
- [ ] Stub gateway not active outside the \`acceptance\` profile (verified by existing webapp unit tests passing)
- [ ] Removing \`@Profile(\"acceptance\")\` activation from \`TestApplicationManager\` causes \`@Order(25)\` to fail with a 401-class error (proves the stub is actually serving the request, not a coincidence)

## Notes / future work

- The stub returns the same canned content for every call. If a future test needs request-aware responses, add a fixture-driven variant rather than complicating this one.
- Storage-growth cap (5) and revision-bump reset are already covered by unit tests from #140; this PR doesn't duplicate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)