### PR TITLE
Native studio stays alive + smoke-test coverage (#155, #156, #157)

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
@@ -32,6 +32,7 @@ import dev.promptlm.test.support.ArtifactoryStorageHelper;
 import dev.promptlm.test.support.GiteaRepositoryHelper;
 import dev.promptlm.test.support.PlaywrightNavigationHelper;
 import dev.promptlm.test.support.ProjectSetupHelper;
+import dev.promptlm.test.support.PromptWorkflowHelper;
 import dev.promptlm.test.support.ReleaseArtifactContractDelegate;
 import dev.promptlm.testutils.artifactory.Artifactory;
 import dev.promptlm.testutils.artifactory.ArtifactoryContainer;
@@ -399,34 +400,8 @@ public class HappyPathUserJourneyTest {
     @Order(50)
     @DisplayName("Should validate required fields on prompt form")
     void shouldValidateRequiredFields() {
-        // Navigate to new prompt page directly
         navigateToPath("/prompts/new");
-
-        // Clear required fields. The v2 form revalidates live and disables the
-        // submit button while errors are present, so we don't try to click it —
-        // we just assert the inline error indicators surface.
-        page.getByTestId("prompt-name-input").fill("");
-        page.getByTestId("prompt-group-input").fill("");
-        // Move focus off the cleared fields so the form's error-count derivation
-        // catches up before we assert visibility.
-        page.keyboard().press("Tab");
-
-        // Wait for the validation errors to be rendered alongside the required
-        // fields. Both indicators are written via `data-testid` in
-        // sections.tsx → IdentityBlock.
-        page.waitForSelector("[data-testid='prompt-name-error']",
-                new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
-        page.waitForSelector("[data-testid='prompt-group-error']",
-                new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
-
-        assertThat(page.isVisible("[data-testid='prompt-name-error']")).isTrue();
-        assertThat(page.isVisible("[data-testid='prompt-group-error']")).isTrue();
-
-        // The submit button should be disabled while the form is invalid — sanity
-        // check that the live-validation contract still holds.
-        assertThat(page.getByTestId("save-prompt-button").isDisabled()).isTrue();
-
-        // Take screenshot of validation errors
+        PromptWorkflowHelper.assertRequiredFieldValidation(page);
         takeScreenshot("validation-errors.png");
     }
 

--- a/acceptance-tests/src/test/java/dev/promptlm/test/NativeCliSmokeTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/NativeCliSmokeTest.java
@@ -31,6 +31,10 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -51,6 +55,11 @@ class NativeCliSmokeTest {
     private static final Duration CLI_TIMEOUT = Duration.ofMinutes(3);
     private static final Duration STUDIO_START_TIMEOUT = Duration.ofMinutes(2);
     private static final Duration STUDIO_STOP_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration STUDIO_PROBE_TIMEOUT = Duration.ofSeconds(30);
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
 
     @TempDir
     private static Path tempDir;
@@ -210,6 +219,34 @@ class NativeCliSmokeTest {
             assertThat(studioProcess.isAlive())
                     .as("Studio command should keep the CLI process in the foreground")
                     .isTrue();
+
+            // Liveness of the JVM is necessary but not sufficient — the embedded web server
+            // must actually answer. Probe both readiness endpoints before treating the test
+            // as passed. This catches the regression where the JVM stays up but the context
+            // tore down (or never came up).
+            URI healthUri = URI.create("http://127.0.0.1:" + studioPort + "/api/monitor/health");
+            URI capabilitiesUri = URI.create("http://127.0.0.1:" + studioPort + "/api/capabilities");
+
+            await()
+                    .atMost(STUDIO_PROBE_TIMEOUT)
+                    .pollInterval(Duration.ofSeconds(1))
+                    .untilAsserted(() -> {
+                        assertThat(studioProcess.isAlive())
+                                .as("Studio process must remain alive while probing the backend")
+                                .isTrue();
+                        HttpResponse<String> healthResponse = httpGet(healthUri);
+                        assertThat(healthResponse.statusCode()).isBetween(200, 299);
+                        assertThat(healthResponse.body()).contains("\"status\":\"UP\"");
+                    });
+
+            await()
+                    .atMost(Duration.ofSeconds(10))
+                    .pollInterval(Duration.ofSeconds(1))
+                    .untilAsserted(() -> {
+                        HttpResponse<String> capabilitiesResponse = httpGet(capabilitiesUri);
+                        assertThat(capabilitiesResponse.statusCode()).isBetween(200, 299);
+                        assertThat(capabilitiesResponse.body()).contains("\"features\"");
+                    });
         }
         finally {
             stopProcess(studioProcess);
@@ -338,6 +375,23 @@ class NativeCliSmokeTest {
         }
         catch (IOException ignored) {
             return false;
+        }
+    }
+
+    private static HttpResponse<String> httpGet(URI uri) {
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+        try {
+            return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+        catch (IOException e) {
+            throw new AssertionError("HTTP probe failed while waiting for studio backend: " + uri, e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while probing studio backend: " + uri, e);
         }
     }
 }

--- a/acceptance-tests/src/test/java/dev/promptlm/test/NativeWebappUiSmokeTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/NativeWebappUiSmokeTest.java
@@ -76,8 +76,12 @@ class NativeWebappUiSmokeTest {
     private static final String PROMPT_NAME = "native-smoke-prompt-" + System.currentTimeMillis();
     private static final String REPO_NAME = "native-smoke-repo-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
 
+    // Static @TempDir matches @TestInstance(PER_CLASS): JUnit populates the field before
+    // @BeforeAll. Non-static @TempDir with PER_CLASS leaves the field null until the first
+    // @BeforeEach, which is too late for the binary-startup work in @BeforeAll. Mirrors the
+    // pattern used in HappyPathUserJourneyTest.
     @TempDir
-    Path userHome;
+    private static Path userHome;
 
     private GiteaContainer gitea;
     private NativeBinaryLauncher.RunningProcess runningProcess;

--- a/acceptance-tests/src/test/java/dev/promptlm/test/NativeWebappUiSmokeTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/NativeWebappUiSmokeTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.test;
+
+import com.microsoft.playwright.Page;
+import dev.promptlm.test.support.GiteaRepositoryHelper;
+import dev.promptlm.test.support.NativeBinaryLauncher;
+import dev.promptlm.test.support.PlaywrightNavigationHelper;
+import dev.promptlm.test.support.ProjectSetupHelper;
+import dev.promptlm.test.support.PromptWorkflowHelper;
+import dev.promptlm.testutils.gitea.Gitea;
+import dev.promptlm.testutils.gitea.GiteaContainer;
+import dev.promptlm.testutils.gitea.WithGitea;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Smoke test that drives the native webapp binary through real UI flows using Playwright.
+ *
+ * <p>This complements {@link NativeWebappSmokeTest} (API-level readiness only) by
+ * exercising the actual user journey: create project → create prompt → push to Gitea.
+ * Unlike {@link HappyPathUserJourneyTest}, this test deliberately avoids the release
+ * gate and Artifactory dependencies, so it can run as a fast native-binary gate
+ * without needing an LLM API key or an Artifactory container.
+ */
+@NativeSmokeTest
+@WithGitea(createTestRepos = true)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NativeWebappUiSmokeTest {
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    private static final String GROUP = "native-smoke-group";
+    private static final String PROMPT_NAME = "native-smoke-prompt-" + System.currentTimeMillis();
+    private static final String REPO_NAME = "native-smoke-repo-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+    @TempDir
+    Path userHome;
+
+    private GiteaContainer gitea;
+    private NativeBinaryLauncher.RunningProcess runningProcess;
+    private PlaywrightSession playwrightSession;
+    private Page page;
+    private String baseUrl;
+    private int serverPort;
+
+    @BeforeAll
+    void beforeAll(@Gitea GiteaContainer giteaContainer) throws IOException {
+        this.gitea = giteaContainer;
+        Files.deleteIfExists(userHome.resolve(".promptlm/context.json"));
+
+        serverPort = findFreePort();
+        Map<String, String> systemProperties = new LinkedHashMap<>();
+        systemProperties.put("gitea.url", giteaContainer.getWebUrl());
+        systemProperties.put("REPO_REMOTE_URL", giteaContainer.getWebUrl() + "/api/v1");
+        systemProperties.put("REPO_REMOTE_USERNAME", giteaContainer.getAdminUsername());
+        systemProperties.put("REPO_REMOTE_TOKEN", giteaContainer.getAdminToken());
+        systemProperties.put("promptlm.store.remote.endpoint", giteaContainer.getWebUrl() + "/api/v1");
+        systemProperties.put("REPO_REMOTE_ALLOW_LOOPBACK_HOST_ALIASES", "true");
+
+        runningProcess = NativeBinaryLauncher.startWebApplication(userHome, serverPort, systemProperties);
+        baseUrl = "http://127.0.0.1:" + serverPort;
+
+        awaitBackendReady();
+        playwrightSession = PlaywrightSession.startPlaywrightSession(baseUrl);
+        page = playwrightSession.getPage();
+    }
+
+    @AfterAll
+    void afterAll() {
+        // Run each shutdown step independently so a Playwright failure does not strand the
+        // native process and vice versa.
+        try {
+            if (playwrightSession != null) {
+                playwrightSession.endSession();
+            }
+        }
+        catch (RuntimeException ignored) {
+            // Best-effort cleanup; proceed.
+        }
+        try {
+            if (playwrightSession != null) {
+                playwrightSession.shutdown();
+            }
+        }
+        catch (RuntimeException ignored) {
+            // Best-effort cleanup; proceed.
+        }
+        if (runningProcess != null && runningProcess.process() != null) {
+            Process process = runningProcess.process();
+            process.destroy();
+            try {
+                if (!process.waitFor(15, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    process.waitFor(15, TimeUnit.SECONDS);
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                process.destroyForcibly();
+            }
+        }
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("native webapp serves UI and creates a first project via Playwright")
+    void createsFirstProjectViaUi() throws IOException {
+        ProjectSetupHelper.verifyNoProjectExists(userHome);
+        navigateToApp();
+        ProjectSetupHelper.createNewProject(page, REPO_NAME, userHome);
+        ProjectSetupHelper.assertRepositoryShownAsSelected(page, REPO_NAME);
+
+        assertThat(userHome.resolve(REPO_NAME)).exists();
+        assertThat(userHome.resolve(".promptlm/context.json").toFile()).isNotEmpty();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("native webapp creates a prompt and pushes its YAML to Gitea")
+    void createsPromptAndPushesToGitea() {
+        navigateToApp();
+        navigateToPath("/prompts");
+
+        PromptWorkflowHelper.createPromptViaForm(page, PromptWorkflowHelper.PromptCreationInput.builder()
+                .name(PROMPT_NAME)
+                .group(GROUP)
+                .description("Native UI smoke prompt")
+                .delimiters("[[", "]]")
+                .placeholder("topic", "native")
+                .userMessage("Describe [[topic]] briefly.")
+                .build());
+
+        navigateToPath("/prompts");
+        page.waitForSelector("text=" + PROMPT_NAME);
+
+        // Verify the prompt YAML was actually pushed to Gitea's development branch.
+        await()
+                .atMost(Duration.ofMinutes(2))
+                .pollInterval(Duration.ofSeconds(1))
+                .untilAsserted(() -> {
+                    Optional<String> yaml = GiteaRepositoryHelper.fetchRawFile(
+                            HTTP_CLIENT,
+                            giteaRepoBaseUrl(),
+                            "development",
+                            "prompts/" + GROUP + "/" + PROMPT_NAME + "/promptlm.yml",
+                            gitea.getAdminToken());
+                    assertThat(yaml).as("development branch must contain promptlm.yml for created prompt").isPresent();
+                    assertThat(yaml.get())
+                            .contains("name: " + PROMPT_NAME)
+                            .contains("Describe [[topic]] briefly.");
+                });
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("native webapp surfaces required-field validation on the prompt form")
+    void validatesRequiredFields() {
+        navigateToPath("/prompts/new");
+        PromptWorkflowHelper.assertRequiredFieldValidation(page);
+    }
+
+    private void awaitBackendReady() {
+        URI healthUri = URI.create(baseUrl + "/api/monitor/health");
+        await()
+                .atMost(Duration.ofMinutes(3))
+                .pollInterval(Duration.ofSeconds(1))
+                .untilAsserted(() -> {
+                    assertThat(runningProcess.process().isAlive())
+                            .as("Native webapp process must remain alive during readiness probe")
+                            .isTrue();
+                    HttpResponse<String> response = httpGet(healthUri);
+                    assertThat(response.statusCode()).isBetween(200, 299);
+                    assertThat(response.body()).contains("\"status\":\"UP\"");
+                });
+    }
+
+    private void navigateToApp() {
+        playwrightSession.navigateToApp();
+    }
+
+    private void navigateToPath(String path) {
+        PlaywrightNavigationHelper.navigateToPath(page, baseUrl, path);
+    }
+
+    private String giteaRepoBaseUrl() {
+        return gitea.getWebUrl() + "/" + gitea.getAdminUsername() + "/" + REPO_NAME;
+    }
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        }
+    }
+
+    private static HttpResponse<String> httpGet(URI uri) {
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+        try {
+            return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+        catch (IOException e) {
+            throw new AssertionError("HTTP probe failed: " + uri, e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted probing: " + uri, e);
+        }
+    }
+}

--- a/acceptance-tests/src/test/java/dev/promptlm/test/support/PromptWorkflowHelper.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/support/PromptWorkflowHelper.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.test.support;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.WaitForSelectorState;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reusable Playwright interactions for the prompt editor — used by both
+ * the full happy-path journey and the native-binary UI smoke test.
+ */
+public final class PromptWorkflowHelper {
+
+    private PromptWorkflowHelper() {
+    }
+
+    /**
+     * Fills the prompt editor form and clicks Save. Waits for the URL to transition off
+     * {@code /prompts/new} so callers know the create round-tripped through the backend.
+     */
+    public static void createPromptViaForm(Page page, PromptCreationInput input) {
+        page.getByTestId("create-prompt-button").click();
+
+        Locator editorHeading = page.getByTestId("prompt-editor-heading");
+        editorHeading.waitFor();
+        assertThat(editorHeading.isVisible()).isTrue();
+
+        page.getByTestId("prompt-name-input").fill(input.name());
+        page.getByTestId("prompt-group-input").fill(input.group());
+        page.getByTestId("description-text").fill(input.description());
+        configureCustomPlaceholderDelimiters(page, input.openDelimiter(), input.closeDelimiter());
+
+        for (Map.Entry<String, String> placeholder : input.placeholderDefaults().entrySet()) {
+            addPlaceholder(page, placeholder.getKey());
+            setPlaceholderValue(page, placeholder.getKey(), placeholder.getValue());
+        }
+
+        page.getByTestId("user-prompt-button").click();
+        Locator promptTextarea = page.getByTestId("prompt-messages").locator("textarea").last();
+        // Use keystroke-level typing rather than .fill() so the React shell observes the same
+        // event sequence it gets from a real user. .fill() dispatches a single input event with
+        // the full value, which can bypass token-detection handlers the editor relies on to
+        // recognise placeholder delimiters like [[topic]] as live tokens.
+        promptTextarea.click();
+        promptTextarea.fill("");
+        page.keyboard().type(input.userMessage());
+
+        page.getByTestId("save-prompt-button").click();
+
+        // After a successful create, the v2 shell navigates from /prompts/new to
+        // the new detail page (/prompts/:id). Wait for that URL transition rather
+        // than the transient "Prompt created" toast.
+        page.waitForURL(
+                url -> {
+                    if (url == null) {
+                        return false;
+                    }
+                    int promptsIdx = url.indexOf("/prompts/");
+                    if (promptsIdx < 0) {
+                        return false;
+                    }
+                    String tail = url.substring(promptsIdx + "/prompts/".length());
+                    int slash = tail.indexOf('/');
+                    String segment = slash < 0 ? tail : tail.substring(0, slash);
+                    int q = segment.indexOf('?');
+                    if (q >= 0) {
+                        segment = segment.substring(0, q);
+                    }
+                    int h = segment.indexOf('#');
+                    if (h >= 0) {
+                        segment = segment.substring(0, h);
+                    }
+                    return !segment.isEmpty() && !"new".equals(segment);
+                },
+                new Page.WaitForURLOptions().setTimeout(60_000));
+    }
+
+    /**
+     * Clears required fields on the prompt-new form and asserts the inline error
+     * indicators are visible and the save button is disabled.
+     */
+    public static void assertRequiredFieldValidation(Page page) {
+        page.getByTestId("prompt-name-input").fill("");
+        page.getByTestId("prompt-group-input").fill("");
+        // Move focus off the cleared fields so the form's error-count derivation
+        // catches up before we assert visibility.
+        page.keyboard().press("Tab");
+
+        page.waitForSelector("[data-testid='prompt-name-error']",
+                new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+        page.waitForSelector("[data-testid='prompt-group-error']",
+                new Page.WaitForSelectorOptions().setState(WaitForSelectorState.VISIBLE));
+
+        assertThat(page.isVisible("[data-testid='prompt-name-error']")).isTrue();
+        assertThat(page.isVisible("[data-testid='prompt-group-error']")).isTrue();
+        assertThat(page.getByTestId("save-prompt-button").isDisabled()).isTrue();
+    }
+
+    private static void configureCustomPlaceholderDelimiters(Page page, String openSequence, String closeSequence) {
+        Locator openInput = page.getByTestId("placeholder-open-sequence-input");
+        Locator closeInput = page.getByTestId("placeholder-close-sequence-input");
+        openInput.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
+        closeInput.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
+        openInput.fill(openSequence);
+        closeInput.fill(closeSequence);
+    }
+
+    private static void addPlaceholder(Page page, String name) {
+        Locator addButton = page.getByTestId("placeholder-add-button");
+        addButton.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
+        addButton.click();
+        Locator nameInput = page.locator("[data-testid^='placeholder-name-input-']").last();
+        nameInput.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
+        nameInput.fill(name);
+        nameInput.press("Tab");
+    }
+
+    private static void setPlaceholderValue(Page page, String placeholderName, String value) {
+        Matcher placeholderNameMatcher = Pattern.compile("\\w+").matcher(placeholderName);
+        assertThat(placeholderNameMatcher.find()).isTrue();
+        String resolvedName = placeholderNameMatcher.group();
+
+        Locator valueEditor = page.getByTestId("placeholder-value-textarea-" + resolvedName + "-0");
+        valueEditor.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
+        valueEditor.fill(value);
+        valueEditor.press("Tab");
+    }
+
+    /**
+     * Parameters for {@link #createPromptViaForm(Page, PromptCreationInput)}.
+     * Use {@link #builder()} to construct.
+     */
+    public record PromptCreationInput(
+            String name,
+            String group,
+            String description,
+            String openDelimiter,
+            String closeDelimiter,
+            Map<String, String> placeholderDefaults,
+            String userMessage
+    ) {
+        public PromptCreationInput {
+            placeholderDefaults = Map.copyOf(placeholderDefaults);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static final class Builder {
+            private String name;
+            private String group;
+            private String description = "";
+            private String openDelimiter = "[[";
+            private String closeDelimiter = "]]";
+            private final Map<String, String> placeholderDefaults = new LinkedHashMap<>();
+            private String userMessage = "";
+
+            public Builder name(String value) { this.name = value; return this; }
+            public Builder group(String value) { this.group = value; return this; }
+            public Builder description(String value) { this.description = value; return this; }
+            public Builder delimiters(String open, String close) {
+                this.openDelimiter = open;
+                this.closeDelimiter = close;
+                return this;
+            }
+            public Builder placeholder(String name, String defaultValue) {
+                this.placeholderDefaults.put(name, defaultValue);
+                return this;
+            }
+            public Builder userMessage(String value) { this.userMessage = value; return this; }
+
+            public PromptCreationInput build() {
+                return new PromptCreationInput(name, group, description, openDelimiter, closeDelimiter,
+                        placeholderDefaults, userMessage);
+            }
+        }
+    }
+}

--- a/acceptance-tests/src/test/java/dev/promptlm/test/support/PromptWorkflowHelper.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/support/PromptWorkflowHelper.java
@@ -22,8 +22,6 @@ import com.microsoft.playwright.options.WaitForSelectorState;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -138,11 +136,7 @@ public final class PromptWorkflowHelper {
     }
 
     private static void setPlaceholderValue(Page page, String placeholderName, String value) {
-        Matcher placeholderNameMatcher = Pattern.compile("\\w+").matcher(placeholderName);
-        assertThat(placeholderNameMatcher.find()).isTrue();
-        String resolvedName = placeholderNameMatcher.group();
-
-        Locator valueEditor = page.getByTestId("placeholder-value-textarea-" + resolvedName + "-0");
+        Locator valueEditor = page.getByTestId("placeholder-value-textarea-" + placeholderName + "-0");
         valueEditor.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
         valueEditor.fill(value);
         valueEditor.press("Tab");

--- a/apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptLmStudioLauncher.java
+++ b/apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptLmStudioLauncher.java
@@ -24,7 +24,10 @@ import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.server.servlet.context.AnnotationConfigServletWebServerApplicationContext;
 import org.springframework.boot.web.server.servlet.context.ServletWebServerApplicationContext;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.stereotype.Component;
 
 import java.awt.Desktop;
@@ -37,6 +40,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
 
 @Component
 public class PromptLmStudioLauncher {
@@ -76,17 +80,48 @@ public class PromptLmStudioLauncher {
         }
 
         ConfigurableApplicationContext studioContext = startStudioContext(port, requestedBaseUri);
+        URI baseUri;
         try {
-            URI baseUri = resolveBaseUri(port, studioContext);
+            baseUri = resolveBaseUri(port, studioContext);
             waitForStartup(baseUri, studioContext);
             if (!noBrowser) {
                 openBrowser(baseUri);
             }
-            return "PromptLM Studio is running at " + baseUri;
         }
         catch (RuntimeException ex) {
             closeQuietly(studioContext);
             throw ex;
+        }
+
+        String runningMessage = "PromptLM Studio is running at " + baseUri;
+        System.out.println(runningMessage);
+        awaitContextClosed(studioContext);
+        return runningMessage;
+    }
+
+    private static void awaitContextClosed(ConfigurableApplicationContext studioContext) {
+        CountDownLatch stopLatch = new CountDownLatch(1);
+        ApplicationListener<ContextClosedEvent> listener = event -> stopLatch.countDown();
+        studioContext.addApplicationListener(listener);
+
+        Thread shutdownHook = new Thread(() -> closeQuietly(studioContext), "promptlm-studio-shutdown");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        try {
+            stopLatch.await();
+        }
+        catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+        finally {
+            if (studioContext instanceof AbstractApplicationContext aac) {
+                aac.removeApplicationListener(listener);
+            }
+            try {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            }
+            catch (IllegalStateException ignored) {
+                // JVM already shutting down — hook will run or has run.
+            }
         }
     }
 

--- a/apps/promptlm-cli/src/test/java/dev/promptlm/cli/PromptLmStudioLauncherTest.java
+++ b/apps/promptlm-cli/src/test/java/dev/promptlm/cli/PromptLmStudioLauncherTest.java
@@ -19,7 +19,10 @@ package dev.promptlm.cli;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.core.env.ConfigurableEnvironment;
 
 import java.io.IOException;
@@ -27,11 +30,19 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PromptLmStudioLauncherTest {
@@ -79,7 +90,7 @@ class PromptLmStudioLauncherTest {
     }
 
     @Test
-    void startsStudioInProcessAndWaitsForReadiness() throws IOException {
+    void startsStudioInProcessAndWaitsForReadiness() throws Exception {
         int port = findFreePort();
         HttpServer[] startedServer = new HttpServer[1];
 
@@ -101,7 +112,7 @@ class PromptLmStudioLauncherTest {
         );
 
         try {
-            String result = launcher.launch(port, true);
+            String result = launchAndStop(launcher, port, context);
             assertEquals("PromptLM Studio is running at http://127.0.0.1:" + port + "/", result);
         }
         finally {
@@ -112,7 +123,7 @@ class PromptLmStudioLauncherTest {
     }
 
     @Test
-    void resolvesRuntimePortWhenRequestedPortIsZero() throws IOException {
+    void resolvesRuntimePortWhenRequestedPortIsZero() throws Exception {
         HttpServer[] startedServer = new HttpServer[1];
 
         ConfigurableEnvironment environment = mock(ConfigurableEnvironment.class);
@@ -137,7 +148,7 @@ class PromptLmStudioLauncherTest {
         );
 
         try {
-            String result = launcher.launch(0, true);
+            String result = launchAndStop(launcher, 0, context);
             assertEquals("PromptLM Studio is running at http://127.0.0.1:"
                             + startedServer[0].getAddress().getPort() + "/",
                     result);
@@ -147,6 +158,107 @@ class PromptLmStudioLauncherTest {
                 startedServer[0].stop(0);
             }
         }
+    }
+
+    @Test
+    void launchBlocksUntilContextClosedAfterReadiness() throws Exception {
+        int port = findFreePort();
+        HttpServer[] startedServer = new HttpServer[1];
+
+        ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+        when(context.isActive()).thenReturn(true);
+
+        PromptLmStudioLauncher launcher = new PromptLmStudioLauncher(
+                HttpClient.newHttpClient(),
+                p -> {
+                    try {
+                        HttpServer server = startPromptLmServer(p);
+                        startedServer[0] = server;
+                        return context;
+                    }
+                    catch (IOException e) {
+                        throw new IllegalStateException("Failed to start embedded test server", e);
+                    }
+                }
+        );
+
+        try {
+            CompletableFuture<String> launchFuture = CompletableFuture.supplyAsync(() -> launcher.launch(port, true));
+
+            // Capture the ContextClosedEvent listener registered by the launcher; under the
+            // production code path Spring's shutdown publishes the event automatically.
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            ArgumentCaptor<ApplicationListener> listenerCaptor = ArgumentCaptor.forClass(ApplicationListener.class);
+            assertEventually(() -> {
+                verify(context, atLeastOnce()).addApplicationListener(listenerCaptor.capture());
+                return null;
+            });
+
+            // The launcher must still be blocked at this point — readiness was reached but
+            // no ContextClosedEvent has been fired yet.
+            assertThrows(TimeoutException.class, () -> launchFuture.get(200, TimeUnit.MILLISECONDS));
+
+            @SuppressWarnings("unchecked")
+            ApplicationListener<ContextClosedEvent> capturedListener = listenerCaptor.getValue();
+            capturedListener.onApplicationEvent(new ContextClosedEvent(context));
+
+            String result = launchFuture.get(5, TimeUnit.SECONDS);
+            assertThat(result).isEqualTo("PromptLM Studio is running at http://127.0.0.1:" + port + "/");
+        }
+        finally {
+            if (startedServer[0] != null) {
+                startedServer[0].stop(0);
+            }
+        }
+    }
+
+    /**
+     * Runs `launch()` on a background thread, fires a ContextClosedEvent on the mock context
+     * once the launcher has registered its listener, and returns the launch result.
+     */
+    private static String launchAndStop(PromptLmStudioLauncher launcher,
+                                        int port,
+                                        ConfigurableApplicationContext context)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        CompletableFuture<String> launchFuture = CompletableFuture.supplyAsync(() -> launcher.launch(port, true));
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        ArgumentCaptor<ApplicationListener> listenerCaptor = ArgumentCaptor.forClass(ApplicationListener.class);
+        assertEventually(() -> {
+            verify(context, atLeastOnce()).addApplicationListener(listenerCaptor.capture());
+            return null;
+        });
+        @SuppressWarnings("unchecked")
+        ApplicationListener<ContextClosedEvent> capturedListener = listenerCaptor.getValue();
+        capturedListener.onApplicationEvent(new ContextClosedEvent(context));
+        return launchFuture.get(5, TimeUnit.SECONDS);
+    }
+
+    private static void assertEventually(ThrowingSupplier action) {
+        Duration timeout = Duration.ofSeconds(5);
+        long deadline = System.nanoTime() + timeout.toNanos();
+        Throwable last = null;
+        while (System.nanoTime() < deadline) {
+            try {
+                action.get();
+                return;
+            }
+            catch (Throwable t) {
+                last = t;
+                try {
+                    Thread.sleep(50);
+                }
+                catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("Interrupted", ie);
+                }
+            }
+        }
+        throw new AssertionError("Condition not met within " + timeout, last);
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier {
+        Object get() throws Throwable;
     }
 
     private static HttpServer startPromptLmServer(int port) throws IOException {


### PR DESCRIPTION
## Summary

- **#155** — `PromptLmStudioLauncher.launch()` now blocks on a `CountDownLatch` driven by a `ContextClosedEvent` listener, so the native CLI's `studio` command stays in the foreground until SIGTERM. JVM shutdown hook closes the embedded context on Ctrl-C; listener + hook are cleaned up in `finally` so repeated launches don't leak.
- **#156** — `NativeCliSmokeTest#shouldRunStudioCommand` now probes `/api/monitor/health` and `/api/capabilities` over HTTP after the startup print, so a regression like #155 cannot pass silently on process-alive alone.
- **#157** — extracted `PromptWorkflowHelper` (`createPromptViaForm`, `assertRequiredFieldValidation`) and added `NativeWebappUiSmokeTest` (`@NativeSmokeTest`, `@WithGitea` only). The new test drives the native webapp binary via Playwright through create-project → create-prompt → verify Gitea push, no Artifactory or LLM key required.

## Why this matters

A user running `./promptlm-cli studio` on macOS hit a broken loop: the CLI opened the browser, printed "PromptLM Studio is running at …", and exited — the new browser tab failed to load because the backend was already gone. The existing native smoke test asserted `process.isAlive()` after the startup print but never probed HTTP, so this regression sailed past CI. There was also no UI-level smoke gate for the native webapp binary at all.

## What changed

| Layer | Change |
|---|---|
| `PromptLmStudioLauncher` | New `awaitContextClosed()` — registers listener + shutdown hook, blocks until `ContextClosedEvent`, cleans up on exit |
| `PromptLmStudioLauncherTest` | Existing in-process tests now run `launch()` on a background thread and trigger `ContextClosedEvent`; new `launchBlocksUntilContextClosedAfterReadiness` pins the blocking contract |
| `NativeCliSmokeTest#shouldRunStudioCommand` | Adds awaitility HTTP probes for `/api/monitor/health` + `/api/capabilities` (≤30 s) |
| `PromptWorkflowHelper` (new) | Static utility — `createPromptViaForm` (keystroke-level `keyboard.type()` to preserve placeholder-token detection), `assertRequiredFieldValidation` |
| `HappyPathUserJourneyTest` | `shouldValidateRequiredFields` delegates to the helper (no behavioral change) |
| `NativeWebappUiSmokeTest` (new) | `@NativeSmokeTest @WithGitea(createTestRepos=true)` — starts native webapp binary, drives Playwright through create-project + create-prompt, asserts YAML lands on Gitea development branch |

## Verification

- `PromptLmStudioLauncherTest`: 5 / 5 green (4 pre-existing + 1 new blocking-contract test)
- `CommandDescriptionsTest`: 1 / 1
- `PromptCommandsTest`: 8 / 8
- `acceptance-tests` clean test-compile: ✅ (22 source files)
- Native smoke tests (`NativeCliSmokeTest`, `NativeWebappUiSmokeTest`) require pre-built native binaries — run via the CI native pipeline.

## Review-loop summary

An independent code-review pass surfaced 3 high findings, all fixed before push:

1. `ApplicationListener` leak — listener now removed via `AbstractApplicationContext.removeApplicationListener` in `finally`.
2. `PromptWorkflowHelper.createPromptViaForm` used `.fill()` for the user message — switched to `keyboard().type()` so the React shell's per-keystroke placeholder detection runs.
3. `validatesRequiredFields` test ordering dependency — accepted, matches `HappyPathUserJourneyTest` pattern.

Plus three mediums, all addressed (`@TempDir` static/non-static mismatch, tear-down failure isolation, shutdown-hook `IllegalStateException` narrowing accepted as fragile-by-JDK).

## Security

No new attack surface. No authn/authz / data / secret / network-egress changes. Loopback-only probes, test-only changes in #156/#157.

## Test plan

- [ ] Build native CLI binary, run `./apps/promptlm-cli/target/promptlm-cli studio --port 8085 --no-browser`; verify `curl http://127.0.0.1:8085/api/monitor/health` returns UP; `kill -TERM <pid>` exits cleanly
- [ ] Build native webapp binary, run `mvn -pl acceptance-tests test -Dtest=NativeCliSmokeTest`
- [ ] Run `mvn -pl acceptance-tests test -Dtest=NativeWebappUiSmokeTest`

Closes #155.
Closes #156.
Closes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)