### PR TITLE
fix(cli): remove custom cliShellApplicationRunner to stop double dispatch

### DIFF
--- a/apps/promptlm-cli/src/main/java/dev/promptlm/CliApplication.java
+++ b/apps/promptlm-cli/src/main/java/dev/promptlm/CliApplication.java
@@ -17,19 +17,10 @@
 package dev.promptlm;
 
 import dev.promptlm.infrastructure.config.ObjectMapperConfiguration;
-import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.shell.core.NonInteractiveShellRunner;
-import org.springframework.shell.core.command.CommandParser;
-import org.springframework.shell.core.command.CommandExecutionException;
-import org.springframework.shell.core.command.CommandNotFoundException;
-import org.springframework.shell.core.command.CommandRegistry;
 
 @SpringBootApplication
 @Import(ObjectMapperConfiguration.class)
@@ -44,74 +35,21 @@ public class CliApplication {
                 .properties(
                         "debug=false",
                         "spring.main.banner-mode=off",
-                        "promptlm.cli.runner.enabled=true",
-                        // Suppress Spring Shell's built-in InteractiveShellRunner /
-                        // NonInteractiveShellRunner ApplicationRunners — we drive
-                        // command dispatch ourselves via cliShellApplicationRunner.
-                        // If the built-in runners are left enabled they emit a stray
-                        // "Running in interactive mode, arguments will be ignored"
-                        // WARN onto stdout, which corrupts CLI output capture in
-                        // smoke tests (NativeCliSmokeTest#shouldRunPromptReleaseCommand).
+                        // Disable Spring Shell's InteractiveShellRunner so a `promptlm-cli`
+                        // invocation with arguments dispatches once through the built-in
+                        // NonInteractiveShellRunner instead of also entering an interactive
+                        // REPL. Previously we additionally registered a custom
+                        // `cliShellApplicationRunner` that re-dispatched every command
+                        // through a second NonInteractiveShellRunner — that caused every
+                        // CLI command to execute twice in the native binary (see #144),
+                        // surfacing as `PromptSpecAlreadyExistsException` /
+                        // `JGitInternalException: Destination path ... already exists` in
+                        // NativeCliSmokeTest. The built-in runner alone is sufficient.
                         "spring.shell.interactive.enabled=false",
-                        "spring.shell.noninteractive.enabled=false",
                         "logging.level.dev.promptlm.infrastructure.config.SerializingAppContext=ERROR",
                         "spring.autoconfigure.exclude="
                                 + "org.springframework.boot.micrometer.metrics.autoconfigure.jvm.JvmMetricsAutoConfiguration"
                 )
                 .run(args);
-    }
-
-    @Bean
-    ApplicationRunner cliShellApplicationRunner(CommandParser commandParser,
-                                                CommandRegistry commandRegistry,
-                                                @Value("${promptlm.cli.runner.enabled:false}") boolean cliRunnerEnabled,
-                                                ConfigurableApplicationContext applicationContext) {
-        return applicationArguments -> {
-            if (!cliRunnerEnabled) {
-                return;
-            }
-            String[] sourceArgs = normalizeArgs(applicationArguments.getSourceArgs());
-            try {
-                runNonInteractive(sourceArgs, commandParser, commandRegistry);
-            }
-            finally {
-                applicationContext.close();
-            }
-        };
-    }
-
-    private static void runNonInteractive(String[] sourceArgs,
-                                          CommandParser commandParser,
-                                          CommandRegistry commandRegistry) throws Exception {
-        try {
-            new NonInteractiveShellRunner(commandParser, commandRegistry).run(sourceArgs);
-        }
-        catch (CommandNotFoundException ex) {
-            throw new IllegalArgumentException("Command '%s' not found.".formatted(ex.getCommandName()), ex);
-        }
-        catch (CommandExecutionException ex) {
-            Throwable rootCause = ex;
-            while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
-                rootCause = rootCause.getCause();
-            }
-            String message = rootCause != ex
-                    ? "Error executing command: " + rootCause
-                    : "Error executing command.";
-            throw new IllegalStateException(message, ex);
-        }
-    }
-
-    private static String[] normalizeArgs(String[] sourceArgs) {
-        if (sourceArgs.length == 0) {
-            return new String[]{"help"};
-        }
-        if (sourceArgs.length == 1) {
-            return switch (sourceArgs[0]) {
-                case "--help", "-h" -> new String[]{"help"};
-                case "--version", "-V" -> new String[]{"version"};
-                default -> sourceArgs;
-            };
-        }
-        return sourceArgs;
     }
 }

--- a/apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptLmStudioLauncher.java
+++ b/apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptLmStudioLauncher.java
@@ -305,7 +305,6 @@ public class PromptLmStudioLauncher {
                             "spring.application.name=promptlm-webapp",
                             "spring.main.banner-mode=off",
                             "server.port=" + port,
-                            "promptlm.cli.runner.enabled=false",
                             "spring.shell.interactive.enabled=false",
                             "spring.shell.noninteractive.enabled=false",
                             "management.metrics.binders.jvm.enabled=false",


### PR DESCRIPTION
## Summary

- Removes the custom `cliShellApplicationRunner` from `CliApplication` — it ran alongside Spring Shell's built-in `springShellApplicationRunner`, causing every CLI command to dispatch twice in the native binary.
- Drops the now-dead `promptlm.cli.runner.enabled=false` default in `PromptLmStudioLauncher`.

Fixes #144.

## Why

In Spring Shell 4.0.2, `ShellRunnerAutoConfiguration.springShellApplicationRunner` is gated on `spring.shell.interactive.enabled` only — `spring.shell.noninteractive.enabled` has no effect on it. The suppression added in #135 stopped working when #108 bumped Spring Shell. With both runners active, the first dispatch succeeded but the second tripped over the state the first one created:

- `prompt create / show / change / release` → `PromptSpecAlreadyExistsException: Prompt native-smoke/native-cli-prompt already exists`
- `repo clone` → `JGitInternalException: Destination path "native-smoke-…" already exists and is not an empty directory`
- `repo create` / `repo use` happened to tolerate a second pass (one catches `RemoteRepositoryAlreadyExistsException` and returns exit 0; the other is idempotent), which masked the regression.

The custom runner only added a bit of error-message wrapping and `--help` / `--version` alias handling. Spring Shell's built-in non-interactive runner is sufficient. `spring.shell.interactive.enabled=false` stays so a no-arg invocation doesn't drop into a REPL.

## Test plan

- [x] `./mvnw -pl apps/promptlm-cli -am -DskipTests compile` succeeds
- [x] Rebuilt CLI native image: `./mvnw -pl apps/promptlm-cli -am -DskipTests -Pnative package`
- [x] `./mvnw -f acceptance-tests/pom.xml -Dtest=NativeCliSmokeTest -Dpromptlm.test.groups=native-smoke test`:

| Test | Before | After |
|---|---|---|
| shouldRunRepoCreateCommand | PASS | PASS |
| shouldRunPromptCreateCommand | FAIL | **PASS** |
| shouldRunPromptShowCommand | FAIL | **PASS** |
| shouldRunPromptChangeCommand | FAIL | **PASS** |
| shouldRunPromptReleaseCommand | FAIL (double-exec) | FAIL (separate: OpenAI 401, tracked in #148) |
| shouldRunRepoUseCommand | PASS | PASS |
| shouldRunRepoCloneCommand | FAIL | **PASS** |
| shouldRunStudioCommand | PASS | PASS |

`shouldRunPromptReleaseCommand` still fails, but for an unrelated reason — the new `PreReleaseExecuteGate` (#140/#141/#143) now actually runs and calls OpenAI for real. The native CLI has no acceptance-profile stub on its classpath. Tracked in #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)