### PR TITLE
chore(template): drop deploy-artifactory.yml test defaults (#162)

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/CiWorkflowHarnessTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/CiWorkflowHarnessTest.java
@@ -163,7 +163,6 @@ class CiWorkflowHarnessTest implements WithAssertions {
         gitea.ensureRepositoryActionsVariable(owner, REPO_NAME, "REPO_REMOTE_URL", runnerCloneUrl);
         gitea.ensureRepositoryActionsVariable(owner, REPO_NAME, "REPO_REMOTE_USERNAME", owner);
         gitea.ensureRepositoryActionsVariable(owner, REPO_NAME, "REPO_REMOTE_TOKEN", gitea.getAdminToken());
-        gitea.ensureRepositoryActionsVariable(owner, REPO_NAME, "OPENAI_API_KEY", "dummy-key");
         gitea.ensureRepositoryActionsVariable(owner, REPO_NAME, "ARTIFACTORY_URL", artifactory.getRunnerAccessibleApiUrl());
         gitea.ensureRepositoryActionsVariable(owner, REPO_NAME, "ARTIFACTORY_REPOSITORY", artifactory.getMavenRepositoryName());
         gitea.ensureRepositoryActionsVariable(owner, REPO_NAME, "ARTIFACTORY_USERNAME", artifactory.getDeployerUsername());

--- a/components/repository-template/repo-resources/.github/actions/checkout-repo/action.yml
+++ b/components/repository-template/repo-resources/.github/actions/checkout-repo/action.yml
@@ -1,0 +1,96 @@
+name: Checkout repository
+description: >
+  Initialise a git checkout in the current workspace, with optional overrides
+  for the remote URL, username, and token. Falls back to the GitHub-provided
+  repository URL and token when overrides are not supplied. Handles file://
+  remotes so the same flow can be exercised by local runners (e.g. nektos/act).
+
+inputs:
+  remote-url:
+    description: Override remote URL (e.g. vars.REPO_REMOTE_URL). Empty means use the fallback.
+    required: false
+    default: ''
+  remote-username:
+    description: Override remote username (e.g. vars.REPO_REMOTE_USERNAME). Empty means use x-access-token.
+    required: false
+    default: ''
+  remote-token:
+    description: Override remote token (e.g. vars.REPO_REMOTE_TOKEN). Empty means use the fallback token.
+    required: false
+    default: ''
+  fallback-url:
+    description: Fallback URL when remote-url is empty (typically the GitHub-provided repository URL).
+    required: true
+  fallback-token:
+    description: Fallback token when remote-token is empty (typically the GitHub-provided token).
+    required: true
+  ref-name:
+    description: Optional branch or tag name to fetch before checking out the SHA.
+    required: false
+    default: ''
+  sha:
+    description: Commit SHA to check out (typically the github.sha context value).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      shell: bash
+      env:
+        CHECKOUT_REMOTE_URL: ${{ inputs.remote-url }}
+        CHECKOUT_REMOTE_USERNAME: ${{ inputs.remote-username }}
+        CHECKOUT_REMOTE_TOKEN: ${{ inputs.remote-token }}
+        CHECKOUT_FALLBACK_URL: ${{ inputs.fallback-url }}
+        CHECKOUT_FALLBACK_TOKEN: ${{ inputs.fallback-token }}
+        CHECKOUT_REF_NAME: ${{ inputs.ref-name }}
+        CHECKOUT_SHA: ${{ inputs.sha }}
+      run: |
+        set -euo pipefail
+
+        REMOTE_URL="${CHECKOUT_REMOTE_URL:-$CHECKOUT_FALLBACK_URL}"
+        IS_FILE_REMOTE=false
+        if [[ "${REMOTE_URL}" == file://* ]]; then
+          IS_FILE_REMOTE=true
+        fi
+
+        git init .
+        git config --global --add safe.directory "$PWD"
+        if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
+          git config --global --add safe.directory "${REMOTE_URL#file://}"
+        else
+          REMOTE_USERNAME="${CHECKOUT_REMOTE_USERNAME:-x-access-token}"
+          REMOTE_TOKEN="${CHECKOUT_REMOTE_TOKEN:-$CHECKOUT_FALLBACK_TOKEN}"
+          if [ -z "${REMOTE_TOKEN}" ]; then
+            echo "No repository token available for checkout" >&2
+            exit 1
+          fi
+          AUTH_HEADER="Authorization: Basic $(printf '%s:%s' "${REMOTE_USERNAME}" "${REMOTE_TOKEN}" | base64 | tr -d '\n')"
+        fi
+
+        if git remote get-url origin >/dev/null 2>&1; then
+          git remote set-url origin "${REMOTE_URL}"
+        else
+          git remote add origin "${REMOTE_URL}"
+        fi
+
+        if [ -n "${CHECKOUT_REF_NAME}" ]; then
+          if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
+            git fetch --force origin "${CHECKOUT_REF_NAME}"
+          else
+            git -c http.extraHeader="${AUTH_HEADER}" fetch --force origin "${CHECKOUT_REF_NAME}"
+          fi
+        else
+          if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
+            git fetch --force origin "${CHECKOUT_SHA}"
+          else
+            git -c http.extraHeader="${AUTH_HEADER}" fetch --force origin "${CHECKOUT_SHA}"
+          fi
+        fi
+
+        if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
+          git fetch --force origin "${CHECKOUT_SHA}"
+        else
+          git -c http.extraHeader="${AUTH_HEADER}" fetch --force origin "${CHECKOUT_SHA}"
+        fi
+        git checkout --force "${CHECKOUT_SHA}"

--- a/components/repository-template/repo-resources/.github/workflows/deploy-artifactory.yml
+++ b/components/repository-template/repo-resources/.github/workflows/deploy-artifactory.yml
@@ -32,10 +32,10 @@ on:
         type: string
 
 env:
-  ARTIFACTORY_URL: ${{ github.event.inputs.artifactory_url || vars.ARTIFACTORY_URL || 'http://host.docker.internal:8091/artifactory' }}
-  ARTIFACTORY_REPOSITORY: ${{ vars.ARTIFACTORY_REPOSITORY || 'example-repo-local' }}
-  ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME || vars.ARTIFACTORY_USERNAME || 'admin' }}
-  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD || vars.ARTIFACTORY_PASSWORD || 'password' }}
+  ARTIFACTORY_URL: ${{ github.event.inputs.artifactory_url || vars.ARTIFACTORY_URL }}
+  ARTIFACTORY_REPOSITORY: ${{ vars.ARTIFACTORY_REPOSITORY }}
+  ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME || vars.ARTIFACTORY_USERNAME }}
+  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD || vars.ARTIFACTORY_PASSWORD }}
   TARGET_ENVIRONMENT: ${{ github.event.inputs.environment || 'development' }}
   MAVEN_OPTS: '-Xmx1024m'
   MAVEN_ARGS: ${{ github.event.inputs.maven_args || vars.PROMPTLM_MAVEN_ARGS || '' }}
@@ -89,65 +89,23 @@ jobs:
       REPO_REMOTE_USERNAME: ${{ vars.REPO_REMOTE_USERNAME }}
       REPO_REMOTE_TOKEN: ${{ vars.REPO_REMOTE_TOKEN }}
     steps:
+      - name: Bootstrap composite actions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
       - name: Checkout repository
-        shell: bash
-        env:
-          CHECKOUT_REMOTE_URL: ${{ env.REPO_REMOTE_URL }}
-          CHECKOUT_REMOTE_USERNAME: ${{ env.REPO_REMOTE_USERNAME }}
-          CHECKOUT_REMOTE_TOKEN: ${{ env.REPO_REMOTE_TOKEN }}
-          CHECKOUT_FALLBACK_URL: ${{ github.server_url }}/${{ github.repository }}.git
-          CHECKOUT_FALLBACK_TOKEN: ${{ github.token }}
-          CHECKOUT_REF_NAME: ${{ github.ref_name }}
-          CHECKOUT_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-
-          REMOTE_URL="${CHECKOUT_REMOTE_URL:-$CHECKOUT_FALLBACK_URL}"
-          IS_FILE_REMOTE=false
-          if [[ "${REMOTE_URL}" == file://* ]]; then
-            IS_FILE_REMOTE=true
-          fi
-
-          git init .
-          git config --global --add safe.directory "$PWD"
-          if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
-            git config --global --add safe.directory "${REMOTE_URL#file://}"
-          else
-            REMOTE_USERNAME="${CHECKOUT_REMOTE_USERNAME:-x-access-token}"
-            REMOTE_TOKEN="${CHECKOUT_REMOTE_TOKEN:-$CHECKOUT_FALLBACK_TOKEN}"
-            if [ -z "${REMOTE_TOKEN}" ]; then
-              echo "No repository token available for checkout" >&2
-              exit 1
-            fi
-            AUTH_HEADER="Authorization: Basic $(printf '%s:%s' "${REMOTE_USERNAME}" "${REMOTE_TOKEN}" | base64 | tr -d '\n')"
-          fi
-
-          if git remote get-url origin >/dev/null 2>&1; then
-            git remote set-url origin "${REMOTE_URL}"
-          else
-            git remote add origin "${REMOTE_URL}"
-          fi
-
-          if [ -n "${CHECKOUT_REF_NAME}" ]; then
-            if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
-              git fetch --force origin "${CHECKOUT_REF_NAME}"
-            else
-              git -c http.extraHeader="${AUTH_HEADER}" fetch --force origin "${CHECKOUT_REF_NAME}"
-            fi
-          else
-            if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
-              git fetch --force origin "${CHECKOUT_SHA}"
-            else
-              git -c http.extraHeader="${AUTH_HEADER}" fetch --force origin "${CHECKOUT_SHA}"
-            fi
-          fi
-
-          if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
-            git fetch --force origin "${CHECKOUT_SHA}"
-          else
-            git -c http.extraHeader="${AUTH_HEADER}" fetch --force origin "${CHECKOUT_SHA}"
-          fi
-          git checkout --force "${CHECKOUT_SHA}"
+        uses: ./.github/actions/checkout-repo
+        with:
+          remote-url: ${{ env.REPO_REMOTE_URL }}
+          remote-username: ${{ env.REPO_REMOTE_USERNAME }}
+          remote-token: ${{ env.REPO_REMOTE_TOKEN }}
+          fallback-url: ${{ github.server_url }}/${{ github.repository }}.git
+          fallback-token: ${{ github.token }}
+          ref-name: ${{ github.ref_name }}
+          sha: ${{ github.sha }}
 
       - name: Show toolchain
         shell: bash
@@ -181,15 +139,6 @@ jobs:
           fi
 
           "${MAVEN_COMMAND[@]}"
-
-      - name: Generate test support artifacts
-        shell: bash
-        run: |
-          if mvn -B -ntp help:describe -Dplugin=dev.promptlm:promptlm-test-support-generator -Ddetail=false >/dev/null 2>&1; then
-            mvn -B -ntp dev.promptlm:promptlm-test-support-generator:generate-test-support
-          else
-            echo "promptlm-test-support-generator plugin is not resolvable in this environment; skipping test-support generation."
-          fi
 
       - name: Ensure packaging prerequisites
         run: |
@@ -227,65 +176,49 @@ jobs:
       REPO_REMOTE_USERNAME: ${{ vars.REPO_REMOTE_USERNAME }}
       REPO_REMOTE_TOKEN: ${{ vars.REPO_REMOTE_TOKEN }}
     steps:
-      - name: Checkout repository
+      - name: Validate Artifactory configuration
         shell: bash
         env:
-          CHECKOUT_REMOTE_URL: ${{ env.REPO_REMOTE_URL }}
-          CHECKOUT_REMOTE_USERNAME: ${{ env.REPO_REMOTE_USERNAME }}
-          CHECKOUT_REMOTE_TOKEN: ${{ env.REPO_REMOTE_TOKEN }}
-          CHECKOUT_FALLBACK_URL: ${{ github.server_url }}/${{ github.repository }}.git
-          CHECKOUT_FALLBACK_TOKEN: ${{ github.token }}
-          CHECKOUT_REF_NAME: ${{ github.ref_name }}
-          CHECKOUT_SHA: ${{ github.sha }}
+          ARTIFACTORY_URL: ${{ env.ARTIFACTORY_URL }}
+          ARTIFACTORY_REPOSITORY: ${{ env.ARTIFACTORY_REPOSITORY }}
+          ARTIFACTORY_USERNAME: ${{ env.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ env.ARTIFACTORY_PASSWORD }}
         run: |
-          set -euo pipefail
-
-          REMOTE_URL="${CHECKOUT_REMOTE_URL:-$CHECKOUT_FALLBACK_URL}"
-          IS_FILE_REMOTE=false
-          if [[ "${REMOTE_URL}" == file://* ]]; then
-            IS_FILE_REMOTE=true
+          set -eu
+          if [ -z "${ARTIFACTORY_URL}" ]; then
+            echo "ARTIFACTORY_URL is not configured. Set it as a repository variable." >&2
+            exit 1
+          fi
+          if [ -z "${ARTIFACTORY_REPOSITORY}" ]; then
+            echo "ARTIFACTORY_REPOSITORY is not configured. Set it as a repository variable." >&2
+            exit 1
+          fi
+          if [ -z "${ARTIFACTORY_USERNAME}" ]; then
+            echo "ARTIFACTORY_USERNAME is not configured. Set it as a repository secret or variable." >&2
+            exit 1
+          fi
+          if [ -z "${ARTIFACTORY_PASSWORD}" ]; then
+            echo "ARTIFACTORY_PASSWORD is not configured. Set it as a repository secret." >&2
+            exit 1
           fi
 
-          git init .
-          git config --global --add safe.directory "$PWD"
-          if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
-            git config --global --add safe.directory "${REMOTE_URL#file://}"
-          else
-            REMOTE_USERNAME="${CHECKOUT_REMOTE_USERNAME:-x-access-token}"
-            REMOTE_TOKEN="${CHECKOUT_REMOTE_TOKEN:-$CHECKOUT_FALLBACK_TOKEN}"
-            if [ -z "${REMOTE_TOKEN}" ]; then
-              echo "No repository token available for checkout" >&2
-              exit 1
-            fi
-            AUTH_HEADER="Authorization: Basic $(printf '%s:%s' "${REMOTE_USERNAME}" "${REMOTE_TOKEN}" | base64 | tr -d '\n')"
-          fi
+      - name: Bootstrap composite actions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
 
-          if git remote get-url origin >/dev/null 2>&1; then
-            git remote set-url origin "${REMOTE_URL}"
-          else
-            git remote add origin "${REMOTE_URL}"
-          fi
-
-          if [ -n "${CHECKOUT_REF_NAME}" ]; then
-            if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
-              git fetch --force origin "${CHECKOUT_REF_NAME}"
-            else
-              git -c http.extraHeader="${AUTH_HEADER}" fetch --force origin "${CHECKOUT_REF_NAME}"
-            fi
-          else
-            if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
-              git fetch --force origin "${CHECKOUT_SHA}"
-            else
-              git -c http.extraHeader="${AUTH_HEADER}" fetch --force origin "${CHECKOUT_SHA}"
-            fi
-          fi
-
-          if [[ "${IS_FILE_REMOTE}" == "true" ]]; then
-            git fetch --force origin "${CHECKOUT_SHA}"
-          else
-            git -c http.extraHeader="${AUTH_HEADER}" fetch --force origin "${CHECKOUT_SHA}"
-          fi
-          git checkout --force "${CHECKOUT_SHA}"
+      - name: Checkout repository
+        uses: ./.github/actions/checkout-repo
+        with:
+          remote-url: ${{ env.REPO_REMOTE_URL }}
+          remote-username: ${{ env.REPO_REMOTE_USERNAME }}
+          remote-token: ${{ env.REPO_REMOTE_TOKEN }}
+          fallback-url: ${{ github.server_url }}/${{ github.repository }}.git
+          fallback-token: ${{ github.token }}
+          ref-name: ${{ github.ref_name }}
+          sha: ${{ github.sha }}
 
       - name: Show toolchain
         shell: bash

--- a/components/repository-template/src/assembly/repo-template.xml
+++ b/components/repository-template/src/assembly/repo-template.xml
@@ -16,6 +16,7 @@
                 <include>prompts/**</include>
                 <include>pom.xml</include>
                 <include>README.md</include>
+                <include>.github/actions/checkout-repo/action.yml</include>
                 <include>.github/artifactory-config.yml</include>
                 <include>.github/workflows/build-artifacts.yml</include>
                 <include>.github/workflows/ci.yml</include>

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateZipContentsTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateZipContentsTest.java
@@ -45,6 +45,7 @@ class RepositoryTemplateZipContentsTest {
             }
 
             Set<String> expectedEntries = new TreeSet<>(List.of(
+                    ".github/actions/checkout-repo/action.yml",
                     ".github/artifactory-config.yml",
                     ".github/workflows/build-artifacts.yml",
                     ".github/workflows/deploy-artifacts.yml",


### PR DESCRIPTION
## Summary

- Remove all four test-specific env fallbacks from generated `deploy-artifactory.yml` (`host.docker.internal`, `admin`, `password`, `example-repo-local`). Required config now comes only from repository variables/secrets.
- Add a `Validate Artifactory configuration` step at the start of the deploy job that fails fast with the exact issue-specified message `ARTIFACTORY_URL is not configured. Set it as a repository variable.` (plus parallel checks for the other three required vars).
- Remove the `Generate test support artifacts` step that called the internal `dev.promptlm:promptlm-test-support-generator` plugin (unresolvable in user repos).
- De-duplicate the ~60-line bespoke checkout block between `build` and `deploy` jobs into a single composite action at `.github/actions/checkout-repo/action.yml`, bootstrapped via `actions/checkout@v4` (sparse, depth=1).
- Drop the unused `OPENAI_API_KEY=dummy-key` injection from `CiWorkflowHarnessTest` (per the #162 issue text and #167's blocker note).

Closes #162. Picks up the `OPENAI_API_KEY` cleanup from #167.

## Test plan

- [x] `RepositoryTemplateZipContentsTest` — composite action packaged into `repo-template.zip`
- [x] `RepositoryTemplateActSmokeTest` — build job runs end-to-end under `nektos/act` with `actions/checkout@v4` bootstrap → composite-action checkout
- [x] `CiWorkflowHarnessTest#shouldExecuteCiWorkflowAndPublishArtifacts` — full workflow green against real Gitea Actions runner + Artifactory container in standalone runs (3:45 + 3:34 pre-build-full.sh)
- [ ] CI re-runs `CiWorkflowHarnessTest` (in-session re-runs after a heavy `build-full.sh` started flaking on **both** this branch **and** unmodified `HEAD` — confirmed environmental, not a regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)