### PR TITLE
docs(repo-template): fix README workflow list and add Mode 1/Mode 2 sections (#166)

### DIFF
--- a/components/repository-template/repo-resources/README.md
+++ b/components/repository-template/repo-resources/README.md
@@ -6,41 +6,57 @@ This repository contains prompts for {{PROJECT_DESCRIPTION}}.
 
 Add your prompts to the `prompts/` directory. Each prompt can be a separate file or organized in subdirectories.
 
+## Usage Modes
+
+This repository can be used in one of two modes. The mode is selected by the `release.enabled` flag in `promptlm.yml`.
+
+### Mode 1 — Prompt management (default)
+
+Use this repository as a plain git store for your prompts. Edit prompts under `prompts/`, commit, push. The included build and deploy workflows stay no-ops unless `.promptlm/artifacts.toml` is configured, so you can ignore them.
+
+### Mode 2 — Prompt releases (opt-in)
+
+Use GitHub Actions to validate, package, and publish your prompts as versioned artifacts. Set `release.enabled: true` in `promptlm.yml`, configure `.promptlm/artifacts.toml`, and tag a commit (`vX.Y.Z`) to cut a release.
+
+If you also need to publish to Artifactory, set the variables and secrets listed under [Environment Variables](#environment-variables).
+
 ## GitHub Actions Workflows
 
-This repository includes a minimal set of pre-configured GitHub Actions workflows:
+The generated repository ships with a small set of GitHub Actions workflows under `.github/workflows/`. Which workflows are present depends on this repository's configuration.
 
-### 📦 **Artifact Build Workflow** (`.github/workflows/build-artifacts.yml`)
-- **Triggers**: Manual dispatch
+### 📦 Artifact build (`build-artifacts.yml`)
+
+- **Triggers**: Manual dispatch.
 - **Actions**: Builds prompt artifacts for Java, Python, and JS based on `.promptlm/artifacts.toml`.
 - **Behavior**: If no targets are configured, the build is skipped (no error).
-- **Notes**: Each language builds in its own job; add/remove targets in the manifest to control which jobs do real work.
 
-### 🚀 **Artifact Deploy Workflow** (`.github/workflows/deploy-artifacts.yml`)
-- **Triggers**: Tag push (`v*`), manual dispatch
+### 🚀 Artifact deploy (`deploy-artifacts.yml`)
+
+- **Triggers**: Tag push (`v*`), manual dispatch.
 - **Actions**: Builds artifacts and publishes them when `deploy.enabled=true` in `.promptlm/artifacts.toml`.
 - **Behavior**: Deployment is skipped when disabled or when no targets are configured.
 
-### 🔄 **CI Workflow** (`.github/workflows/ci.yml`)
-- **Triggers**: Push to `main`
-- **Actions**: Builds and tests the prompt repository, generates test-support artifacts, and uploads outputs.
+### ✅ Prompt validation (`validate.yml`) — when release capability is enabled
 
-### 🏭 **Deploy to Artifactory** (`.github/workflows/deploy-artifactory.yml`)
-- **Triggers**: Push to `main`, manual dispatch
+- **Triggers**: Push, pull request.
+- **Actions**: Validates prompts before packaging (non-empty prompt files, required metadata fields).
+- **Availability**: Present when `release.enabled: true` in `promptlm.yml`.
+
+### 🏷️ Release (`release.yml`) — when release capability is enabled
+
+- **Triggers**: Tag push (`v*.*.*`), manual dispatch.
+- **Actions**: Validates, packages, generates a release manifest with checksums, and publishes a GitHub Release.
+- **Availability**: Present when `release.enabled: true` in `promptlm.yml`.
+
+### 🏭 Deploy to Artifactory (`deploy-artifactory.yml`) — when Artifactory deployment is configured
+
+- **Triggers**: Push to `main`, manual dispatch.
 - **Actions**: Resolves version, builds in-place, and deploys artifacts to Artifactory.
-- **Requirements**: Artifactory configuration in `.github/artifactory-config.yml` and matching repository variables/secrets.
-
-## Test Support Generation
-
-The repository automatically generates WireMock stub mappings from your prompt specifications using the promptLM test support generator. This enables:
-
-- **Automated testing**: Generated stubs mock LLM API responses based on your prompts
-- **CI/CD integration**: Test artifacts are built and uploaded with each change
-- **Consistent testing**: Same prompts used in production are available for testing
+- **Availability**: Present when Artifactory deployment is configured. Requires the variables and secrets listed under [Environment Variables](#environment-variables).
 
 ## Environment Variables
 
-For `.github/workflows/deploy-artifactory.yml`, configure these repository variables or secrets when you want the generated repository to publish to Artifactory:
+For `deploy-artifactory.yml`, configure these repository variables or secrets when you want the generated repository to publish to Artifactory:
 
 - `ARTIFACTORY_URL`: Base Artifactory URL, for example `https://artifactory.example.com/artifactory`
 - `ARTIFACTORY_REPOSITORY`: Target Maven repository key
@@ -57,17 +73,11 @@ In normal GitHub or Gitea workflows, the checkout logic should usually rely on `
 
 ## Usage
 
-1. Add your prompt specifications to the `prompts/` directory
-2. Update `.promptlm/prompts-meta.json` with metadata
-3. Configure `.promptlm/artifacts.toml` (including `project.version`) for optional artifact builds and deployment
-4. Push changes to `main` to trigger CI workflows as configured
-5. Use manual workflow dispatch for controlled artifact builds or deploys when needed
-
-## Workflow Archive
-
-Deprecated or optional workflow variants are kept in
-`components/repository-template/workflow-archive/` in the PromptLM monorepo.
-Only the minimal runtime set is shipped in this template archive.
+1. Add your prompt specifications to the `prompts/` directory.
+2. Update `.promptlm/prompts-meta.json` with metadata.
+3. Configure `.promptlm/artifacts.toml` (including `project.version`) for optional artifact builds and deployment.
+4. Push changes to `main` to trigger configured workflows.
+5. Use manual workflow dispatch for controlled artifact builds or deploys when needed.
 
 ## License
 

--- a/components/repository-template/src/assembly/repo-template.xml
+++ b/components/repository-template/src/assembly/repo-template.xml
@@ -18,7 +18,6 @@
                 <include>README.md</include>
                 <include>.github/artifactory-config.yml</include>
                 <include>.github/workflows/build-artifacts.yml</include>
-                <include>.github/workflows/ci.yml</include>
                 <include>.github/workflows/deploy-artifacts.yml</include>
                 <include>.github/workflows/deploy-artifactory.yml</include>
                 <include>tools/release/**</include>

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateReadmeContentTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateReadmeContentTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.repository.template;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RepositoryTemplateReadmeContentTest {
+
+    @Test
+    void readmeInPackagedZipHasNoBrokenReferencesAndKeepsTemplateTokens() throws Exception {
+        String readme = readReadmeFromTemplateZip();
+
+        assertFalse(readme.contains("ci.yml"),
+                "README must not reference ci.yml — that workflow is parked, not shipped (see issue #166)");
+        assertFalse(readme.contains("workflow-archive"),
+                "README must not reference the internal monorepo path 'workflow-archive' (see issue #166)");
+
+        assertTrue(readme.contains("{{REPO_NAME}}"),
+                "README must keep the {{REPO_NAME}} template token canonical for the substitution pipeline (#160)");
+        assertTrue(readme.contains("{{PROJECT_DESCRIPTION}}"),
+                "README must keep the {{PROJECT_DESCRIPTION}} template token canonical for the substitution pipeline (#160)");
+
+        assertTrue(readme.contains("Mode 1"),
+                "README must include the Mode 1 (prompt management) usage section (see issue #166)");
+        assertTrue(readme.contains("Mode 2"),
+                "README must include the Mode 2 (prompt releases) usage section (see issue #166)");
+    }
+
+    private String readReadmeFromTemplateZip() throws Exception {
+        try (InputStream resource = getClass().getClassLoader().getResourceAsStream("repo-template.zip")) {
+            assertNotNull(resource, "repo-template.zip must be packaged in module resources");
+            try (ZipInputStream zip = new ZipInputStream(resource)) {
+                ZipEntry entry;
+                while ((entry = zip.getNextEntry()) != null) {
+                    if (!entry.isDirectory() && "README.md".equals(entry.getName())) {
+                        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                        zip.transferTo(buffer);
+                        return buffer.toString(StandardCharsets.UTF_8);
+                    }
+                }
+            }
+        }
+        throw new AssertionError("README.md not found in repo-template.zip");
+    }
+}


### PR DESCRIPTION
## Summary

- Drop the parked `ci.yml` reference and the monorepo-internal "Workflow Archive" section from the generated `README.md` (closes [#166](https://github.com/promptLM/promptlm-app/issues/166), F-020 from epic [#159](https://github.com/promptLM/promptlm-app/issues/159)).
- Restructure the GitHub Actions list with explicit availability conditions and add a Usage Modes section (Mode 1: prompt management / Mode 2: prompt releases). Forward-looking workflows (`validate.yml`, `release.yml`) are gated on "when release capability enabled" so the text is accurate today and after [#161](https://github.com/promptLM/promptlm-app/issues/161) / [#163](https://github.com/promptLM/promptlm-app/issues/163) land.
- Remove the dead `<include>.github/workflows/ci.yml</include>` from the maven-assembly descriptor — the file lives under `.github/parked/`, so the include was silently ignored.
- New `RepositoryTemplateReadmeContentTest` pins four README invariants in the packaged ZIP: no `ci.yml`, no `workflow-archive`, both `{{REPO_NAME}}` / `{{PROJECT_DESCRIPTION}}` template tokens preserved (for the substitution pipeline in [#160](https://github.com/promptLM/promptlm-app/issues/160)), both Mode headings present.

The "Test Support Generation" section was also removed because it described an internal-only plugin (F-006) that does not resolve from user repositories; that's adjacent to [#162](https://github.com/promptLM/promptlm-app/issues/162) but leaving misleading docs after a docs-cleanup pass would be worse.

## Test plan

- [x] `mvn -pl components/repository-template test -Dtest='RepositoryTemplateReadmeContentTest,RepositoryTemplateZipContentsTest,TemplateExtractionExceptionTest'` → 3/3 PASS locally
- [ ] `mvn -pl components/repository-template test` on a host with a healthy Docker daemon — `RepositoryTemplateActSmokeTest` was not run locally (Docker daemon corruption in this worktree, pre-existing and unrelated to this text-only change)
- [x] Manual: unzip the packaged `repo-template.zip` and eyeball the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)