### PR TITLE
refactor(store-github): introduce ReleaseTemplateProvider SPI and RepositoryGenerationConfig (#165)

### DIFF
--- a/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/GeneratedFile.java
+++ b/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/GeneratedFile.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.api;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * A single file produced by a release-template (or other repository generation)
+ * provider.
+ *
+ * <p>The {@code relativePath} is interpreted relative to the root of the
+ * generated repository and must use forward slashes; it must not be absolute
+ * and must not contain {@code ".."} segments.
+ *
+ * <p>The {@code content} byte array is treated as immutable by convention —
+ * callers must not mutate the array after constructing a {@code GeneratedFile}.
+ *
+ * @param relativePath repository-relative path (e.g.
+ *                     {@code ".github/workflows/build-artifacts.yml"})
+ * @param content      raw file contents
+ * @param executable   whether the file should be marked executable when
+ *                     written to disk (relevant for shell scripts)
+ */
+public record GeneratedFile(String relativePath, byte[] content, boolean executable) {
+
+    public GeneratedFile {
+        Objects.requireNonNull(relativePath, "relativePath must not be null");
+        Objects.requireNonNull(content, "content must not be null");
+        if (relativePath.isBlank()) {
+            throw new IllegalArgumentException("relativePath must not be blank");
+        }
+        if (relativePath.startsWith("/")) {
+            throw new IllegalArgumentException("relativePath must be repository-relative, not absolute: " + relativePath);
+        }
+        for (String segment : relativePath.split("/")) {
+            if (segment.equals("..")) {
+                throw new IllegalArgumentException("relativePath must not contain '..' segments: " + relativePath);
+            }
+        }
+    }
+
+    /**
+     * Convenience factory for a text file using UTF-8 encoding.
+     */
+    public static GeneratedFile textFile(String relativePath, String content) {
+        return new GeneratedFile(relativePath, content.getBytes(StandardCharsets.UTF_8), false);
+    }
+
+    /**
+     * Convenience factory for an executable text file using UTF-8 encoding.
+     */
+    public static GeneratedFile executableTextFile(String relativePath, String content) {
+        return new GeneratedFile(relativePath, content.getBytes(StandardCharsets.UTF_8), true);
+    }
+}

--- a/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/ReleaseProvider.java
+++ b/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/ReleaseProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.api;
+
+/**
+ * Identifies the CI/CD platform that hosts the generated release workflow for a
+ * promptLM store repository.
+ * <p>
+ * The enum is intentionally minimal — new providers (for example
+ * {@code GITLAB_CI}) can be added without touching the consuming code, because
+ * provider selection is dispatched through {@code ReleaseTemplateProvider}
+ * implementations rather than through {@code switch} statements on this value.
+ */
+public enum ReleaseProvider {
+
+    /**
+     * Release workflow files target GitHub Actions / Gitea Actions.
+     */
+    GITHUB_ACTIONS,
+
+    /**
+     * No release workflow is generated. Used when release capability is disabled
+     * (Mode 1 / "no release" configurations).
+     */
+    NONE
+}

--- a/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/ReleaseTemplateProvider.java
+++ b/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/ReleaseTemplateProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.api;
+
+import java.util.List;
+
+/**
+ * SPI for contributing CI/CD release-workflow files into a generated promptLM
+ * store repository.
+ *
+ * <p>Each implementation targets one {@link ReleaseProvider} value (GitHub
+ * Actions, GitLab CI, etc.). The selection happens at provisioning time, based
+ * on the {@code releaseProvider} field of the supplied
+ * {@link RepositoryGenerationConfig}.
+ *
+ * <p>Implementations must be <em>pure</em>: they return the files that should
+ * be added to the repository and must not perform IO on the target filesystem
+ * themselves. Writing the files is the caller's responsibility.
+ *
+ * <p>Adding a new CI/CD platform (for example GitLab) is therefore a matter of
+ * adding a new enum value to {@link ReleaseProvider} and a new
+ * {@code ReleaseTemplateProvider} implementation — no changes to the
+ * provisioning core are required.
+ */
+public interface ReleaseTemplateProvider {
+
+    /**
+     * @return the release provider this implementation targets.
+     */
+    ReleaseProvider provider();
+
+    /**
+     * Returns the set of files to add to the generated repository when release
+     * capability is enabled for the given configuration.
+     *
+     * <p>Implementations may return an empty list when release files are not
+     * required (for example {@code NoReleaseTemplateProvider} or a future
+     * provider that bundles its assets through some other mechanism).
+     *
+     * @param config the repository generation configuration; never {@code null}
+     * @return an immutable list of files to add; never {@code null}
+     */
+    List<GeneratedFile> generateFiles(RepositoryGenerationConfig config);
+}

--- a/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/RepositoryGenerationConfig.java
+++ b/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/RepositoryGenerationConfig.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.api;
+
+/**
+ * Configuration value object passed through the repository generation pipeline.
+ * <p>
+ * It carries the parameters required to provision a remote repository and to
+ * select the appropriate {@code ReleaseTemplateProvider} implementation.
+ *
+ * <p>This type is intentionally provider-agnostic — it does <em>not</em> contain
+ * any GitHub-specific fields. Provider-specific behaviour is encapsulated behind
+ * the {@code ReleaseTemplateProvider} SPI.
+ *
+ * @param repositoryName  the short name of the repository (must not be blank)
+ * @param ownerName       the owner login / organisation (must not be blank)
+ * @param description     human-readable description applied to the remote
+ *                        repository; defaults to {@link #DEFAULT_DESCRIPTION}
+ * @param defaultBranch   the default branch used for the initial commit;
+ *                        defaults to {@link #DEFAULT_BRANCH}
+ * @param releaseEnabled  whether release workflow files should be generated
+ * @param releaseProvider which release provider implementation to dispatch to;
+ *                        ignored when {@code releaseEnabled} is {@code false}
+ */
+public record RepositoryGenerationConfig(
+        String repositoryName,
+        String ownerName,
+        String description,
+        String defaultBranch,
+        boolean releaseEnabled,
+        ReleaseProvider releaseProvider
+) {
+
+    /** Default repository description used when none is supplied. */
+    public static final String DEFAULT_DESCRIPTION = "A promptLM store";
+
+    /** Default branch name used when none is supplied. */
+    public static final String DEFAULT_BRANCH = "main";
+
+    public RepositoryGenerationConfig {
+        if (repositoryName == null || repositoryName.isBlank()) {
+            throw new IllegalArgumentException("repositoryName must not be blank");
+        }
+        if (ownerName == null || ownerName.isBlank()) {
+            throw new IllegalArgumentException("ownerName must not be blank");
+        }
+        if (description == null || description.isBlank()) {
+            description = DEFAULT_DESCRIPTION;
+        }
+        if (defaultBranch == null || defaultBranch.isBlank()) {
+            defaultBranch = DEFAULT_BRANCH;
+        }
+        if (releaseProvider == null) {
+            releaseProvider = releaseEnabled ? ReleaseProvider.GITHUB_ACTIONS : ReleaseProvider.NONE;
+        }
+    }
+
+    /**
+     * Convenience factory for the common "no release / defaults" case used by
+     * Mode 1 configurations and by callers that have not yet been migrated to
+     * pass an explicit configuration.
+     */
+    public static RepositoryGenerationConfig defaults(String ownerName, String repositoryName) {
+        return new RepositoryGenerationConfig(
+                repositoryName,
+                ownerName,
+                DEFAULT_DESCRIPTION,
+                DEFAULT_BRANCH,
+                false,
+                ReleaseProvider.NONE
+        );
+    }
+
+    /**
+     * Returns a copy of this configuration with the given description.
+     */
+    public RepositoryGenerationConfig withDescription(String newDescription) {
+        return new RepositoryGenerationConfig(
+                repositoryName,
+                ownerName,
+                newDescription,
+                defaultBranch,
+                releaseEnabled,
+                releaseProvider
+        );
+    }
+
+    /**
+     * Returns a copy of this configuration with the given default branch.
+     */
+    public RepositoryGenerationConfig withDefaultBranch(String newDefaultBranch) {
+        return new RepositoryGenerationConfig(
+                repositoryName,
+                ownerName,
+                description,
+                newDefaultBranch,
+                releaseEnabled,
+                releaseProvider
+        );
+    }
+}

--- a/components/promptlm-store/promptlm-store-api/src/test/java/dev/promptlm/store/api/GeneratedFileTest.java
+++ b/components/promptlm-store/promptlm-store-api/src/test/java/dev/promptlm/store/api/GeneratedFileTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GeneratedFileTest {
+
+    @Test
+    void shouldRejectAbsolutePath() {
+        assertThatThrownBy(() -> new GeneratedFile("/absolute/path", new byte[0], false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("repository-relative");
+    }
+
+    @Test
+    void shouldRejectTraversalSegment() {
+        assertThatThrownBy(() -> new GeneratedFile("foo/../bar", new byte[0], false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("'..'");
+    }
+
+    @Test
+    void shouldRejectBlankPath() {
+        assertThatThrownBy(() -> new GeneratedFile("   ", new byte[0], false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("blank");
+    }
+
+    @Test
+    void textFileShouldUseUtf8AndNonExecutable() {
+        GeneratedFile file = GeneratedFile.textFile("readme.md", "hello");
+
+        assertThat(file.relativePath()).isEqualTo("readme.md");
+        assertThat(new String(file.content(), StandardCharsets.UTF_8)).isEqualTo("hello");
+        assertThat(file.executable()).isFalse();
+    }
+
+    @Test
+    void executableTextFileShouldMarkExecutable() {
+        GeneratedFile file = GeneratedFile.executableTextFile("tools/run.sh", "#!/bin/sh");
+
+        assertThat(file.executable()).isTrue();
+    }
+}

--- a/components/promptlm-store/promptlm-store-api/src/test/java/dev/promptlm/store/api/RepositoryGenerationConfigTest.java
+++ b/components/promptlm-store/promptlm-store-api/src/test/java/dev/promptlm/store/api/RepositoryGenerationConfigTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RepositoryGenerationConfigTest {
+
+    @Test
+    void shouldFillDefaultDescriptionWhenBlank() {
+        RepositoryGenerationConfig config = new RepositoryGenerationConfig(
+                "my-repo", "alice", "  ", "main", false, ReleaseProvider.NONE);
+
+        assertThat(config.description()).isEqualTo(RepositoryGenerationConfig.DEFAULT_DESCRIPTION);
+    }
+
+    @Test
+    void shouldFillDefaultBranchWhenBlank() {
+        RepositoryGenerationConfig config = new RepositoryGenerationConfig(
+                "my-repo", "alice", "desc", null, false, ReleaseProvider.NONE);
+
+        assertThat(config.defaultBranch()).isEqualTo("main");
+    }
+
+    @Test
+    void shouldRejectBlankRepositoryName() {
+        assertThatThrownBy(() -> new RepositoryGenerationConfig(
+                " ", "alice", "desc", "main", false, ReleaseProvider.NONE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("repositoryName");
+    }
+
+    @Test
+    void shouldRejectBlankOwner() {
+        assertThatThrownBy(() -> new RepositoryGenerationConfig(
+                "my-repo", null, "desc", "main", false, ReleaseProvider.NONE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ownerName");
+    }
+
+    @Test
+    void defaultsShouldDisableReleaseAndUseDefaults() {
+        RepositoryGenerationConfig config = RepositoryGenerationConfig.defaults("alice", "my-repo");
+
+        assertThat(config.repositoryName()).isEqualTo("my-repo");
+        assertThat(config.ownerName()).isEqualTo("alice");
+        assertThat(config.description()).isEqualTo("A promptLM store");
+        assertThat(config.defaultBranch()).isEqualTo("main");
+        assertThat(config.releaseEnabled()).isFalse();
+        assertThat(config.releaseProvider()).isEqualTo(ReleaseProvider.NONE);
+    }
+
+    @Test
+    void shouldDefaultReleaseProviderToGithubActionsWhenReleaseEnabled() {
+        RepositoryGenerationConfig config = new RepositoryGenerationConfig(
+                "my-repo", "alice", "desc", "main", true, null);
+
+        assertThat(config.releaseProvider()).isEqualTo(ReleaseProvider.GITHUB_ACTIONS);
+    }
+
+    @Test
+    void shouldDefaultReleaseProviderToNoneWhenReleaseDisabled() {
+        RepositoryGenerationConfig config = new RepositoryGenerationConfig(
+                "my-repo", "alice", "desc", "main", false, null);
+
+        assertThat(config.releaseProvider()).isEqualTo(ReleaseProvider.NONE);
+    }
+
+    @Test
+    void withDescriptionShouldReturnUpdatedCopy() {
+        RepositoryGenerationConfig original = RepositoryGenerationConfig.defaults("alice", "my-repo");
+
+        RepositoryGenerationConfig updated = original.withDescription("custom");
+
+        assertThat(updated.description()).isEqualTo("custom");
+        assertThat(original.description()).isEqualTo("A promptLM store");
+    }
+
+    @Test
+    void withDefaultBranchShouldReturnUpdatedCopy() {
+        RepositoryGenerationConfig original = RepositoryGenerationConfig.defaults("alice", "my-repo");
+
+        RepositoryGenerationConfig updated = original.withDefaultBranch("trunk");
+
+        assertThat(updated.defaultBranch()).isEqualTo("trunk");
+        assertThat(original.defaultBranch()).isEqualTo("main");
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubActionsReleaseTemplateProvider.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubActionsReleaseTemplateProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import dev.promptlm.store.api.GeneratedFile;
+import dev.promptlm.store.api.ReleaseProvider;
+import dev.promptlm.store.api.ReleaseTemplateProvider;
+import dev.promptlm.store.api.RepositoryGenerationConfig;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * {@link ReleaseTemplateProvider} that targets GitHub / Gitea Actions.
+ *
+ * <p>Used when {@link RepositoryGenerationConfig#releaseProvider()} is
+ * {@link ReleaseProvider#GITHUB_ACTIONS} and
+ * {@link RepositoryGenerationConfig#releaseEnabled()} is {@code true}.
+ *
+ * <h2>Transitional behaviour</h2>
+ * <p>Today the GitHub Actions workflow files (along with the matching
+ * validation and packaging scripts) ship as part of the
+ * {@code repository-template} zip and are extracted by
+ * {@code RepositoryTemplateExtractor}. Behaviour is therefore preserved by
+ * this provider returning an empty list — the files are still delivered, just
+ * through the existing zip mechanism.
+ *
+ * <p>Once the release-toggle / Mode 2 work (tracked under issues #161 and
+ * #163) lands, the responsibility for those files moves into this provider so
+ * that disabling release capability simply omits them. At that point this
+ * implementation will return the workflow files, validation scripts, and
+ * packaging scripts derived from the supplied configuration.
+ */
+@Component
+public class GitHubActionsReleaseTemplateProvider implements ReleaseTemplateProvider {
+
+    @Override
+    public ReleaseProvider provider() {
+        return ReleaseProvider.GITHUB_ACTIONS;
+    }
+
+    @Override
+    public List<GeneratedFile> generateFiles(RepositoryGenerationConfig config) {
+        // Files are currently delivered via the repository-template zip
+        // extractor. This provider exists as the SPI hook into which #161 /
+        // #163 will plug the actual workflow / script files. Returning an
+        // empty list keeps behaviour equivalent to pre-refactor.
+        return List.of();
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitProjectService.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitProjectService.java
@@ -24,6 +24,7 @@ import dev.promptlm.repository.template.TemplateContext;
 import dev.promptlm.repository.template.TemplateSubstitutionEngine;
 import dev.promptlm.store.api.ProjectService;
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
+import dev.promptlm.store.api.RepositoryGenerationConfig;
 import dev.promptlm.store.api.RepositoryOwner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -224,7 +225,12 @@ public class GitProjectService implements ProjectService {
                     ownerAndRepo.repo()
             );
         }
-        return remoteGitRepositoryProvisioner.createRemoteRepository(ownerAndRepo.owner(), ownerAndRepo.repo());
+        // TODO(#161): drive description / defaultBranch / release config from promptlm.yml.
+        RepositoryGenerationConfig config = RepositoryGenerationConfig.defaults(
+                ownerAndRepo.owner(),
+                ownerAndRepo.repo()
+        );
+        return remoteGitRepositoryProvisioner.createRemoteRepository(config);
     }
 
 

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/NoReleaseTemplateProvider.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/NoReleaseTemplateProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import dev.promptlm.store.api.GeneratedFile;
+import dev.promptlm.store.api.ReleaseProvider;
+import dev.promptlm.store.api.ReleaseTemplateProvider;
+import dev.promptlm.store.api.RepositoryGenerationConfig;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * {@link ReleaseTemplateProvider} used when release capability is disabled
+ * (Mode 1 default). It contributes no files.
+ *
+ * <p>Targets {@link ReleaseProvider#NONE}.
+ */
+@Component
+public class NoReleaseTemplateProvider implements ReleaseTemplateProvider {
+
+    @Override
+    public ReleaseProvider provider() {
+        return ReleaseProvider.NONE;
+    }
+
+    @Override
+    public List<GeneratedFile> generateFiles(RepositoryGenerationConfig config) {
+        return List.of();
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ReleaseTemplateProviderRegistry.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ReleaseTemplateProviderRegistry.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import dev.promptlm.store.api.ReleaseProvider;
+import dev.promptlm.store.api.ReleaseTemplateProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Selects the appropriate {@link ReleaseTemplateProvider} for a given
+ * {@link ReleaseProvider} value.
+ *
+ * <p>Implementations are discovered through Spring's component scanning, but
+ * the registry resolves them by {@link ReleaseTemplateProvider#provider()}
+ * rather than by bean name. This keeps adding a new CI/CD platform a one-class
+ * change.
+ */
+@Component
+public class ReleaseTemplateProviderRegistry {
+
+    private final Map<ReleaseProvider, ReleaseTemplateProvider> providersByKey;
+
+    public ReleaseTemplateProviderRegistry(List<ReleaseTemplateProvider> providers) {
+        Map<ReleaseProvider, ReleaseTemplateProvider> map = new EnumMap<>(ReleaseProvider.class);
+        for (ReleaseTemplateProvider provider : providers) {
+            ReleaseTemplateProvider previous = map.put(provider.provider(), provider);
+            if (previous != null) {
+                throw new IllegalStateException(
+                        "Duplicate ReleaseTemplateProvider registered for " + provider.provider()
+                                + ": " + previous.getClass().getName()
+                                + " and " + provider.getClass().getName());
+            }
+        }
+        this.providersByKey = Map.copyOf(map);
+    }
+
+    /**
+     * Returns the registered provider for the given key.
+     *
+     * @throws IllegalStateException if no provider is registered for the key
+     */
+    public ReleaseTemplateProvider get(ReleaseProvider key) {
+        ReleaseTemplateProvider provider = providersByKey.get(key);
+        if (provider == null) {
+            throw new IllegalStateException("No ReleaseTemplateProvider registered for " + key);
+        }
+        return provider;
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/RemoteGitRepositoryProvisioner.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/RemoteGitRepositoryProvisioner.java
@@ -17,6 +17,7 @@
 package dev.promptlm.store.github;
 
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
+import dev.promptlm.store.api.RepositoryGenerationConfig;
 import dev.promptlm.store.api.RepositoryOwner;
 import org.kohsuke.github.*;
 import org.slf4j.Logger;
@@ -89,13 +90,43 @@ public class RemoteGitRepositoryProvisioner {
         return resolved;
     }
 
+    /**
+     * Creates a remote repository using the supplied {@link RepositoryGenerationConfig}.
+     *
+     * <p>The configuration drives the repository description and default branch,
+     * replacing the previously hard-coded {@code "A promptLM store"} description
+     * and {@code "main"} branch values.
+     *
+     * @param config the repository generation configuration; never {@code null}
+     * @return the created remote repository
+     * @throws RemoteRepositoryAlreadyExistsException if a repository already exists at
+     *         {@code owner/repositoryName}
+     */
+    public RemoteRepository createRemoteRepository(RepositoryGenerationConfig config) throws RemoteRepositoryAlreadyExistsException {
+        if (config == null) {
+            throw new IllegalArgumentException("config must not be null");
+        }
+        String effectiveOwner = resolveOwner(config.ownerName());
+        String baseUrl = gitHubProperties.getBaseUrl();
+        if (repositoryExists(baseUrl, effectiveOwner, config.repositoryName())) {
+            throw new RemoteRepositoryAlreadyExistsException(baseUrl, effectiveOwner, config.repositoryName());
+        }
+        return _createRemoteRepository(effectiveOwner, config.repositoryName(), config.description(), config.defaultBranch());
+    }
+
+    /**
+     * Backwards-compatible overload that delegates to
+     * {@link #createRemoteRepository(RepositoryGenerationConfig)} using the
+     * default description and default branch.
+     *
+     * @deprecated callers should construct an explicit
+     *             {@link RepositoryGenerationConfig} so that description and
+     *             default branch can be driven by {@code promptlm.yml}.
+     */
+    @Deprecated
     public RemoteRepository createRemoteRepository(String owner, String repoName) throws RemoteRepositoryAlreadyExistsException {
         String effectiveOwner = resolveOwner(owner);
-        String baseUrl = gitHubProperties.getBaseUrl();
-        if (repositoryExists(baseUrl, effectiveOwner, repoName)) {
-            throw new RemoteRepositoryAlreadyExistsException(baseUrl, effectiveOwner, repoName);
-        }
-        return _createRemoteRepository(effectiveOwner, repoName);
+        return createRemoteRepository(RepositoryGenerationConfig.defaults(effectiveOwner, repoName));
     }
 
 
@@ -120,7 +151,7 @@ public class RemoteGitRepositoryProvisioner {
     }
 
 
-    private GitHubRepository _createRemoteRepository(String owner, String repoName) {
+    private GitHubRepository _createRemoteRepository(String owner, String repoName, String description, String defaultBranch) {
 
         try {
             GitHub gitHub = buildClient(gitHubProperties.getBaseUrl());
@@ -131,8 +162,8 @@ public class RemoteGitRepositoryProvisioner {
                 GHMyself myself = gitHub.getMyself();
                 log.debug("Creating repository under authenticated user: {}", myself.getLogin());
                 r = gitHub.createRepository(repoName)
-                        .description("A promptLM store")
-                        .defaultBranch("main")
+                        .description(description)
+                        .defaultBranch(defaultBranch)
                         .private_(true)
                         .create();
             } else {
@@ -142,8 +173,8 @@ public class RemoteGitRepositoryProvisioner {
                 }
                 log.debug("Creating repository under organization: {}", owner);
                 r = organization.createRepository(repoName)
-                        .description("A promptLM store")
-                        .defaultBranch("main")
+                        .description(description)
+                        .defaultBranch(defaultBranch)
                         .private_(true)
                         .create();
             }

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitProjectServiceTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitProjectServiceTest.java
@@ -24,6 +24,7 @@ import dev.promptlm.repository.template.TemplateContext;
 import dev.promptlm.repository.template.TemplateSubstitutionEngine;
 import dev.promptlm.store.api.ProjectService;
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
+import dev.promptlm.store.api.RepositoryGenerationConfig;
 import dev.promptlm.store.api.RepositoryOwner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -100,7 +101,8 @@ class GitProjectServiceTest {
         String owner = "owner";
         RemoteRepository createdRemoteRepository = GitHubRepository.create(owner, projectName, gitCloneUrl);
 
-        when(remoteRepositoryProvisioner.createRemoteRepository(owner, projectName)).thenReturn(createdRemoteRepository);
+        when(remoteRepositoryProvisioner.createRemoteRepository(any(RepositoryGenerationConfig.class)))
+                .thenReturn(createdRemoteRepository);
 
         ProjectSpec projectSpec = service.newProject(baseDir, owner, projectName);
 
@@ -120,6 +122,13 @@ class GitProjectServiceTest {
         verify(git).addAllAndCommit(repoDir.toFile(), "initial commit");
         verify(git).checkoutOrCreateBranch(GitProjectService.DEVELOPMENT_BRANCH, repoDir.toFile());
         verify(git, times(2)).pushAll(repoDir.toFile());
+        verify(remoteRepositoryProvisioner).createRemoteRepository(argThat((RepositoryGenerationConfig config) ->
+                config != null
+                        && owner.equals(config.ownerName())
+                        && projectName.equals(config.repositoryName())
+                        && RepositoryGenerationConfig.DEFAULT_DESCRIPTION.equals(config.description())
+                        && RepositoryGenerationConfig.DEFAULT_BRANCH.equals(config.defaultBranch())
+                        && !config.releaseEnabled()));
         assertThat(appContext.getActiveProject()).isSameAs(projectSpec);
         verify(eventPublisher).publishEvent((Object) argThat( event -> {
             if (!(event instanceof ProjectCreatedEvent)) {
@@ -144,6 +153,7 @@ class GitProjectServiceTest {
                 .hasMessageContaining("Remote repository already exists");
 
         verify(remoteRepositoryProvisioner, never()).createRemoteRepository(anyString(), anyString());
+        verify(remoteRepositoryProvisioner, never()).createRemoteRepository(any(RepositoryGenerationConfig.class));
     }
 
     @Test

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ReleaseTemplateProviderTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ReleaseTemplateProviderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import dev.promptlm.store.api.GeneratedFile;
+import dev.promptlm.store.api.ReleaseProvider;
+import dev.promptlm.store.api.ReleaseTemplateProvider;
+import dev.promptlm.store.api.RepositoryGenerationConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleaseTemplateProviderTest {
+
+    private final RepositoryGenerationConfig config =
+            RepositoryGenerationConfig.defaults("alice", "my-repo");
+
+    @Test
+    void noReleaseProviderTargetsNoneAndProducesNoFiles() {
+        NoReleaseTemplateProvider provider = new NoReleaseTemplateProvider();
+
+        assertThat(provider.provider()).isEqualTo(ReleaseProvider.NONE);
+        assertThat(provider.generateFiles(config)).isEmpty();
+    }
+
+    @Test
+    void gitHubActionsProviderTargetsGithubActions() {
+        GitHubActionsReleaseTemplateProvider provider = new GitHubActionsReleaseTemplateProvider();
+
+        assertThat(provider.provider()).isEqualTo(ReleaseProvider.GITHUB_ACTIONS);
+        // Transitional: today the workflow files still ship via the
+        // repository-template zip, so this provider returns no files. The
+        // assertion documents the contract — see class javadoc.
+        assertThat(provider.generateFiles(config)).isEmpty();
+    }
+
+    @Test
+    void registryShouldResolveProviderByKey() {
+        ReleaseTemplateProviderRegistry registry = new ReleaseTemplateProviderRegistry(
+                List.of(new NoReleaseTemplateProvider(), new GitHubActionsReleaseTemplateProvider()));
+
+        assertThat(registry.get(ReleaseProvider.NONE)).isInstanceOf(NoReleaseTemplateProvider.class);
+        assertThat(registry.get(ReleaseProvider.GITHUB_ACTIONS)).isInstanceOf(GitHubActionsReleaseTemplateProvider.class);
+    }
+
+    @Test
+    void registryShouldRejectDuplicateProvidersForSameKey() {
+        ReleaseTemplateProvider duplicate = new ReleaseTemplateProvider() {
+            @Override
+            public ReleaseProvider provider() {
+                return ReleaseProvider.NONE;
+            }
+
+            @Override
+            public List<GeneratedFile> generateFiles(RepositoryGenerationConfig config) {
+                return List.of();
+            }
+        };
+
+        assertThatThrownBy(() -> new ReleaseTemplateProviderRegistry(
+                List.of(new NoReleaseTemplateProvider(), duplicate)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Duplicate");
+    }
+
+    @Test
+    void registryShouldThrowWhenProviderMissing() {
+        ReleaseTemplateProviderRegistry registry = new ReleaseTemplateProviderRegistry(
+                List.of(new NoReleaseTemplateProvider()));
+
+        assertThatThrownBy(() -> registry.get(ReleaseProvider.GITHUB_ACTIONS))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No ReleaseTemplateProvider");
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/RemoteGitRepositoryProvisionerConfigTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/RemoteGitRepositoryProvisionerConfigTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
+import dev.promptlm.store.api.RepositoryGenerationConfig;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RemoteGitRepositoryProvisionerConfigTest {
+
+    @Test
+    void shouldRejectNullConfig() {
+        GitHubProperties properties = new GitHubProperties();
+        properties.setBaseUrl("http://example.invalid");
+        properties.setUsername("alice");
+
+        RemoteGitRepositoryProvisioner provisioner = new RemoteGitRepositoryProvisioner(properties);
+
+        assertThatThrownBy(() -> provisioner.createRemoteRepository(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("config");
+    }
+
+    /**
+     * Drives the existence check via {@link RepositoryGenerationConfig} and
+     * asserts that {@code RemoteRepositoryAlreadyExistsException} is thrown
+     * when the target repository already exists. This guards the new code path
+     * that consumes the config object end-to-end.
+     */
+    @Test
+    void shouldThrowWhenRepositoryAlreadyExistsUsingConfig() {
+        try (FakeGitHubApi api = FakeGitHubApi.start(true)) {
+            GitHubProperties properties = new GitHubProperties();
+            properties.setBaseUrl(api.baseApiUrl());
+            properties.setEndpoint(api.baseApiUrl());
+            properties.setUsername("alice");
+            properties.setToken("token");
+
+            RemoteGitRepositoryProvisioner provisioner = new RemoteGitRepositoryProvisioner(properties);
+
+            RepositoryGenerationConfig config = new RepositoryGenerationConfig(
+                    "repo", "owner", "custom desc", "trunk", false, null);
+
+            assertThatThrownBy(() -> provisioner.createRemoteRepository(config))
+                    .isInstanceOf(RemoteRepositoryAlreadyExistsException.class);
+
+            assertThat(api.requestPaths()).contains("/api/v3/repos/owner/repo");
+        }
+    }
+
+    private static final class FakeGitHubApi implements AutoCloseable {
+        private final HttpServer server;
+        private final List<String> requestPaths = new CopyOnWriteArrayList<>();
+        private final boolean repositoryExists;
+
+        private FakeGitHubApi(HttpServer server, boolean repositoryExists) {
+            this.server = server;
+            this.repositoryExists = repositoryExists;
+        }
+
+        static FakeGitHubApi start(boolean repositoryExists) {
+            try {
+                HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+                FakeGitHubApi fake = new FakeGitHubApi(server, repositoryExists);
+                server.createContext("/", fake::handle);
+                server.start();
+                return fake;
+            } catch (IOException ioException) {
+                throw new RuntimeException("Failed to start fake GitHub API server for test", ioException);
+            }
+        }
+
+        String baseApiUrl() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/api/v3";
+        }
+
+        List<String> requestPaths() {
+            return requestPaths;
+        }
+
+        private void handle(HttpExchange exchange) throws IOException {
+            String path = exchange.getRequestURI().getPath();
+            requestPaths.add(path);
+
+            if (path.endsWith("/repos/owner/repo")) {
+                if (repositoryExists) {
+                    writeJson(exchange, 200, """
+                            {"full_name":"owner/repo","name":"repo"}
+                            """);
+                } else {
+                    writeJson(exchange, 404, """
+                            {"message":"Not Found"}
+                            """);
+                }
+                return;
+            }
+
+            writeJson(exchange, 200, "{}");
+        }
+
+        private static void writeJson(HttpExchange exchange, int statusCode, String body) throws IOException {
+            byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(statusCode, payload.length);
+            exchange.getResponseBody().write(payload);
+            exchange.close();
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+}


### PR DESCRIPTION
Closes #165. Addresses findings **F-015** and **F-019** from epic #159.

## Summary

Introduce a provider-agnostic CI/CD abstraction so future GitLab CI/CD support is a one-class change rather than a refactor of the provisioning core.

- **`ReleaseTemplateProvider` SPI** (new, in `promptlm-store-api`) returns the set of `GeneratedFile`s to add to a generated repository, given a `RepositoryGenerationConfig`. Two implementations ship: `NoReleaseTemplateProvider` (Mode 1 default) and `GitHubActionsReleaseTemplateProvider` (current behavior). A `ReleaseTemplateProviderRegistry` resolves them by `ReleaseProvider` enum key — adding GitLab is a new class + new enum value, no core changes needed.
- **`RepositoryGenerationConfig`** value object carries `repositoryName`, `ownerName`, `description`, `defaultBranch`, `releaseEnabled`, and `releaseProvider` (`GITHUB_ACTIONS`, `NONE`).
- **`GeneratedFile`** value type with validation against absolute paths and `..` traversal.
- **`RemoteGitRepositoryProvisioner`** now accepts `RepositoryGenerationConfig`, replacing the hard-coded `"A promptLM store"` description and `"main"` default branch (F-019). The legacy `(owner, repoName)` overload is retained as a deprecated delegating wrapper for surgicality.
- **`GitProjectService`** builds a default `RepositoryGenerationConfig` for now (see TODO referencing #161).

## Behaviour equivalence

This PR is intentionally a **structural refactor**:
- All existing callers continue to get the default description / branch.
- `GitHubActionsReleaseTemplateProvider.generateFiles` currently returns an empty list — the workflow / script files still ship via the existing `repository-template` zip and `RepositoryTemplateExtractor`. The provider is the SPI hook into which #163 plugs the actual files when it lands.

## Dependencies / coordination

- **#161** (release-toggle, `promptlm.yml` parsing) will replace `RepositoryGenerationConfig.defaults(...)` in `GitProjectService` with values sourced from the config file. The injection point is the existing `newProject(...)` flow — no API shape changes needed.
- **#163** (workflow generation) will move workflow / packaging files from the `repository-template` zip into `GitHubActionsReleaseTemplateProvider.generateFiles` and add a hook in `GitProjectService` to write the returned files after `repositoryTemplateExtractor.extractTo(...)`. The SPI surface is ready for this.

## Test plan

- [x] New unit tests cover `RepositoryGenerationConfig` validation and defaulting (9 tests).
- [x] New unit tests cover `GeneratedFile` validation (5 tests).
- [x] New unit tests cover `NoReleaseTemplateProvider`, `GitHubActionsReleaseTemplateProvider`, and `ReleaseTemplateProviderRegistry` resolution and duplicate-rejection (5 tests).
- [x] `RemoteGitRepositoryProvisionerConfigTest` exercises the new `createRemoteRepository(RepositoryGenerationConfig)` path (null-config rejection, repository-exists short-circuit).
- [x] Existing `GitProjectServiceTest.shouldCreateLocalAndRemoteRepoIfNoneExists` updated to mock the new method signature and assert that the constructed config carries the expected owner / repo / default description / default branch / release-disabled.
- [x] `mvn -pl components/promptlm-store/promptlm-store-api test` — 18 / 18 pass.
- [x] `mvn -pl components/promptlm-store/promptlm-store-github test` — 81 / 81 pass.
- [x] Full reactor `mvn -DskipTests install` — clean across all 18 modules.
- [ ] CI build (Testcontainers / acceptance tests not runnable locally — broken docker socket).

## Caveats

- The `repository-template/RepositoryTemplateActSmokeTest` could not be run locally because of the documented broken `/var/run/docker.sock` symlink. Behaviour is unchanged by this PR (no template files were touched), so this is expected to remain green in CI.
- A local sibling worktree was building `repository-template` with a divergent `RepositoryTemplateExtractor` interface (`extractTo(Path, TemplateContext)`); the local `~/.m2` was reset to the version from this worktree before tests ran. CI builds from a clean checkout, so this is local-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)