### PR TITLE
feat(repository-template): add promptlm.yml and release capability toggle (#161)

### DIFF
--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractor.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractor.java
@@ -23,11 +23,20 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -36,6 +45,24 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
 
     private static final Logger log = LoggerFactory.getLogger(ZipFileRepositoryTemplateExtractor.class);
     private static final String DEFAULT_TEMPLATE_ARCHIVE = "repo-template.zip";
+    private static final String CONFIG_FILE_NAME = "promptlm.yml";
+
+    /**
+     * Entries that are only relevant in Mode 2 (release-enabled). When
+     * {@code release.enabled} is {@code false} in the generated repository's
+     * {@value #CONFIG_FILE_NAME}, these files are skipped during extraction so
+     * that the produced repository is a plain prompt-management store with no
+     * CI/CD or build pipeline noise.
+     *
+     * @see <a href="https://github.com/promptLM/promptlm-app/issues/161">Issue #161</a>
+     */
+    private static final List<Pattern> RELEASE_ONLY_PATH_PATTERNS = List.of(
+            Pattern.compile("^\\.github/.*"),
+            Pattern.compile("^tools/.*"),
+            Pattern.compile("^scripts/.*"),
+            Pattern.compile("^pom\\.xml$"),
+            Pattern.compile("^\\.promptlm/artifacts\\.toml$")
+    );
 
     private final Resource templateArchive;
 
@@ -48,26 +75,109 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
     }
 
     public void extractTo(Path repoPath) {
-        try (InputStream zipInputStream = templateArchive.getInputStream();
-             ZipInputStream zis = new ZipInputStream(zipInputStream)) {
+        Map<String, byte[]> entries = readAllEntries();
+        boolean releaseEnabled = isReleaseEnabled(entries.get(CONFIG_FILE_NAME));
+        log.debug("Repository template release.enabled resolved to {}", releaseEnabled);
 
-            ZipEntry entry;
-            while ((entry = zis.getNextEntry()) != null) {
-                Path targetPath = repoPath.resolve(entry.getName());
-
-                if (entry.isDirectory()) {
-                    Files.createDirectories(targetPath);
-                } else {
-                    Files.createDirectories(targetPath.getParent());
-                    Files.copy(zis, targetPath, StandardCopyOption.REPLACE_EXISTING);
+        try {
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                String name = entry.getKey();
+                if (!releaseEnabled && isReleaseOnly(name)) {
+                    log.debug("Skipping release-only template entry (release.enabled=false): {}", name);
+                    continue;
                 }
-
-                zis.closeEntry();
+                Path targetPath = repoPath.resolve(name);
+                Files.createDirectories(targetPath.getParent());
+                Files.copy(new ByteArrayInputStream(entry.getValue()), targetPath, StandardCopyOption.REPLACE_EXISTING);
             }
-
             log.debug("Successfully extracted repository template to: {}", repoPath);
         } catch (IOException e) {
             throw new RuntimeException("Failed to extract repository template", e);
         }
+    }
+
+    private Map<String, byte[]> readAllEntries() {
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        try (InputStream zipInputStream = templateArchive.getInputStream();
+             ZipInputStream zis = new ZipInputStream(zipInputStream)) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    zis.closeEntry();
+                    continue;
+                }
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                zis.transferTo(buffer);
+                entries.put(entry.getName(), buffer.toByteArray());
+                zis.closeEntry();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read repository template archive", e);
+        }
+        return entries;
+    }
+
+    private static boolean isReleaseOnly(String entryName) {
+        for (Pattern pattern : RELEASE_ONLY_PATH_PATTERNS) {
+            if (pattern.matcher(entryName).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Parse {@code release.enabled} from the template's {@code promptlm.yml}.
+     * Defaults to {@code false} when the file is missing or the flag cannot be
+     * read so that the safer Mode 1 (prompt management) layout is produced.
+     *
+     * <p>The parsing intentionally avoids pulling in a full YAML library here:
+     * only one flag is consulted and it sits at a fixed location in the
+     * template. A regex over the indented {@code release.enabled} key is
+     * sufficient and keeps this low-level component dependency-free.
+     */
+    static boolean isReleaseEnabled(byte[] configBytes) {
+        if (configBytes == null || configBytes.length == 0) {
+            return false;
+        }
+        String yaml = new String(configBytes, StandardCharsets.UTF_8);
+        Matcher matcher = Pattern
+                .compile("(?m)^\\s+enabled:\\s*(true|false)\\b")
+                .matcher(stripCommentsAndIsolateReleaseBlock(yaml));
+        if (matcher.find()) {
+            return Boolean.parseBoolean(matcher.group(1));
+        }
+        return false;
+    }
+
+    private static String stripCommentsAndIsolateReleaseBlock(String yaml) {
+        List<String> lines = new ArrayList<>();
+        boolean inReleaseBlock = false;
+        for (String rawLine : yaml.split("\\R", -1)) {
+            String line = stripInlineComment(rawLine);
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (line.startsWith("release:")) {
+                inReleaseBlock = true;
+                continue;
+            }
+            if (inReleaseBlock) {
+                if (!Character.isWhitespace(line.charAt(0))) {
+                    break;
+                }
+                lines.add(line);
+            }
+        }
+        return String.join("\n", lines);
+    }
+
+    private static String stripInlineComment(String line) {
+        int hashIndex = line.indexOf('#');
+        if (hashIndex < 0) {
+            return line;
+        }
+        return line.substring(0, hashIndex);
     }
 }

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorReleaseToggleTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorReleaseToggleTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.ByteArrayResource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises the {@code release.enabled} gate in
+ * {@link ZipFileRepositoryTemplateExtractor}. The extractor reads the
+ * embedded {@code promptlm.yml} and skips Mode-2-only entries when
+ * {@code release.enabled: false}. See issue #161.
+ */
+class ZipFileRepositoryTemplateExtractorReleaseToggleTest {
+
+    private static final String MODE_1_YAML = """
+            release:
+              enabled: false
+              provider: github-actions
+            """;
+
+    private static final String MODE_2_YAML = """
+            release:
+              enabled: true
+              provider: github-actions
+            """;
+
+    @Test
+    void releaseDisabledOmitsMode2OnlyFiles(@TempDir Path tempDir) throws IOException {
+        byte[] zip = buildFullTemplateArchive(MODE_1_YAML);
+
+        new ZipFileRepositoryTemplateExtractor(new ByteArrayResource(zip)).extractTo(tempDir);
+
+        assertThat(tempDir.resolve("promptlm.yml")).exists();
+        assertThat(tempDir.resolve(".promptlm/metadata.json")).exists();
+        assertThat(tempDir.resolve(".promptlm/prompts-meta.json")).exists();
+        assertThat(tempDir.resolve("prompts/examples/hello.md")).exists();
+        assertThat(tempDir.resolve("README.md")).exists();
+
+        // Mode 2 release infrastructure must be absent.
+        assertThat(tempDir.resolve(".github")).doesNotExist();
+        assertThat(tempDir.resolve("tools")).doesNotExist();
+        assertThat(tempDir.resolve("scripts")).doesNotExist();
+        assertThat(tempDir.resolve("pom.xml")).doesNotExist();
+        assertThat(tempDir.resolve(".promptlm/artifacts.toml")).doesNotExist();
+    }
+
+    @Test
+    void releaseEnabledIncludesMode2Files(@TempDir Path tempDir) throws IOException {
+        byte[] zip = buildFullTemplateArchive(MODE_2_YAML);
+
+        new ZipFileRepositoryTemplateExtractor(new ByteArrayResource(zip)).extractTo(tempDir);
+
+        assertThat(tempDir.resolve("promptlm.yml")).exists();
+        assertThat(tempDir.resolve(".github/workflows/build-artifacts.yml")).exists();
+        assertThat(tempDir.resolve("tools/release/build-artifacts")).exists();
+        assertThat(tempDir.resolve("pom.xml")).exists();
+        assertThat(tempDir.resolve(".promptlm/artifacts.toml")).exists();
+    }
+
+    @Test
+    void missingPromptlmYmlFallsBackToMode1(@TempDir Path tempDir) throws IOException {
+        byte[] zip = buildArchive(builder -> {
+            builder.write("README.md", "readme");
+            builder.write(".github/workflows/build-artifacts.yml", "name: build");
+            builder.write("pom.xml", "<project/>");
+        });
+
+        new ZipFileRepositoryTemplateExtractor(new ByteArrayResource(zip)).extractTo(tempDir);
+
+        // Without an explicit opt-in, default to the safer Mode 1 layout.
+        assertThat(tempDir.resolve("README.md")).exists();
+        assertThat(tempDir.resolve(".github")).doesNotExist();
+        assertThat(tempDir.resolve("pom.xml")).doesNotExist();
+    }
+
+    @Test
+    void isReleaseEnabledRecognisesTrueRegardlessOfWhitespace() {
+        assertThat(ZipFileRepositoryTemplateExtractor.isReleaseEnabled(MODE_1_YAML.getBytes(StandardCharsets.UTF_8)))
+                .isFalse();
+        assertThat(ZipFileRepositoryTemplateExtractor.isReleaseEnabled(MODE_2_YAML.getBytes(StandardCharsets.UTF_8)))
+                .isTrue();
+    }
+
+    @Test
+    void isReleaseEnabledIgnoresUnrelatedEnabledKeys() {
+        String yaml = """
+                release:
+                  enabled: false
+                  validation:
+                    enabled: true
+                """;
+        assertThat(ZipFileRepositoryTemplateExtractor.isReleaseEnabled(yaml.getBytes(StandardCharsets.UTF_8)))
+                .as("Only the top-level release.enabled flag should control the gate, not nested enabled keys")
+                .isFalse();
+    }
+
+    @Test
+    void isReleaseEnabledDefaultsToFalseOnEmptyInput() {
+        assertThat(ZipFileRepositoryTemplateExtractor.isReleaseEnabled(null)).isFalse();
+        assertThat(ZipFileRepositoryTemplateExtractor.isReleaseEnabled(new byte[0])).isFalse();
+    }
+
+    private static byte[] buildFullTemplateArchive(String promptlmYml) throws IOException {
+        return buildArchive(builder -> {
+            builder.write("promptlm.yml", promptlmYml);
+            builder.write("README.md", "readme");
+            builder.write(".promptlm/metadata.json", "{}");
+            builder.write(".promptlm/prompts-meta.json", "{}");
+            builder.write(".promptlm/artifacts.toml", "[project]");
+            builder.write("prompts/examples/hello.md", "hello");
+            builder.write(".github/workflows/build-artifacts.yml", "name: build");
+            builder.write(".github/workflows/deploy-artifacts.yml", "name: deploy");
+            builder.write(".github/artifactory-config.yml", "config");
+            builder.write("tools/release/build-artifacts", "#!/bin/sh");
+            builder.write("pom.xml", "<project/>");
+        });
+    }
+
+    private static byte[] buildArchive(ArchivePopulator populator) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+            populator.populate(new ArchiveBuilder(zipOutputStream));
+        }
+        return outputStream.toByteArray();
+    }
+
+    @FunctionalInterface
+    private interface ArchivePopulator {
+        void populate(ArchiveBuilder builder) throws IOException;
+    }
+
+    private record ArchiveBuilder(ZipOutputStream zipOutputStream) {
+        void write(String entryName, String content) throws IOException {
+            zipOutputStream.putNextEntry(new ZipEntry(entryName));
+            zipOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeEntry();
+        }
+    }
+}

--- a/components/repository-template/repo-resources/README.md
+++ b/components/repository-template/repo-resources/README.md
@@ -12,7 +12,7 @@ This repository can be used in one of two modes. The mode is selected by the `re
 
 ### Mode 1 — Prompt management (default)
 
-Use this repository as a plain git store for your prompts. Edit prompts under `prompts/`, commit, push. The included build and deploy workflows stay no-ops unless `.promptlm/artifacts.toml` is configured, so you can ignore them.
+Use this repository as a plain git store for your prompts. Edit prompts under `prompts/`, commit, push. With `release.enabled: false` in `promptlm.yml` (the default), the generated repository ships **without** CI/CD workflows, build scripts, `pom.xml`, or `.promptlm/artifacts.toml` — it is the minimal prompt-management layout.
 
 ### Mode 2 — Prompt releases (opt-in)
 

--- a/components/repository-template/repo-resources/promptlm.yml
+++ b/components/repository-template/repo-resources/promptlm.yml
@@ -1,0 +1,36 @@
+# promptLM repository configuration.
+#
+# This file is the canonical entry point for promptLM behaviour in this
+# repository. The most important setting is `release.enabled`:
+#
+#   release.enabled: false  (default) — Mode 1, "Prompt management"
+#     The repository is a plain git store for prompts under `prompts/`.
+#     No CI/CD workflows, no Maven/Artifactory tooling, no `artifacts.toml`,
+#     and no `pom.xml` are generated.
+#
+#   release.enabled: true                — Mode 2, "Prompt releases"
+#     The repository additionally ships GitHub Actions workflows, build
+#     scripts under `tools/`, `.promptlm/artifacts.toml`, and a `pom.xml`
+#     for building, validating, and publishing versioned prompt artifacts.
+#
+# Flip `release.enabled` and regenerate the repository to switch modes.
+release:
+  enabled: false
+  provider: github-actions
+  trigger:
+    type: tag
+    tagPattern: "v*.*.*"
+    workflowDispatch: true
+  artifact:
+    name: "${repository.name}"
+    format: zip
+    outputDirectory: dist
+    includeManifest: true
+    includeChecksums: true
+  versioning:
+    strategy: semver
+    source: git-tag
+  validation:
+    enabled: true
+    failOnEmpty: true
+    failOnMissingMetadata: true

--- a/components/repository-template/src/assembly/repo-template.xml
+++ b/components/repository-template/src/assembly/repo-template.xml
@@ -14,6 +14,7 @@
             <includes>
                 <include>.promptlm/**</include>
                 <include>prompts/**</include>
+                <include>promptlm.yml</include>
                 <include>pom.xml</include>
                 <include>README.md</include>
                 <include>.github/artifactory-config.yml</include>

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplatePromptlmYmlTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplatePromptlmYmlTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.repository.template;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Verifies the bundled {@code promptlm.yml} template defaults to Mode 1
+ * (release disabled) and ships the full schema required by issue #161.
+ */
+class RepositoryTemplatePromptlmYmlTest {
+
+    @Test
+    void promptlmYmlIsPackagedInTheTemplateArchive() throws Exception {
+        String content = readPromptlmYmlFromTemplateZip();
+        assertThat(content)
+                .as("promptlm.yml must be bundled in repo-template.zip (issue #161)")
+                .isNotNull();
+    }
+
+    @Test
+    void promptlmYmlDefaultsReleaseEnabledToFalse() throws Exception {
+        String content = readPromptlmYmlFromTemplateZip();
+        // The default must be Mode 1 (prompt management) so private users do
+        // not unexpectedly receive a full CI/CD pipeline.
+        assertThat(content)
+                .as("Default promptlm.yml must set release.enabled to false (issue #161, F-007/F-010)")
+                .containsPattern("(?m)^\\s+enabled:\\s*false\\b");
+    }
+
+    @Test
+    void promptlmYmlExposesTheFullReleaseSchema() throws Exception {
+        String content = readPromptlmYmlFromTemplateZip();
+        assertThat(content).contains("release:");
+        assertThat(content).contains("provider: github-actions");
+        assertThat(content).contains("trigger:");
+        assertThat(content).contains("tagPattern:");
+        assertThat(content).contains("workflowDispatch:");
+        assertThat(content).contains("artifact:");
+        assertThat(content).contains("includeManifest:");
+        assertThat(content).contains("includeChecksums:");
+        assertThat(content).contains("versioning:");
+        assertThat(content).contains("strategy: semver");
+        assertThat(content).contains("source: git-tag");
+        assertThat(content).contains("validation:");
+        assertThat(content).contains("failOnEmpty:");
+        assertThat(content).contains("failOnMissingMetadata:");
+    }
+
+    private String readPromptlmYmlFromTemplateZip() throws Exception {
+        try (InputStream resource = getClass().getClassLoader().getResourceAsStream("repo-template.zip")) {
+            assertNotNull(resource, "repo-template.zip must be packaged in module resources");
+            try (ZipInputStream zip = new ZipInputStream(resource)) {
+                ZipEntry entry;
+                while ((entry = zip.getNextEntry()) != null) {
+                    if (!entry.isDirectory() && "promptlm.yml".equals(entry.getName())) {
+                        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                        zip.transferTo(buffer);
+                        return buffer.toString(StandardCharsets.UTF_8);
+                    }
+                }
+            }
+        }
+        throw new AssertionError("promptlm.yml not found in repo-template.zip");
+    }
+}

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateZipContentsTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateZipContentsTest.java
@@ -54,6 +54,7 @@ class RepositoryTemplateZipContentsTest {
                     ".promptlm/prompts-meta.json",
                     "README.md",
                     "pom.xml",
+                    "promptlm.yml",
                     "prompts/.gitignore",
                     "prompts/examples/hello.md",
                     "tools/release/build-artifacts",


### PR DESCRIPTION
Closes #161. Addresses findings F-007, F-010, F-011 from epic #159.

## Summary

- Adds a canonical `promptlm.yml` at the generated repository root, populated with the full release schema (provider, trigger, artifact, versioning, validation) from the issue spec.
- Default `release.enabled: false` produces a **Mode 1** repository: no `.github/`, no `tools/`, no `scripts/`, no `pom.xml`, no `.promptlm/artifacts.toml` — a clean prompt-management store for private users.
- Setting `release.enabled: true` produces a **Mode 2** repository with the full release infrastructure (workflow contents themselves remain the scope of #163).
- `ZipFileRepositoryTemplateExtractor` reads the toggle at extraction time and filters Mode-2-only entries before writing, so a single bundled template archive serves both modes.

## Why parse YAML by hand?

The extractor lives in `promptlm-store-github` and intentionally has no dependency on Jackson/YAML libraries. Only a single top-level key (`release.enabled`) is consulted, so a tight regex confined to the `release:` block is sufficient and avoids coupling the low-level component to domain serialization. Missing/empty config falls back to the safer Mode 1, and nested `enabled:` keys (such as `validation.enabled`) are explicitly ignored.

## Coordination with sibling work

- **#160 (template substitution):** This PR uses neutral, substitution-free defaults in `promptlm.yml` (the literal `${repository.name}` token is documentary, not parsed). No conflict expected.
- **#163 (release workflow):** Workflow contents are out of scope here. The toggle/config model is the prerequisite.
- **#165 (ReleaseTemplateProvider abstraction):** Not introduced here. The current single-archive + filter approach is minimal and keeps the door open for #165 to refactor without churning this PR.
- **#168 (build-artifacts.yml fixes):** Untouched.

## Test plan

- [x] `RepositoryTemplatePromptlmYmlTest` — `promptlm.yml` is packaged, defaults to `release.enabled: false`, exposes the full schema.
- [x] `RepositoryTemplateZipContentsTest` — updated expected entries to include `promptlm.yml`.
- [x] `ZipFileRepositoryTemplateExtractorReleaseToggleTest` — six cases covering Mode 1 (excludes `.github`/`tools`/`scripts`/`pom.xml`/`artifacts.toml`), Mode 2 (includes them), missing-config fallback, nested-key insensitivity, and empty/null inputs.
- [x] Existing `ZipFileRepositoryRepositoryTemplateExtractorTest`, `GitProjectServiceTest`, `RepositoryTemplateReadmeContentTest`, `RepositoryTemplateActSmokeTest` all green locally.
- [x] Full module reactor (`repository-template`, `promptlm-store-github` and deps): 80 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)