### PR TITLE
feat(template): substitute template variables during repository extraction (#160)

### DIFF
--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitProjectService.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitProjectService.java
@@ -20,6 +20,8 @@ import dev.promptlm.domain.AppContext;
 import dev.promptlm.domain.events.ProjectCreatedEvent;
 import dev.promptlm.domain.projectspec.ProjectSpec;
 import dev.promptlm.repository.template.RepositoryTemplateExtractor;
+import dev.promptlm.repository.template.TemplateContext;
+import dev.promptlm.repository.template.TemplateSubstitutionEngine;
 import dev.promptlm.store.api.ProjectService;
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
 import dev.promptlm.store.api.RepositoryOwner;
@@ -31,6 +33,7 @@ import org.springframework.util.StringUtils;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 
 @Component
@@ -38,6 +41,7 @@ public class GitProjectService implements ProjectService {
 
     private static final Logger log = LoggerFactory.getLogger(GitProjectService.class);
     public static final String DEVELOPMENT_BRANCH = "development";
+    static final String DEFAULT_PROJECT_DESCRIPTION = "prompts managed by promptLM";
     private final AppContext appContext;
     private final GitHubProperties gitHubProperties;
     private final Git git;
@@ -93,7 +97,14 @@ public class GitProjectService implements ProjectService {
 
         git.createRepository(repoPath, gitCloneUrl);
 
-        repositoryTemplateExtractor.extractTo(repoPath);
+        TemplateContext templateContext = new TemplateContext(
+                ownerAndRepo.repo(),
+                ownerAndRepo.owner(),
+                DEFAULT_PROJECT_DESCRIPTION,
+                Instant.now(),
+                TemplateSubstitutionEngine.BUILD_GENERATOR_VERSION
+        );
+        repositoryTemplateExtractor.extractTo(repoPath, templateContext);
 
         git.addAllAndCommit(repoPath.toFile(), "initial commit");
         push(repoPath);

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractor.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractor.java
@@ -17,24 +17,25 @@
 package dev.promptlm.store.github;
 
 import dev.promptlm.repository.template.RepositoryTemplateExtractor;
+import dev.promptlm.repository.template.TemplateContext;
+import dev.promptlm.repository.template.TemplateSubstitutionEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -65,16 +66,25 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
     );
 
     private final Resource templateArchive;
+    private final TemplateSubstitutionEngine substitutionEngine;
 
     public ZipFileRepositoryTemplateExtractor() {
-        this(new ClassPathResource(DEFAULT_TEMPLATE_ARCHIVE));
+        this(new ClassPathResource(DEFAULT_TEMPLATE_ARCHIVE), new TemplateSubstitutionEngine());
     }
 
     ZipFileRepositoryTemplateExtractor(Resource templateArchive) {
-        this.templateArchive = templateArchive;
+        this(templateArchive, new TemplateSubstitutionEngine());
     }
 
-    public void extractTo(Path repoPath) {
+    ZipFileRepositoryTemplateExtractor(Resource templateArchive, TemplateSubstitutionEngine substitutionEngine) {
+        this.templateArchive = templateArchive;
+        this.substitutionEngine = substitutionEngine;
+    }
+
+    @Override
+    public void extractTo(Path repoPath, TemplateContext context) {
+        Objects.requireNonNull(context, "context");
+
         Map<String, byte[]> entries = readAllEntries();
         boolean releaseEnabled = isReleaseEnabled(entries.get(CONFIG_FILE_NAME));
         log.debug("Repository template release.enabled resolved to {}", releaseEnabled);
@@ -88,7 +98,11 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
                 }
                 Path targetPath = repoPath.resolve(name);
                 Files.createDirectories(targetPath.getParent());
-                Files.copy(new ByteArrayInputStream(entry.getValue()), targetPath, StandardCopyOption.REPLACE_EXISTING);
+                byte[] payload = entry.getValue();
+                if (substitutionEngine.isTextEntry(name)) {
+                    payload = substitutionEngine.substitute(name, payload, context);
+                }
+                Files.write(targetPath, payload);
             }
             log.debug("Successfully extracted repository template to: {}", repoPath);
         } catch (IOException e) {

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitProjectServiceTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitProjectServiceTest.java
@@ -20,6 +20,8 @@ import dev.promptlm.domain.BasicAppContext;
 import dev.promptlm.domain.events.ProjectCreatedEvent;
 import dev.promptlm.domain.projectspec.ProjectSpec;
 import dev.promptlm.repository.template.RepositoryTemplateExtractor;
+import dev.promptlm.repository.template.TemplateContext;
+import dev.promptlm.repository.template.TemplateSubstitutionEngine;
 import dev.promptlm.store.api.ProjectService;
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
 import dev.promptlm.store.api.RepositoryOwner;
@@ -108,7 +110,13 @@ class GitProjectServiceTest {
         assertThat(projectSpec.getRepoUrl()).isEqualTo(remoteUrl);
 
         verify(git).createRepository(repoDir, remoteUrl);
-        verify(templateExtractor).extractTo(repoDir);
+        verify(templateExtractor).extractTo(eq(repoDir), argThat((TemplateContext ctx) ->
+                ctx != null
+                        && projectName.equals(ctx.repositoryName())
+                        && owner.equals(ctx.ownerName())
+                        && GitProjectService.DEFAULT_PROJECT_DESCRIPTION.equals(ctx.projectDescription())
+                        && ctx.createdAt() != null
+                        && TemplateSubstitutionEngine.BUILD_GENERATOR_VERSION.equals(ctx.generatorVersion())));
         verify(git).addAllAndCommit(repoDir.toFile(), "initial commit");
         verify(git).checkoutOrCreateBranch(GitProjectService.DEVELOPMENT_BRANCH, repoDir.toFile());
         verify(git, times(2)).pushAll(repoDir.toFile());

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryRepositoryTemplateExtractorTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryRepositoryTemplateExtractorTest.java
@@ -16,6 +16,7 @@
 
 package dev.promptlm.store.github;
 
+import dev.promptlm.repository.template.TemplateContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.core.io.ByteArrayResource;
@@ -25,6 +26,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -37,7 +39,7 @@ class ZipFileRepositoryRepositoryTemplateExtractorTest {
         byte[] zipBytes = createTemplateArchive();
         ZipFileRepositoryTemplateExtractor extractor = new ZipFileRepositoryTemplateExtractor(new ByteArrayResource(zipBytes));
 
-        extractor.extractTo(tempDir);
+        extractor.extractTo(tempDir, sampleContext());
 
         Path readme = tempDir.resolve("README.md");
         Path nested = tempDir.resolve("docs/info.txt");
@@ -45,6 +47,15 @@ class ZipFileRepositoryRepositoryTemplateExtractorTest {
         assertThat(nested).exists();
         assertThat(Files.readString(readme)).isEqualTo("hello world");
         assertThat(Files.readString(nested)).isEqualTo("more info");
+    }
+
+    private static TemplateContext sampleContext() {
+        return new TemplateContext(
+                "sample-repo",
+                "sample-owner",
+                "sample description",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                "1.2.3");
     }
 
     private byte[] createTemplateArchive() throws IOException {

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorReleaseToggleTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorReleaseToggleTest.java
@@ -16,6 +16,7 @@
 
 package dev.promptlm.store.github;
 
+import dev.promptlm.repository.template.TemplateContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.core.io.ByteArrayResource;
@@ -24,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -53,7 +55,7 @@ class ZipFileRepositoryTemplateExtractorReleaseToggleTest {
     void releaseDisabledOmitsMode2OnlyFiles(@TempDir Path tempDir) throws IOException {
         byte[] zip = buildFullTemplateArchive(MODE_1_YAML);
 
-        new ZipFileRepositoryTemplateExtractor(new ByteArrayResource(zip)).extractTo(tempDir);
+        new ZipFileRepositoryTemplateExtractor(new ByteArrayResource(zip)).extractTo(tempDir, sampleContext());
 
         assertThat(tempDir.resolve("promptlm.yml")).exists();
         assertThat(tempDir.resolve(".promptlm/metadata.json")).exists();
@@ -73,7 +75,7 @@ class ZipFileRepositoryTemplateExtractorReleaseToggleTest {
     void releaseEnabledIncludesMode2Files(@TempDir Path tempDir) throws IOException {
         byte[] zip = buildFullTemplateArchive(MODE_2_YAML);
 
-        new ZipFileRepositoryTemplateExtractor(new ByteArrayResource(zip)).extractTo(tempDir);
+        new ZipFileRepositoryTemplateExtractor(new ByteArrayResource(zip)).extractTo(tempDir, sampleContext());
 
         assertThat(tempDir.resolve("promptlm.yml")).exists();
         assertThat(tempDir.resolve(".github/workflows/build-artifacts.yml")).exists();
@@ -90,7 +92,7 @@ class ZipFileRepositoryTemplateExtractorReleaseToggleTest {
             builder.write("pom.xml", "<project/>");
         });
 
-        new ZipFileRepositoryTemplateExtractor(new ByteArrayResource(zip)).extractTo(tempDir);
+        new ZipFileRepositoryTemplateExtractor(new ByteArrayResource(zip)).extractTo(tempDir, sampleContext());
 
         // Without an explicit opt-in, default to the safer Mode 1 layout.
         assertThat(tempDir.resolve("README.md")).exists();
@@ -123,6 +125,15 @@ class ZipFileRepositoryTemplateExtractorReleaseToggleTest {
     void isReleaseEnabledDefaultsToFalseOnEmptyInput() {
         assertThat(ZipFileRepositoryTemplateExtractor.isReleaseEnabled(null)).isFalse();
         assertThat(ZipFileRepositoryTemplateExtractor.isReleaseEnabled(new byte[0])).isFalse();
+    }
+
+    private static TemplateContext sampleContext() {
+        return new TemplateContext(
+                "sample-repo",
+                "sample-owner",
+                "sample description",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                "1.2.3");
     }
 
     private static byte[] buildFullTemplateArchive(String promptlmYml) throws IOException {

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorSubstitutionTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorSubstitutionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import dev.promptlm.repository.template.TemplateContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link ZipFileRepositoryTemplateExtractor} against the real
+ * {@code repo-template.zip} packaged on the classpath. Exercises the addressed acceptance
+ * criteria of issue #160:
+ *
+ * <ul>
+ *     <li>AC-7: no {@code {{...}}} tokens remain in any text file after extraction.</li>
+ *     <li>AC-8: {@code metadata.json} reflects runtime timestamp and generator version.</li>
+ *     <li>AC-9: {@code README.md} has no literal {@code {{REPO_NAME}}} / {@code {{PROJECT_DESCRIPTION}}} tokens.</li>
+ * </ul>
+ */
+class ZipFileRepositoryTemplateExtractorSubstitutionTest {
+
+    private static final List<String> TEXT_FILE_EXTENSIONS = List.of(
+            ".md", ".json", ".toml", ".yml", ".yaml", ".txt", ".xml", ".properties");
+
+    /**
+     * Matches our template-token convention: {@code {{UPPER_SNAKE}}}. Crucially, this is NOT
+     * preceded by {@code $}, so it does not match GitHub Actions expressions like
+     * {@code ${{ github.event.inputs.x }}} which are intended to survive extraction.
+     */
+    private static final Pattern UNRESOLVED_TOKEN_PATTERN =
+            Pattern.compile("(?<![$])\\{\\{\\s*[A-Z][A-Z0-9_]*\\s*}}");
+
+    @Test
+    void extractedRepoHasNoUnresolvedTemplateTokens(@TempDir Path tempDir) throws IOException {
+        ZipFileRepositoryTemplateExtractor extractor = new ZipFileRepositoryTemplateExtractor();
+        TemplateContext context = new TemplateContext(
+                "issue-160-demo",
+                "promptLM",
+                "issue-160 acceptance prompts",
+                Instant.parse("2026-05-17T01:23:45Z"),
+                "9.9.9");
+
+        extractor.extractTo(tempDir, context);
+
+        List<Path> textFiles = collectTextFiles(tempDir);
+        assertThat(textFiles).isNotEmpty();
+        for (Path file : textFiles) {
+            String content = Files.readString(file, StandardCharsets.UTF_8);
+            Matcher matcher = UNRESOLVED_TOKEN_PATTERN.matcher(content);
+            if (matcher.find()) {
+                throw new AssertionError("Unresolved template token '" + matcher.group()
+                        + "' remains in " + tempDir.relativize(file));
+            }
+        }
+    }
+
+    @Test
+    void readmeContainsSubstitutedRepoNameAndDescription(@TempDir Path tempDir) throws IOException {
+        ZipFileRepositoryTemplateExtractor extractor = new ZipFileRepositoryTemplateExtractor();
+        TemplateContext context = new TemplateContext(
+                "issue-160-demo",
+                "promptLM",
+                "issue-160 acceptance prompts",
+                Instant.parse("2026-05-17T01:23:45Z"),
+                "9.9.9");
+
+        extractor.extractTo(tempDir, context);
+
+        String readme = Files.readString(tempDir.resolve("README.md"), StandardCharsets.UTF_8);
+        assertThat(readme).contains("# issue-160-demo");
+        assertThat(readme).contains("issue-160 acceptance prompts");
+        assertThat(readme).doesNotContain("{{REPO_NAME}}");
+        assertThat(readme).doesNotContain("{{PROJECT_DESCRIPTION}}");
+    }
+
+    @Test
+    void metadataJsonHasRuntimeTimestampAndGeneratorVersion(@TempDir Path tempDir) throws IOException {
+        ZipFileRepositoryTemplateExtractor extractor = new ZipFileRepositoryTemplateExtractor();
+        TemplateContext context = new TemplateContext(
+                "issue-160-demo",
+                "promptLM",
+                "issue-160 acceptance prompts",
+                Instant.parse("2026-05-17T01:23:45Z"),
+                "9.9.9");
+
+        extractor.extractTo(tempDir, context);
+
+        String metadata = Files.readString(tempDir.resolve(".promptlm/metadata.json"), StandardCharsets.UTF_8);
+        assertThat(metadata).contains("\"name\": \"issue-160-demo\"");
+        assertThat(metadata).contains("\"created\": \"2026-05-17T01:23:45Z\"");
+        assertThat(metadata).contains("\"updated\": \"2026-05-17T01:23:45Z\"");
+        assertThat(metadata).contains("\"generator_version\": \"9.9.9\"");
+        assertThat(metadata).doesNotContain("2025-01-19T22:42:35Z");
+        assertThat(metadata).doesNotContain("0.1.0-SNAPSHOT");
+        assertThat(metadata).doesNotContain("{{");
+    }
+
+    private static List<Path> collectTextFiles(Path root) throws IOException {
+        List<Path> files = new ArrayList<>();
+        try (Stream<Path> walk = Files.walk(root)) {
+            walk.filter(Files::isRegularFile)
+                    .sorted(Comparator.naturalOrder())
+                    .forEach(p -> {
+                        String name = p.getFileName().toString().toLowerCase();
+                        for (String ext : TEXT_FILE_EXTENSIONS) {
+                            if (name.endsWith(ext)) {
+                                files.add(p);
+                                return;
+                            }
+                        }
+                        // Also pick up the unextensioned release scripts that we substitute.
+                        Path relative = root.relativize(p);
+                        if (relative.toString().replace('\\', '/').startsWith("tools/release/")) {
+                            files.add(p);
+                        }
+                    });
+        }
+        return files;
+    }
+}

--- a/components/repository-template/pom.xml
+++ b/components/repository-template/pom.xml
@@ -24,6 +24,15 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources-filtered</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/components/repository-template/repo-resources/.promptlm/metadata.json
+++ b/components/repository-template/repo-resources/.promptlm/metadata.json
@@ -1,10 +1,10 @@
 {
   "repository": {
-    "name": "REPLACE_ME_repository_name",
+    "name": "{{REPO_NAME}}",
     "version": "1.0.0-SNAPSHOT",
-    "description": "A repository of prompts for LLM applications",
-    "created": "2025-01-19T22:42:35Z",
-    "updated": "2025-01-19T22:42:35Z"
+    "description": "{{PROJECT_DESCRIPTION}}",
+    "created": "{{CREATED_AT}}",
+    "updated": "{{CREATED_AT}}"
   },
   "prompts": [
     {
@@ -19,6 +19,6 @@
   "metadata": {
     "format_version": "1.0",
     "generator": "promptLM",
-    "generator_version": "0.1.0-SNAPSHOT"
+    "generator_version": "{{GENERATOR_VERSION}}"
   }
 }

--- a/components/repository-template/src/main/java/dev/promptlm/repository/template/RepositoryTemplateExtractor.java
+++ b/components/repository-template/src/main/java/dev/promptlm/repository/template/RepositoryTemplateExtractor.java
@@ -19,14 +19,17 @@ package dev.promptlm.repository.template;
 import java.nio.file.Path;
 
 /**
- * Extracts repository template resources into a target directory.
+ * Extracts repository template resources into a target directory, substituting
+ * template tokens (e.g. {@code {{REPO_NAME}}}) using the supplied {@link TemplateContext}.
  */
 public interface RepositoryTemplateExtractor {
 
     /**
-     * Extract the repository template archive to the provided directory.
+     * Extract the repository template archive to the provided directory, substituting template
+     * tokens in text files using {@code context}. Binary files are copied unchanged.
      *
      * @param targetDirectory directory to populate with template contents
+     * @param context         values to substitute into template tokens; must not be {@code null}
      */
-    void extractTo(Path targetDirectory);
+    void extractTo(Path targetDirectory, TemplateContext context);
 }

--- a/components/repository-template/src/main/java/dev/promptlm/repository/template/TemplateContext.java
+++ b/components/repository-template/src/main/java/dev/promptlm/repository/template/TemplateContext.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.repository.template;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Values that the repository template extractor substitutes into the generated repository at
+ * extraction time. Carries the canonical token sources for {@code {{REPO_NAME}}},
+ * {@code {{REPO_OWNER}}}, {@code {{PROJECT_DESCRIPTION}}}, {@code {{CREATED_AT}}} and
+ * {@code {{GENERATOR_VERSION}}}.
+ *
+ * <p>{@code createdAt} is rendered as ISO-8601 UTC (e.g. {@code 2026-05-17T01:23:45Z}).
+ *
+ * <p>This is an immutable, equality-by-value record; callers should construct one per repository
+ * generation.
+ */
+public record TemplateContext(
+        String repositoryName,
+        String ownerName,
+        String projectDescription,
+        Instant createdAt,
+        String generatorVersion) {
+
+    public TemplateContext {
+        Objects.requireNonNull(repositoryName, "repositoryName");
+        Objects.requireNonNull(ownerName, "ownerName");
+        Objects.requireNonNull(projectDescription, "projectDescription");
+        Objects.requireNonNull(createdAt, "createdAt");
+        Objects.requireNonNull(generatorVersion, "generatorVersion");
+    }
+}

--- a/components/repository-template/src/main/java/dev/promptlm/repository/template/TemplateSubstitutionEngine.java
+++ b/components/repository-template/src/main/java/dev/promptlm/repository/template/TemplateSubstitutionEngine.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.repository.template;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Substitutes template tokens of the form {@code {{TOKEN}}} in text files extracted from the
+ * repository template archive. Binary files are copied through unchanged.
+ *
+ * <p>Recognized tokens:
+ * <ul>
+ *     <li>{@code {{REPO_NAME}}}</li>
+ *     <li>{@code {{REPO_OWNER}}}</li>
+ *     <li>{@code {{PROJECT_DESCRIPTION}}}</li>
+ *     <li>{@code {{CREATED_AT}}} (ISO-8601 UTC)</li>
+ *     <li>{@code {{GENERATOR_VERSION}}}</li>
+ * </ul>
+ *
+ * <p>Substitution is single-pass: substituted output is never re-scanned for tokens.
+ *
+ * <p>For files with a {@code .json} extension, replacement values are JSON-escaped so a project
+ * name that happens to contain a double-quote does not corrupt the file. For other text formats
+ * we insert values verbatim — values are user-controlled and not executed as code in any of the
+ * shipped template files.
+ *
+ * <p>The {@code GENERATOR_VERSION} token defaults to the value loaded from
+ * {@code META-INF/promptlm-repository-template.properties} (produced by Maven resource filtering)
+ * when the corresponding field in the {@link TemplateContext} is set to the sentinel
+ * {@link #BUILD_GENERATOR_VERSION}.
+ */
+public final class TemplateSubstitutionEngine {
+
+    /**
+     * Sentinel that callers can pass as {@link TemplateContext#generatorVersion()} to ask the
+     * engine to substitute the build-time generator version loaded from the filtered resource.
+     */
+    public static final String BUILD_GENERATOR_VERSION = "${build.generator.version}";
+
+    private static final String BUILD_PROPERTIES_RESOURCE =
+            "META-INF/promptlm-repository-template.properties";
+    private static final String BUILD_PROPERTY_GENERATOR_VERSION = "generator.version";
+    private static final String FALLBACK_GENERATOR_VERSION = "dev";
+
+    private static final Set<String> TEXT_EXTENSIONS = Set.of(
+            "md", "json", "toml", "yml", "yaml", "txt", "xml", "properties");
+    private static final Set<String> ALWAYS_TEXT_PATH_PREFIXES = Set.of(
+            "tools/release/");
+
+    private final String buildGeneratorVersion;
+
+    public TemplateSubstitutionEngine() {
+        this(loadBuildGeneratorVersion());
+    }
+
+    // Package-private — intended for tests that need a deterministic build-version source.
+    TemplateSubstitutionEngine(String buildGeneratorVersion) {
+        this.buildGeneratorVersion = buildGeneratorVersion;
+    }
+
+    /**
+     * @return the generator version loaded from the build-time properties resource, or
+     *         {@value #FALLBACK_GENERATOR_VERSION} if the resource is missing.
+     */
+    public String buildGeneratorVersion() {
+        return buildGeneratorVersion;
+    }
+
+    /**
+     * @return {@code true} when {@code entryName} should be treated as a text file and have
+     *         template tokens substituted.
+     */
+    public boolean isTextEntry(String entryName) {
+        if (entryName == null || entryName.isEmpty()) {
+            return false;
+        }
+        for (String prefix : ALWAYS_TEXT_PATH_PREFIXES) {
+            if (entryName.startsWith(prefix)) {
+                return true;
+            }
+        }
+        int dot = entryName.lastIndexOf('.');
+        int slash = entryName.lastIndexOf('/');
+        if (dot < 0 || dot < slash) {
+            // No file extension and not in an always-text prefix → treat as binary.
+            return false;
+        }
+        String ext = entryName.substring(dot + 1).toLowerCase(Locale.ROOT);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    /**
+     * Substitute template tokens in {@code source} using {@code context}.
+     *
+     * @param entryName the archive entry name (used to decide JSON-escaping)
+     * @param source    the raw file content read from the archive
+     * @param context   the substitution values
+     * @return substituted bytes (UTF-8)
+     */
+    public byte[] substitute(String entryName, byte[] source, TemplateContext context) {
+        String text = new String(source, StandardCharsets.UTF_8);
+        boolean jsonEscape = entryName != null && entryName.toLowerCase(Locale.ROOT).endsWith(".json");
+        Map<String, String> tokens = resolveTokens(context, jsonEscape);
+
+        StringBuilder out = new StringBuilder(text.length() + 64);
+        int i = 0;
+        while (i < text.length()) {
+            int open = text.indexOf("{{", i);
+            if (open < 0) {
+                out.append(text, i, text.length());
+                break;
+            }
+            out.append(text, i, open);
+            int close = text.indexOf("}}", open + 2);
+            if (close < 0) {
+                // Unbalanced — leave the rest as-is.
+                out.append(text, open, text.length());
+                break;
+            }
+            String token = text.substring(open + 2, close);
+            String replacement = tokens.get(token);
+            if (replacement != null) {
+                out.append(replacement);
+            } else {
+                // Unknown token — leave it as-is so downstream tests catch it.
+                out.append(text, open, close + 2);
+            }
+            i = close + 2;
+        }
+        return out.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private Map<String, String> resolveTokens(TemplateContext context, boolean jsonEscape) {
+        String generatorVersion = context.generatorVersion();
+        if (BUILD_GENERATOR_VERSION.equals(generatorVersion)) {
+            generatorVersion = buildGeneratorVersion;
+        }
+        String createdAt = DateTimeFormatter.ISO_INSTANT.format(context.createdAt());
+
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("REPO_NAME", maybeJsonEscape(context.repositoryName(), jsonEscape));
+        tokens.put("REPO_OWNER", maybeJsonEscape(context.ownerName(), jsonEscape));
+        tokens.put("PROJECT_DESCRIPTION", maybeJsonEscape(context.projectDescription(), jsonEscape));
+        tokens.put("CREATED_AT", maybeJsonEscape(createdAt, jsonEscape));
+        tokens.put("GENERATOR_VERSION", maybeJsonEscape(generatorVersion, jsonEscape));
+        return tokens;
+    }
+
+    private static String maybeJsonEscape(String value, boolean jsonEscape) {
+        if (!jsonEscape) {
+            return value;
+        }
+        StringBuilder out = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"' -> out.append("\\\"");
+                case '\\' -> out.append("\\\\");
+                case '\n' -> out.append("\\n");
+                case '\r' -> out.append("\\r");
+                case '\t' -> out.append("\\t");
+                case '\b' -> out.append("\\b");
+                case '\f' -> out.append("\\f");
+                default -> {
+                    if (c < 0x20) {
+                        out.append(String.format(Locale.ROOT, "\\u%04x", (int) c));
+                    } else {
+                        out.append(c);
+                    }
+                }
+            }
+        }
+        return out.toString();
+    }
+
+    private static String loadBuildGeneratorVersion() {
+        try (InputStream in = TemplateSubstitutionEngine.class.getClassLoader()
+                .getResourceAsStream(BUILD_PROPERTIES_RESOURCE)) {
+            if (in == null) {
+                return FALLBACK_GENERATOR_VERSION;
+            }
+            Properties props = new Properties();
+            props.load(in);
+            String version = props.getProperty(BUILD_PROPERTY_GENERATOR_VERSION);
+            if (version == null || version.isBlank() || version.startsWith("${")) {
+                return FALLBACK_GENERATOR_VERSION;
+            }
+            return version;
+        } catch (IOException e) {
+            return FALLBACK_GENERATOR_VERSION;
+        }
+    }
+
+    /**
+     * @return all token names this engine recognizes (used by tests).
+     */
+    static Set<String> recognizedTokens() {
+        return new LinkedHashSet<>(Set.of(
+                "REPO_NAME", "REPO_OWNER", "PROJECT_DESCRIPTION", "CREATED_AT", "GENERATOR_VERSION"));
+    }
+}

--- a/components/repository-template/src/main/resources-filtered/META-INF/promptlm-repository-template.properties
+++ b/components/repository-template/src/main/resources-filtered/META-INF/promptlm-repository-template.properties
@@ -1,0 +1,4 @@
+# Filtered at build time by Maven. Carries values from the parent pom into the
+# repository-template jar so that TemplateSubstitutionEngine can resolve the
+# {{GENERATOR_VERSION}} token without hard-coding the version in source.
+generator.version=${project.version}

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/TemplateContextTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/TemplateContextTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.repository.template;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TemplateContextTest {
+
+    @Test
+    void exposesAllFields() {
+        Instant now = Instant.parse("2026-01-15T10:00:00Z");
+        TemplateContext ctx = new TemplateContext("repo", "owner", "desc", now, "1.0.0");
+
+        assertEquals("repo", ctx.repositoryName());
+        assertEquals("owner", ctx.ownerName());
+        assertEquals("desc", ctx.projectDescription());
+        assertEquals(now, ctx.createdAt());
+        assertEquals("1.0.0", ctx.generatorVersion());
+    }
+
+    @Test
+    void rejectsNulls() {
+        Instant now = Instant.now();
+
+        assertThrows(NullPointerException.class,
+                () -> new TemplateContext(null, "o", "d", now, "v"));
+        assertThrows(NullPointerException.class,
+                () -> new TemplateContext("r", null, "d", now, "v"));
+        assertThrows(NullPointerException.class,
+                () -> new TemplateContext("r", "o", null, now, "v"));
+        assertThrows(NullPointerException.class,
+                () -> new TemplateContext("r", "o", "d", null, "v"));
+        assertThrows(NullPointerException.class,
+                () -> new TemplateContext("r", "o", "d", now, null));
+    }
+}

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/TemplateSubstitutionEngineTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/TemplateSubstitutionEngineTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.repository.template;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TemplateSubstitutionEngineTest {
+
+    private static final TemplateContext CTX = new TemplateContext(
+            "my-prompts",
+            "alice",
+            "experiments in pedagogy",
+            Instant.parse("2026-05-17T09:30:00Z"),
+            "9.9.9");
+
+    private final TemplateSubstitutionEngine engine = new TemplateSubstitutionEngine("9.9.9-build");
+
+    @Test
+    void substitutesAllRecognizedTokensInMarkdown() {
+        byte[] source = "# {{REPO_NAME}}\n\nOwned by {{REPO_OWNER}}.\nDesc: {{PROJECT_DESCRIPTION}}.\nCreated {{CREATED_AT}}, generator {{GENERATOR_VERSION}}."
+                .getBytes(StandardCharsets.UTF_8);
+
+        String result = new String(engine.substitute("README.md", source, CTX), StandardCharsets.UTF_8);
+
+        assertThat(result).isEqualTo("# my-prompts\n\nOwned by alice.\nDesc: experiments in pedagogy.\nCreated 2026-05-17T09:30:00Z, generator 9.9.9.");
+    }
+
+    @Test
+    void jsonEscapesValuesInJsonFiles() {
+        TemplateContext quoted = new TemplateContext(
+                "name-with-\"quotes\"",
+                "owner\\path",
+                "line1\nline2",
+                Instant.parse("2026-05-17T09:30:00Z"),
+                "1.0.0");
+        byte[] source = "{\"name\":\"{{REPO_NAME}}\",\"owner\":\"{{REPO_OWNER}}\",\"desc\":\"{{PROJECT_DESCRIPTION}}\"}".getBytes(StandardCharsets.UTF_8);
+
+        String result = new String(engine.substitute("metadata.json", source, quoted), StandardCharsets.UTF_8);
+
+        assertThat(result).isEqualTo("{\"name\":\"name-with-\\\"quotes\\\"\",\"owner\":\"owner\\\\path\",\"desc\":\"line1\\nline2\"}");
+    }
+
+    @Test
+    void doesNotEscapeInNonJsonFiles() {
+        TemplateContext quoted = new TemplateContext(
+                "name-with-\"quotes\"",
+                "owner",
+                "desc",
+                Instant.parse("2026-05-17T09:30:00Z"),
+                "1.0.0");
+        byte[] source = "# {{REPO_NAME}}".getBytes(StandardCharsets.UTF_8);
+
+        String result = new String(engine.substitute("README.md", source, quoted), StandardCharsets.UTF_8);
+
+        assertThat(result).isEqualTo("# name-with-\"quotes\"");
+    }
+
+    @Test
+    void leavesUnknownTokensIntactSoCallersCanCatchThem() {
+        byte[] source = "version={{NOT_A_KNOWN_TOKEN}}".getBytes(StandardCharsets.UTF_8);
+
+        String result = new String(engine.substitute("artifacts.toml", source, CTX), StandardCharsets.UTF_8);
+
+        assertThat(result).isEqualTo("version={{NOT_A_KNOWN_TOKEN}}");
+    }
+
+    @Test
+    void doesNotRescanSubstitutedOutput() {
+        TemplateContext mischievous = new TemplateContext(
+                "{{REPO_OWNER}}",
+                "alice",
+                "desc",
+                Instant.parse("2026-05-17T09:30:00Z"),
+                "1.0.0");
+        byte[] source = "name={{REPO_NAME}}".getBytes(StandardCharsets.UTF_8);
+
+        String result = new String(engine.substitute("README.md", source, mischievous), StandardCharsets.UTF_8);
+
+        assertThat(result).isEqualTo("name={{REPO_OWNER}}");
+    }
+
+    @Test
+    void resolvesBuildGeneratorVersionSentinel() {
+        TemplateContext ctx = new TemplateContext(
+                "repo",
+                "owner",
+                "desc",
+                Instant.parse("2026-05-17T09:30:00Z"),
+                TemplateSubstitutionEngine.BUILD_GENERATOR_VERSION);
+        byte[] source = "generator={{GENERATOR_VERSION}}".getBytes(StandardCharsets.UTF_8);
+
+        String result = new String(engine.substitute("README.md", source, ctx), StandardCharsets.UTF_8);
+
+        assertThat(result).isEqualTo("generator=9.9.9-build");
+    }
+
+    @Test
+    void loadsBuildVersionFromClasspathProperties() {
+        TemplateSubstitutionEngine real = new TemplateSubstitutionEngine();
+        assertThat(real.buildGeneratorVersion()).isNotBlank();
+        // Either the filtered Maven value or the "dev" fallback — never the unfiltered token.
+        assertThat(real.buildGeneratorVersion()).doesNotStartWith("${");
+    }
+
+    @Test
+    void treatsKnownTextExtensionsAsText() {
+        assertThat(engine.isTextEntry("README.md")).isTrue();
+        assertThat(engine.isTextEntry(".promptlm/metadata.json")).isTrue();
+        assertThat(engine.isTextEntry(".promptlm/artifacts.toml")).isTrue();
+        assertThat(engine.isTextEntry(".github/workflows/x.yml")).isTrue();
+        assertThat(engine.isTextEntry(".github/workflows/x.yaml")).isTrue();
+        assertThat(engine.isTextEntry("pom.xml")).isTrue();
+        assertThat(engine.isTextEntry("notes.txt")).isTrue();
+    }
+
+    @Test
+    void treatsUnextensionedReleaseScriptsAsText() {
+        assertThat(engine.isTextEntry("tools/release/build-artifacts")).isTrue();
+        assertThat(engine.isTextEntry("tools/release/publish-artifacts")).isTrue();
+    }
+
+    @Test
+    void treatsUnknownExtensionsAsBinary() {
+        assertThat(engine.isTextEntry("image.png")).isFalse();
+        assertThat(engine.isTextEntry("docs/diagram.jpg")).isFalse();
+        assertThat(engine.isTextEntry("prompts/.gitignore")).isFalse();
+        assertThat(engine.isTextEntry("Makefile")).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Implements template variable substitution at repository extraction time so generated repositories no longer ship with literal `{{REPO_NAME}}` / `{{PROJECT_DESCRIPTION}}` tokens, a frozen `2025-01-19T22:42:35Z` timestamp, or `0.1.0-SNAPSHOT` generator version. Foundation for epic #159 — addresses findings F-001, F-002, F-024.

Closes part of #160 (the user can close the issue when satisfied).

### Approach

Adopted **Option A** from the issue comment — extend `RepositoryTemplateExtractor`:

```java
void extractTo(Path targetDirectory, TemplateContext context);
```

`TemplateContext` (record) carries `repositoryName`, `ownerName`, `projectDescription`, `createdAt`, `generatorVersion`. A new `TemplateSubstitutionEngine` does single-pass substitution of `{{REPO_NAME}}`, `{{REPO_OWNER}}`, `{{PROJECT_DESCRIPTION}}`, `{{CREATED_AT}}`, `{{GENERATOR_VERSION}}` in text files (`.md`, `.json`, `.toml`, `.yml`, `.yaml`, `.txt`, `.xml`, `.properties`, plus the unextensioned scripts under `tools/release/`). Binary files pass through unchanged. JSON files get value-escaping so a project name containing `"` cannot corrupt `metadata.json`.

`GENERATOR_VERSION` is sourced from a Maven-filtered properties file (`META-INF/promptlm-repository-template.properties`) — no hard-coded version in source. The engine accepts a `BUILD_GENERATOR_VERSION` sentinel from callers so `GitProjectService` does not need to know the version itself.

`metadata.json` in the template now uses `{{REPO_NAME}}`, `{{PROJECT_DESCRIPTION}}`, `{{CREATED_AT}}`, `{{GENERATOR_VERSION}}` placeholders instead of frozen values.

### Notable details

- Single-pass substitution: substituted output is never re-scanned for tokens (`doesNotRescanSubstitutedOutput` test).
- GitHub Actions `${{ … }}` expressions in workflow YAML are intentionally preserved — the AC-7 sweep test uses the regex `(?<![$])\{\{[A-Z_]+\}\}` so `$`-prefixed expressions don't trigger.
- Only one production implementation (`ZipFileRepositoryTemplateExtractor`) and one production caller (`GitProjectService`); both updated. The Mockito mock in `GitProjectServiceTest` switches automatically to the new signature.
- `PROJECT_DESCRIPTION` defaults to `"prompts managed by promptLM"` — making it user-configurable is F-019, deliberately out of scope here. Threaded through cleanly when #161 lands the `promptlm.yml` config.

## Test plan

- [x] `./mvnw -pl components/repository-template -am clean test` — passes 15/16 (the 1 failure was a Docker RWLayer transient in `RepositoryTemplateActSmokeTest`; passed on next run).
- [x] `./mvnw -pl components/promptlm-store/promptlm-store-github -am test` — **77/77 green** including the 13 new tests.
- [x] Manual: `grep -E "\{\{[A-Z_]+\}\}" components/repository-template/repo-resources` returns only tokens the engine resolves.

### New tests

- `TemplateContextTest` (2 tests) — record contract, null guards.
- `TemplateSubstitutionEngineTest` (10 tests) — markdown substitution, JSON escaping, no-escape in non-JSON, unknown-token passthrough, single-pass guarantee, sentinel resolution, build-properties load, text-vs-binary classification.
- `ZipFileRepositoryTemplateExtractorSubstitutionTest` (3 tests) — integration extraction of the real `repo-template.zip`: no `{{[A-Z_]+}}` survives, README has substituted name + description, `metadata.json` has runtime timestamp and generator version.

### Updated tests

- `GitProjectServiceTest#shouldCreateLocalAndRemoteRepoIfNoneExists` — verifies the new `extractTo(eq(repoDir), argThat(ctx -> …))` signature.
- `ZipFileRepositoryRepositoryTemplateExtractorTest` — passes a sample `TemplateContext`.

### Caveats

- `RepositoryTemplateActSmokeTest` is sensitive to local Docker state and intermittently fails with `RWLayer of container ... is unexpectedly nil`. Not introduced by this PR; documented in the user's local-build memory.
- JSON escaping in the engine is hand-rolled (covers `"`, `\`, control chars) rather than Jackson — sufficient for the values we substitute today.

## Acceptance criteria (issue #160)

- [x] Substitution step in the extraction pipeline.
- [x] Tokens supported at minimum: `{{REPO_NAME}}`, `{{REPO_OWNER}}`, `{{PROJECT_DESCRIPTION}}`, `{{CREATED_AT}}` (ISO-8601 UTC), `{{GENERATOR_VERSION}}`.
- [x] `GENERATOR_VERSION` sourced from build-time properties via Maven resource filtering.
- [x] Substitution applied to all text files (`.md`, `.json`, `.toml`, `.yml`, `.yaml`, …).
- [x] Binary files copied unchanged.
- [x] Test asserting no `{{...}}` tokens remain after extraction.

## Follow-ups (not in this PR)

1. Pre-existing zip-slip exposure in `ZipFileRepositoryTemplateExtractor` (`Path::resolve` without containment check). Out of scope but worth tracking.
2. When #161 lands `promptlm.yml`, thread the user-supplied description through to `TemplateContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)