### PR TITLE
Widen EvaluationExtensionSupport for commercial evaluation subtypes

### DIFF
--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/ObjectMapperFactory.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/ObjectMapperFactory.java
@@ -16,6 +16,7 @@
 
 package dev.promptlm.domain;
 
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationFeature;
@@ -40,6 +41,7 @@ public class ObjectMapperFactory {
     public static JsonMapper createJsonMapper() {
         JsonMapper.Builder builder = JsonMapper.builder()
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS, false)
                 .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, false);
 

--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/EvaluationExtensions.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/EvaluationExtensions.java
@@ -54,6 +54,17 @@ public final class EvaluationExtensions {
     }
 
     /**
+     * Resets the mapper to its default configuration (no registered commercial modules).
+     * <p>
+     * <strong>For testing only.</strong> Do not call from production code.
+     */
+    public static void resetForTesting() {
+        synchronized (EvaluationExtensions.class) {
+            MAPPER = createMapper();
+        }
+    }
+
+    /**
      * Allows commercial modules to register additional evaluation subtypes.
      */
     public static void registerModule(JacksonModule module) {

--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/EvaluationExtensions.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/EvaluationExtensions.java
@@ -37,6 +37,23 @@ public final class EvaluationExtensions {
     }
 
     /**
+     * Returns {@code true} if the extensible mapper can serialize this spec without error.
+     * Used by {@link dev.promptlm.evaluation.EvaluationExtensionSupport} as a probe before
+     * writing commercial subtypes to the {@code x-evaluation} extension.
+     */
+    public static boolean writeProbe(EvaluationSpec spec) {
+        if (spec == null) {
+            return false;
+        }
+        try {
+            MAPPER.writeValueAsString(spec);
+            return true;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    /**
      * Allows commercial modules to register additional evaluation subtypes.
      */
     public static void registerModule(JacksonModule module) {

--- a/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/EvaluationResultTest.java
+++ b/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/EvaluationResultTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.domain.promptspec;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+import dev.promptlm.domain.ObjectMapperFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class EvaluationResultTest {
+
+    private final ObjectMapper mapper = ObjectMapperFactory.createJsonMapper();
+
+    /**
+     * A v2-schema EvaluationResult row (extra fields: outcome, threshold, metadata,
+     * subScores, comparison, diagnostics, schemaVersion) must deserialize into the v1
+     * EvaluationResult without throwing, and the v1 fields must be extracted correctly.
+     */
+    @Test
+    void v2RowOnV1Reader_doesNotThrow() {
+        ObjectNode v2Node = mapper.createObjectNode()
+                .put("evaluator", "semantic-match")
+                .put("type", "rubric")
+                .put("score", 0.9)
+                .put("reasoning", "Response is highly relevant")
+                .put("comments", "Meets all rubric criteria")
+                // v2-only fields — must be silently ignored
+                .put("outcome", "pass")
+                .put("threshold", 0.7)
+                .put("comparison", "gte")
+                .put("schemaVersion", 2);
+        v2Node.putObject("metadata").put("model", "gpt-4o");
+        v2Node.putArray("subScores").add(0.85).add(0.95);
+        v2Node.putObject("diagnostics").put("latencyMs", 340);
+
+        EvaluationResult result = assertDoesNotThrow(
+                () -> mapper.convertValue(v2Node, EvaluationResult.class));
+
+        assertThat(result.getEvaluator()).isEqualTo("semantic-match");
+        assertThat(result.getType()).isEqualTo("rubric");
+        assertThat(result.getScore()).isEqualTo(0.9);
+        assertThat(result.getReasoning()).isEqualTo("Response is highly relevant");
+        assertThat(result.getComments()).isEqualTo("Meets all rubric criteria");
+    }
+}

--- a/components/promptlm-evaluation/src/main/java/dev/promptlm/evaluation/EvaluationExtensionSupport.java
+++ b/components/promptlm-evaluation/src/main/java/dev/promptlm/evaluation/EvaluationExtensionSupport.java
@@ -21,10 +21,14 @@ import dev.promptlm.domain.promptspec.EvaluationExtensions;
 import dev.promptlm.domain.promptspec.EvaluationResults;
 import dev.promptlm.domain.promptspec.EvaluationSpec;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
 final class EvaluationExtensionSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EvaluationExtensionSupport.class);
 
     static final String EVALUATION_EXTENSION_KEY = EvaluationExtensions.KEY;
 
@@ -46,8 +50,14 @@ final class EvaluationExtensionSupport {
         if (ext == null) {
             ext = Map.of();
         }
-        if (spec != null && !hasSpec(ext) && EvaluationExtensions.writeProbe(spec)) {
-            ext = EvaluationExtensions.withSpec(ext, spec);
+        if (spec != null && !hasSpec(ext)) {
+            if (EvaluationExtensions.writeProbe(spec)) {
+                ext = EvaluationExtensions.withSpec(ext, spec);
+            } else {
+                LOG.warn("EvaluationSpec could not be serialized by the extensible mapper and was not written " +
+                         "to extensions. Ensure the evaluation subtype is registered via " +
+                         "EvaluationExtensions.registerModule before first use.");
+            }
         }
         if (results != null) {
             ext = EvaluationExtensions.withResults(ext, results);

--- a/components/promptlm-evaluation/src/main/java/dev/promptlm/evaluation/EvaluationExtensionSupport.java
+++ b/components/promptlm-evaluation/src/main/java/dev/promptlm/evaluation/EvaluationExtensionSupport.java
@@ -17,138 +17,46 @@
 package dev.promptlm.evaluation;
 
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.node.ObjectNode;
-import dev.promptlm.domain.ObjectMapperFactory;
-import dev.promptlm.domain.promptspec.Evaluation;
+import dev.promptlm.domain.promptspec.EvaluationExtensions;
 import dev.promptlm.domain.promptspec.EvaluationResults;
 import dev.promptlm.domain.promptspec.EvaluationSpec;
-import dev.promptlm.domain.promptspec.PromptEvaluationDefinition;
 import dev.promptlm.domain.promptspec.PromptSpec;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 final class EvaluationExtensionSupport {
 
-    static final String EVALUATION_EXTENSION_KEY = "x-evaluation";
-
-    private static final ObjectMapper MAPPER = ObjectMapperFactory.createJsonMapper();
+    static final String EVALUATION_EXTENSION_KEY = EvaluationExtensions.KEY;
 
     private EvaluationExtensionSupport() {
     }
 
     static EvaluationSpec extractSpec(PromptSpec promptSpec) {
-        EvaluationSpec spec = extractSpecFromExtensions(promptSpec);
+        EvaluationSpec spec = EvaluationExtensions.readSpec(promptSpec.getExtensions());
         return spec != null ? spec : promptSpec.getEvaluationSpec();
     }
 
     static EvaluationResults extractResults(PromptSpec promptSpec) {
-        EvaluationResults results = extractExtensionValue(promptSpec, "results", EvaluationResults.class);
+        EvaluationResults results = EvaluationExtensions.readResults(promptSpec.getExtensions());
         return results != null ? results : promptSpec.getEvaluationResults();
     }
 
     static PromptSpec withResults(PromptSpec promptSpec, EvaluationSpec spec, EvaluationResults results) {
-        Map<String, JsonNode> existing = promptSpec.getExtensions();
-        Map<String, JsonNode> updated = existing == null ? new LinkedHashMap<>() : new LinkedHashMap<>(existing);
-
-        ObjectNode evaluationNode = extractEvaluationNode(existing);
-        if (evaluationNode == null) {
-            evaluationNode = MAPPER.createObjectNode();
+        Map<String, JsonNode> ext = promptSpec.getExtensions();
+        if (ext == null) {
+            ext = Map.of();
         }
-        if (spec != null && evaluationNode.get("spec") == null && canSerializeSpec(spec)) {
-            evaluationNode.set("spec", MAPPER.valueToTree(spec));
+        if (spec != null && !hasSpec(ext) && EvaluationExtensions.writeProbe(spec)) {
+            ext = EvaluationExtensions.withSpec(ext, spec);
         }
         if (results != null) {
-            evaluationNode.set("results", MAPPER.valueToTree(results));
+            ext = EvaluationExtensions.withResults(ext, results);
         }
-
-        if (evaluationNode.size() > 0) {
-            updated.put(EVALUATION_EXTENSION_KEY, evaluationNode);
-        } else {
-            updated.remove(EVALUATION_EXTENSION_KEY);
-        }
-
-        return promptSpec.withExtensions(updated);
+        return promptSpec.withExtensions(ext);
     }
 
-    private static ObjectNode extractEvaluationNode(Map<String, JsonNode> extensions) {
-        if (extensions == null || extensions.isEmpty()) {
-            return null;
-        }
-        JsonNode node = extensions.get(EVALUATION_EXTENSION_KEY);
-        if (node != null && node.isObject()) {
-            return (ObjectNode) node.deepCopy();
-        }
-        return null;
-    }
-
-    private static <T> T extractExtensionValue(PromptSpec promptSpec, String field, Class<T> valueType) {
-        Map<String, JsonNode> extensions = promptSpec.getExtensions();
-        if (extensions == null || extensions.isEmpty()) {
-            return null;
-        }
-        JsonNode evaluationNode = extensions.get(EVALUATION_EXTENSION_KEY);
-        if (evaluationNode == null || !evaluationNode.isObject()) {
-            return null;
-        }
-        JsonNode fieldNode = evaluationNode.get(field);
-        if (fieldNode == null || fieldNode.isNull()) {
-            return null;
-        }
-        try {
-            return MAPPER.convertValue(fieldNode, valueType);
-        } catch (IllegalArgumentException ignored) {
-            return null;
-        }
-    }
-
-    private static EvaluationSpec extractSpecFromExtensions(PromptSpec promptSpec) {
-        Map<String, JsonNode> extensions = promptSpec.getExtensions();
-        if (extensions == null || extensions.isEmpty()) {
-            return null;
-        }
-        JsonNode evaluationNode = extensions.get(EVALUATION_EXTENSION_KEY);
-        if (evaluationNode == null || !evaluationNode.isObject()) {
-            return null;
-        }
-        JsonNode specNode = evaluationNode.get("spec");
-        if (specNode == null || specNode.isNull()) {
-            return null;
-        }
-        JsonNode evaluationsNode = specNode.isArray() ? specNode : specNode.get("evaluations");
-        if (evaluationsNode == null || evaluationsNode.isNull()) {
-            return new EvaluationSpec(List.of());
-        }
-        if (!evaluationsNode.isArray()) {
-            return null;
-        }
-        List<Evaluation> evaluations = new ArrayList<>();
-        for (JsonNode evaluationNodeItem : evaluationsNode) {
-            try {
-                evaluations.add(MAPPER.convertValue(evaluationNodeItem, PromptEvaluationDefinition.class));
-            } catch (IllegalArgumentException ignored) {
-                return null;
-            }
-        }
-        return new EvaluationSpec(evaluations);
-    }
-
-    private static boolean canSerializeSpec(EvaluationSpec spec) {
-        if (spec == null) {
-            return false;
-        }
-        List<Evaluation> evaluations = spec.getEvaluations();
-        if (evaluations == null || evaluations.isEmpty()) {
-            return true;
-        }
-        for (Evaluation evaluation : evaluations) {
-            if (evaluation != null && !(evaluation instanceof PromptEvaluationDefinition)) {
-                return false;
-            }
-        }
-        return true;
+    private static boolean hasSpec(Map<String, JsonNode> extensions) {
+        JsonNode eval = extensions.get(EVALUATION_EXTENSION_KEY);
+        return eval != null && eval.isObject() && eval.has("spec");
     }
 }

--- a/components/promptlm-evaluation/src/test/java/dev/promptlm/evaluation/EvaluationExtensionSupportTest.java
+++ b/components/promptlm-evaluation/src/test/java/dev/promptlm/evaluation/EvaluationExtensionSupportTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.evaluation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tools.jackson.databind.module.SimpleAbstractTypeResolver;
+import tools.jackson.databind.module.SimpleModule;
+import dev.promptlm.domain.promptspec.Evaluation;
+import dev.promptlm.domain.promptspec.EvaluationExtensions;
+import dev.promptlm.domain.promptspec.EvaluationResult;
+import dev.promptlm.domain.promptspec.EvaluationSpec;
+import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EvaluationExtensionSupportTest {
+
+    /**
+     * A fake commercial evaluation subtype — has its own field (threshold) beyond
+     * the standard PromptEvaluationDefinition shape. Structurally compatible so
+     * deserialization from a fresh EvaluationExtensions mapper succeeds even when
+     * the FakeEvaluation mapping is active.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class FakeEvaluation implements Evaluation {
+
+        private final String evaluator;
+        private final String type;
+        private final double threshold;
+
+        @JsonCreator
+        FakeEvaluation(
+                @JsonProperty("evaluator") String evaluator,
+                @JsonProperty("type") String type,
+                @JsonProperty("threshold") double threshold) {
+            this.evaluator = evaluator;
+            this.type = type;
+            this.threshold = threshold;
+        }
+
+        public String getEvaluator() { return evaluator; }
+        public String getType() { return type; }
+        public double getThreshold() { return threshold; }
+
+        @Override
+        public EvaluationResult evaluate(Response response) {
+            return new EvaluationResult(evaluator, type, 1.0, null, null);
+        }
+    }
+
+    /**
+     * Registers a fake commercial subtype, round-trips a PromptSpec through
+     * EvaluationExtensionSupport, and asserts no IllegalArgumentException is thrown.
+     * Before the fix, canSerializeSpec rejected non-PromptEvaluationDefinition subtypes,
+     * so the spec was never written to extensions and the round-trip silently lost data.
+     */
+    @Test
+    void customEvaluation_roundTrips() {
+        SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
+        resolver.addMapping(Evaluation.class, FakeEvaluation.class);
+        SimpleModule module = new SimpleModule();
+        module.setAbstractTypes(resolver);
+        EvaluationExtensions.registerModule(module);
+
+        FakeEvaluation fakeEval = new FakeEvaluation("custom-eval", "threshold-check", 0.8);
+        EvaluationSpec spec = new EvaluationSpec(List.of(fakeEval));
+        PromptSpec promptSpec = basePromptSpec();
+
+        // Write — canSerializeSpec must return true for FakeEvaluation
+        PromptSpec withSpec = EvaluationExtensionSupport.withResults(promptSpec, spec, null);
+
+        // Spec must have been written to extensions
+        assertThat(withSpec.getExtensions())
+                .containsKey(EvaluationExtensionSupport.EVALUATION_EXTENSION_KEY);
+
+        // Read back — must not throw IllegalArgumentException
+        EvaluationSpec readSpec = EvaluationExtensionSupport.extractSpec(withSpec);
+        assertThat(readSpec).isNotNull();
+        assertThat(readSpec.getEvaluations()).hasSize(1);
+    }
+
+    private static PromptSpec basePromptSpec() {
+        return PromptSpec.builder()
+                .withGroup("group")
+                .withName("name")
+                .withVersion("1.0.0-SNAPSHOT")
+                .withRevision(1)
+                .withDescription("desc")
+                .withRequest(dev.promptlm.domain.promptspec.ChatCompletionRequest.builder()
+                        .withVendor("openai")
+                        .withModel("gpt-4")
+                        .withMessages(List.of())
+                        .build())
+                .build();
+    }
+}

--- a/components/promptlm-evaluation/src/test/java/dev/promptlm/evaluation/EvaluationExtensionSupportTest.java
+++ b/components/promptlm-evaluation/src/test/java/dev/promptlm/evaluation/EvaluationExtensionSupportTest.java
@@ -27,6 +27,7 @@ import dev.promptlm.domain.promptspec.EvaluationResult;
 import dev.promptlm.domain.promptspec.EvaluationSpec;
 import dev.promptlm.domain.promptspec.PromptSpec;
 import dev.promptlm.domain.promptspec.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,6 +35,11 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class EvaluationExtensionSupportTest {
+
+    @AfterEach
+    void resetExtensionsMapper() {
+        EvaluationExtensions.resetForTesting();
+    }
 
     /**
      * A fake commercial evaluation subtype — has its own field (threshold) beyond


### PR DESCRIPTION
## Summary

- **Delegates** all reads/writes in `EvaluationExtensionSupport` to `EvaluationExtensions`, which holds the extensible (module-aware) Jackson mapper. Commercial subtypes registered via `EvaluationExtensions.registerModule` now round-trip correctly.
- **Adds** `EvaluationExtensions.writeProbe(EvaluationSpec)` — a probe that attempts serialization with the extensible mapper before committing a spec write. Replaces the `instanceof PromptEvaluationDefinition` guard in `canSerializeSpec`.
- **Disables** `FAIL_ON_UNKNOWN_PROPERTIES` in `ObjectMapperFactory.createJsonMapper()` so `EvaluationResult`/`EvaluationResults` silently ignore v2+ fields (single-point fix).
- **Adds two tests** (TDD): `customEvaluation_roundTrips` + `v2RowOnV1Reader_doesNotThrow`.
- **Adds** `EvaluationExtensions.resetForTesting()` for test isolation.
- **Adds** WARN log when `writeProbe` returns false to surface silent spec-drops.

Closes promptLM/promptlm-evals#7. Required before any commercial adapter ships.

## Acceptance criteria

- [x] `EvaluationExtensionSupport.canSerializeSpec` returns `true` for a registered commercial subtype
- [x] `EvaluationResult` and `EvaluationResults` host POJOs silently ignore unknown JSON fields
- [x] All existing `promptlm-app` tests pass (48 domain + 8 evaluation = 56 total)
- [x] `customEvaluation_roundTrips` passes
- [x] `v2RowOnV1Reader_doesNotThrow` passes

## Test plan

- [x] `mvn -B test -pl components/promptlm-domain,components/promptlm-evaluation -am` — 56 tests, 0 failures
- [x] License header check (pre-commit hook) — passed
- [ ] Full CI run on GitHub Actions

## Files changed

| File | Change |
|---|---|
| `ObjectMapperFactory.java` | +`FAIL_ON_UNKNOWN_PROPERTIES=false` |
| `EvaluationExtensions.java` | +`writeProbe`, +`resetForTesting` |
| `EvaluationExtensionSupport.java` | Rewritten to delegate to EvaluationExtensions; +WARN log |
| `EvaluationExtensionSupportTest.java` | New — `customEvaluation_roundTrips` |
| `EvaluationResultTest.java` | New — `v2RowOnV1Reader_doesNotThrow` |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)