### PR TITLE
refactor(acceptance-tests): prepare CiWorkflowHarnessTest for Mode 2 template (#167)

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/CiWorkflowHarnessTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/CiWorkflowHarnessTest.java
@@ -209,14 +209,27 @@ class CiWorkflowHarnessTest implements WithAssertions {
 
     private static final class RepositorySeeder {
 
+        private static final String DEFAULT_TEMPLATE_RESOURCE = "repo-template.zip";
+
         private final GiteaContainer gitea;
         private final Path workspace;
         private final Path repoDir;
+        private final String templateResource;
 
         private RepositorySeeder(GiteaContainer gitea, Path workspace) {
+            this(gitea, workspace, DEFAULT_TEMPLATE_RESOURCE);
+        }
+
+        /**
+         * Hook for tests that need to seed a non-default template archive (for example a
+         * Mode 2 release-enabled template once #161 splits the repository template). The
+         * two-arg constructor preserves today's behaviour by loading {@code repo-template.zip}.
+         */
+        private RepositorySeeder(GiteaContainer gitea, Path workspace, String templateResource) {
             this.gitea = gitea;
             this.workspace = workspace;
             this.repoDir = workspace.resolve(REPO_NAME + "-local");
+            this.templateResource = templateResource;
         }
 
         String seedTemplateRepository() {
@@ -257,7 +270,7 @@ class CiWorkflowHarnessTest implements WithAssertions {
                 classLoader = RepositorySeeder.class.getClassLoader();
             }
             try {
-                var resources = classLoader.getResources("repo-template.zip");
+                var resources = classLoader.getResources(templateResource);
                 StringBuilder locations = new StringBuilder();
                 while (resources.hasMoreElements()) {
                     var resourceUrl = resources.nextElement();
@@ -270,10 +283,10 @@ class CiWorkflowHarnessTest implements WithAssertions {
                         return resourceUrl.openStream();
                     }
                 }
-                throw new IllegalStateException("repo-template.zip from repository-template module not found. "
+                throw new IllegalStateException(templateResource + " from repository-template module not found. "
                         + "Discovered locations: [" + locations + "]");
             } catch (IOException e) {
-                throw new IllegalStateException("Failed to load repo-template.zip from repository-template module", e);
+                throw new IllegalStateException("Failed to load " + templateResource + " from repository-template module", e);
             }
         }
 

--- a/acceptance-tests/src/test/java/dev/promptlm/test/support/ReleaseArtifactContractDelegate.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/support/ReleaseArtifactContractDelegate.java
@@ -47,6 +47,12 @@ public final class ReleaseArtifactContractDelegate {
     /**
      * Downloads the first published archive from Artifactory and validates the release artifact contract.
      *
+     * <p>This convenience method couples the Artifactory-specific download step to the
+     * container-free contract assertion in {@link #assertReleaseArtifactContract(Path)}.
+     * For release flows that do not publish to Artifactory (e.g. a GitHub Releases harness
+     * test), download the archive separately and call
+     * {@link #assertReleaseArtifactContract(Path)} directly.
+     *
      * @return extracted archive directory
      */
     public static Path assertPublishedReleaseArtifactContract(HttpClient httpClient,
@@ -72,7 +78,14 @@ public final class ReleaseArtifactContractDelegate {
     }
 
     /**
-     * Validates required release artifact structure and metadata files.
+     * Validates the required release artifact structure and metadata files.
+     *
+     * <p>Intentionally decoupled from {@link ArtifactoryContainer}: this method operates
+     * solely on an extracted archive directory and is the reusable contract validator for
+     * alternate release flows (e.g. a future GitHub Releases harness test that downloads
+     * the artifact directly from Gitea and extracts it locally before asserting the
+     * contract). The Artifactory-bound entry point lives at
+     * {@link #assertPublishedReleaseArtifactContract(HttpClient, ArtifactoryContainer)}.
      */
     public static void assertReleaseArtifactContract(Path extractedDir) {
         Path metadataFile = extractedDir.resolve("META-INF/metadata.json");


### PR DESCRIPTION
## Summary

- Parameterize `CiWorkflowHarnessTest.RepositorySeeder` with an explicit template-archive resource name (default `repo-template.zip`, behaviour preserved) so #161's Mode 2 archive can be plugged in without touching the seeder.
- Strengthen JavaDoc on `ReleaseArtifactContractDelegate` to make the existing decoupling explicit — `assertReleaseArtifactContract(Path)` is documented as the reusable, container-free contract validator for a future GitHub Releases harness test.
- Scope refinement: items 1 and 3 in #167's original body are obsolete on current `main` (no `OPENAI_API_KEY` injection in `configureRepositoryVariables`; no `generate-test-support` references in `acceptance-tests/`).

## Closes / refs

- Refs #167 (closeout comment posted with full scope analysis).
- Does not close #167 — leaves room for follow-ups (#163-driven GitHub Releases test, #161 archive-name plug-in).

## Test plan

- [x] `cd acceptance-tests && ../mvnw -q test-compile` — passes (1.2 s on JDK 21).
- [x] `cd acceptance-tests && ../mvnw test -Dtest=CiWorkflowHarnessTest` — fails on workflow conclusion assertion (line 197). **Control run with the two #167 files reverted to `main` fails identically** (same assertion, same message, same elapsed time). This is a pre-existing regression tracked in #173 (suspected: PR #162's new `.github/actions/checkout-repo` composite action cannot resolve `actions/checkout@v4` inside the test's Gitea Actions runner).
- [x] Reviewed for byte-equivalence: when the 2-arg constructor is used, both branches flow through identical `resourceStream()` logic with the same resource name string. No behaviour change at the default.
- [ ] AC2 of #167 ("test passes on current `main`") cannot be verified locally until #173 is fixed.

## Files changed

- `acceptance-tests/src/test/java/dev/promptlm/test/CiWorkflowHarnessTest.java` (+17, -3)
- `acceptance-tests/src/test/java/dev/promptlm/test/support/ReleaseArtifactContractDelegate.java` (+13, -1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)