### PR TITLE
fix(template): conditional language jobs and Python version guard in build-artifacts (#168)

### DIFF
--- a/components/repository-template/repo-resources/.github/workflows/build-artifacts.yml
+++ b/components/repository-template/repo-resources/.github/workflows/build-artifacts.yml
@@ -4,7 +4,54 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  read-config:
+    runs-on: ubuntu-latest
+    outputs:
+      has_java: ${{ steps.parse.outputs.has_java }}
+      has_python: ${{ steps.parse.outputs.has_python }}
+      has_js: ${{ steps.parse.outputs.has_js }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Parse artifacts.toml
+        id: parse
+        shell: bash
+        run: |
+          python <<'PY' >> "$GITHUB_OUTPUT"
+          import sys
+          if sys.version_info < (3, 11):
+              raise SystemExit(
+                  "ERROR: Python 3.11 or later is required (found {}.{})".format(
+                      *sys.version_info[:2]
+                  )
+              )
+          import tomllib
+          from pathlib import Path
+
+          manifest_path = Path(".promptlm/artifacts.toml")
+          targets: list[str] = []
+          if manifest_path.exists():
+              with manifest_path.open("rb") as handle:
+                  manifest = tomllib.load(handle)
+              raw = manifest.get("project", {}).get("targets")
+              if raw is None:
+                  raw = manifest.get("targets")
+              if isinstance(raw, list):
+                  targets = [str(t).strip() for t in raw if str(t).strip()]
+
+          for lang in ("java", "python", "js"):
+              print(f"has_{lang}={'true' if lang in targets else 'false'}")
+          PY
+
   build-java:
+    needs: read-config
+    if: needs.read-config.outputs.has_java == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -32,6 +79,8 @@ jobs:
           path: dist/java/
 
   build-python:
+    needs: read-config
+    if: needs.read-config.outputs.has_python == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -56,6 +105,8 @@ jobs:
           path: dist/python/
 
   build-js:
+    needs: read-config
+    if: needs.read-config.outputs.has_js == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -65,11 +116,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
 
       - name: Build JS artifacts
         run: ./tools/release/build-artifacts --target js

--- a/components/repository-template/repo-resources/tools/release/build-artifacts
+++ b/components/repository-template/repo-resources/tools/release/build-artifacts
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
+import sys
+
+if sys.version_info < (3, 11):
+    raise SystemExit(
+        "ERROR: Python 3.11 or later is required (found {}.{})".format(
+            *sys.version_info[:2]
+        )
+    )
+
 import argparse
 import json
 import shutil
 import subprocess
-import sys
+import tomllib  # Python 3.11+
 from pathlib import Path
-
-try:
-    import tomllib  # Python 3.11+
-except ModuleNotFoundError:  # pragma: no cover
-    tomllib = None
 
 
 def eprint(message: str) -> None:
@@ -21,8 +25,6 @@ def run(cmd, cwd=None) -> None:
 
 
 def read_toml(path: Path) -> dict:
-    if tomllib is None:
-        raise RuntimeError("Python 3.11+ is required (tomllib missing).")
     with path.open("rb") as handle:
         return tomllib.load(handle)
 

--- a/components/repository-template/repo-resources/tools/release/publish-artifacts
+++ b/components/repository-template/repo-resources/tools/release/publish-artifacts
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
+import sys
+
+if sys.version_info < (3, 11):
+    raise SystemExit(
+        "ERROR: Python 3.11 or later is required (found {}.{})".format(
+            *sys.version_info[:2]
+        )
+    )
+
 import argparse
 import shutil
 import subprocess
-import sys
+import tomllib  # Python 3.11+
 from pathlib import Path
-
-try:
-    import tomllib  # Python 3.11+
-except ModuleNotFoundError:  # pragma: no cover
-    tomllib = None
 
 
 def eprint(message: str) -> None:
@@ -20,8 +24,6 @@ def run(cmd, cwd=None) -> None:
 
 
 def read_toml(path: Path) -> dict:
-    if tomllib is None:
-        raise RuntimeError("Python 3.11+ is required (tomllib missing).")
     with path.open("rb") as handle:
         return tomllib.load(handle)
 


### PR DESCRIPTION
## Summary

- Add a `read-config` job to `build-artifacts.yml` that parses `.promptlm/artifacts.toml` with `tomllib` and emits `has_java` / `has_python` / `has_js` outputs; gate each language job on the corresponding flag (addresses F-021).
- Add an explicit `sys.version_info < (3, 11)` startup guard to `tools/release/build-artifacts` and `tools/release/publish-artifacts` so they fail loudly instead of silently returning 0 on older Python (addresses F-025).
- Remove the redundant `Set up Python` step from `build-js`; `build-artifacts --target js` only needs Node + npm (addresses F-026).

Closes #168.

## Acceptance criteria

- [x] `read-config` job emits `has_java`, `has_python`, `has_js` outputs from `artifacts.toml`.
- [x] `build-java`, `build-python`, `build-js` gated by `if: needs.read-config.outputs.has_<lang> == 'true'`.
- [x] Scripts raise `SystemExit("ERROR: Python 3.11 or later is required ...")` before any TOML parse on Python < 3.11.
- [x] `build-js` no longer sets up Python.
- [x] Missing manifest / missing `targets =` line → all language jobs skipped (no failures).

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` on both scripts → OK.
- [x] `--help` smoke run on Python 3.14 for both scripts.
- [x] `yaml.safe_load` of `build-artifacts.yml` → 4 jobs, correct `needs`/`if` graph, no Python step in `build-js`.
- [x] read-config Python block run against three fixtures: `targets=["python"]`, no `targets =` line, missing manifest — outputs as expected.
- [x] Simulated `(3, 10) < (3, 11)` exercises the guard message.
- [x] `./mvnw -pl components/repository-template -am test -Dtest=RepositoryTemplateZipContentsTest` → 1 test, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)