### PR TITLE
refactor(context): reference activeProject by id in context.json (#138)

### DIFF
--- a/components/promptlm-core/src/main/java/dev/promptlm/infrastructure/config/SerializingAppContext.java
+++ b/components/promptlm-core/src/main/java/dev/promptlm/infrastructure/config/SerializingAppContext.java
@@ -16,8 +16,8 @@
 
 package dev.promptlm.infrastructure.config;
 
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.DeserializationFeature;
 import dev.promptlm.domain.AppContext;
 import dev.promptlm.domain.BasicAppContext;
 import dev.promptlm.domain.projectspec.ProjectHealthStatus;
@@ -37,7 +37,9 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -121,7 +123,7 @@ public class SerializingAppContext implements AppContext, InitializingBean, Disp
             Path contextFile = getUserConfigPath().resolve(CONTEXT_FILE);
             try (Writer writer = Files.newBufferedWriter(contextFile)) {
                 ensureIdentifiers();
-                objectMapper.writeValue(writer, this.configData);
+                objectMapper.writeValue(writer, toWireFormat(this.configData));
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -144,10 +146,7 @@ public class SerializingAppContext implements AppContext, InitializingBean, Disp
             if (Files.notExists(appDataFile) || Files.readString(appDataFile).isBlank()) {
                 createDefaultConfig(appDataFile);
             } else {
-                this.configData = objectMapper
-                        .readerFor(BasicAppContext.class)
-                        .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                        .readValue(appDataFile.toFile());
+                this.configData = readFromTree(appDataFile);
                 validateLoadedProjects();
             }
             ensureIdentifiers();
@@ -155,6 +154,77 @@ public class SerializingAppContext implements AppContext, InitializingBean, Disp
         } catch (IOException e) {
             throw  new RuntimeException("Could not deserialize app context from %s".formatted(appDataFile), e);
         }
+    }
+
+    /**
+     * Builds the wire-format document written to {@code context.json}: the full project list is kept,
+     * but {@code activeProject} is reduced to a reference object containing only the {@code id}.
+     */
+    private static Map<String, Object> toWireFormat(AppContext source) {
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("projects", source.getProjects());
+        ProjectSpec activeProject = source.getActiveProject();
+        if (activeProject == null || activeProject.getId() == null) {
+            document.put("activeProject", null);
+        } else {
+            document.put("activeProject", Map.of("id", activeProject.getId()));
+        }
+        return document;
+    }
+
+    /**
+     * Reads {@code context.json} via the Jackson tree API. The {@code activeProject} field is
+     * expected as an id-only reference object ({@code {"id": "<uuid>"}}) that points at an entry
+     * in {@code projects[]}. The resulting {@link BasicAppContext} has an {@code activeProject}
+     * that is identity-equal to the matching entry in its projects list.
+     */
+    private BasicAppContext readFromTree(Path appDataFile) throws IOException {
+        JsonNode root = objectMapper.readTree(appDataFile.toFile());
+        BasicAppContext loaded = new BasicAppContext();
+
+        JsonNode projectsNode = root.get("projects");
+        if (projectsNode != null && !projectsNode.isNull()) {
+            List<ProjectSpec> projects = new ArrayList<>();
+            for (JsonNode projectNode : projectsNode) {
+                ProjectSpec project = objectMapper.treeToValue(projectNode, ProjectSpec.class);
+                if (project != null) {
+                    projects.add(project);
+                }
+            }
+            loaded.setProjects(projects);
+        }
+
+        JsonNode activeNode = root.get("activeProject");
+        if (activeNode == null || activeNode.isNull()) {
+            return loaded;
+        }
+
+        UUID activeId = parseActiveId(activeNode);
+        ProjectSpec resolved = resolveProjectById(activeId, loaded.getProjects());
+        if (resolved != null) {
+            loaded.setActiveProject(resolved);
+        }
+        return loaded;
+    }
+
+    private static UUID parseActiveId(JsonNode activeNode) {
+        JsonNode idNode = activeNode.get("id");
+        if (idNode == null || idNode.isNull()) {
+            return null;
+        }
+        return UUID.fromString(idNode.asText());
+    }
+
+    private static ProjectSpec resolveProjectById(UUID id, List<ProjectSpec> projects) {
+        if (id == null || projects == null) {
+            return null;
+        }
+        for (ProjectSpec project : projects) {
+            if (project != null && id.equals(project.getId())) {
+                return project;
+            }
+        }
+        return null;
     }
 
     private static void createDefaultConfig(Path appDataFile) {

--- a/components/promptlm-core/src/test/java/dev/promptlm/infrastructure/config/SerializingAppContextTest.java
+++ b/components/promptlm-core/src/test/java/dev/promptlm/infrastructure/config/SerializingAppContextTest.java
@@ -16,6 +16,7 @@
 
 package dev.promptlm.infrastructure.config;
 
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import dev.promptlm.domain.ObjectMapperFactory;
 import dev.promptlm.domain.projectspec.ProjectHealthStatus;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -80,9 +82,14 @@ class SerializingAppContextTest {
             Files.createDirectories(repoDir);
             Files.writeString(configPath, """
                     {
-                        "activeProject": {
-                            "repoDir": "%s"
-                        }
+                        "projects": [
+                            {
+                                "id": "00000000-0000-0000-0000-000000000001",
+                                "name": "demo",
+                                "repoDir": "%s"
+                            }
+                        ],
+                        "activeProject": { "id": "00000000-0000-0000-0000-000000000001" }
                     }
                     """.formatted(repoDir));
             System.setProperty("user.home", userHome.toString());
@@ -90,7 +97,7 @@ class SerializingAppContextTest {
             ObjectMapper mapper = ObjectMapperFactory.createJsonMapper();
             SerializingAppContext context = new SerializingAppContext(mapper);
             context.afterPropertiesSet();
-            assertThat(context.getActiveProject().getRepoDir().toString()).isEqualTo(repoDir.toString());
+            assertThat(context.getActiveProject().getRepoDir()).isEqualTo(repoDir.toAbsolutePath().normalize());
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
@@ -100,7 +107,7 @@ class SerializingAppContextTest {
     }
 
     @Test
-    @DisplayName("ignores unknown fields while reading existing config")
+    @DisplayName("ignores unknown fields on projects while reading existing config")
     void ignoresUnknownFieldsWhileReadingExistingConfig(@TempDir Path tempDir) throws IOException {
         String originalUserHome = System.getProperty("user.home");
         Path userHome = tempDir.resolve("user.unknown");
@@ -117,17 +124,13 @@ class SerializingAppContextTest {
                                 "name": "demo",
                                 "repoDir": "%s",
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "localPath": "%s"
+                                "localPath": "%s",
+                                "futureField": "ignored"
                             }
                         ],
-                        "activeProject": {
-                            "id": "00000000-0000-0000-0000-000000000001",
-                            "name": "demo",
-                            "repoDir": "%s",
-                            "updatedAt": "2026-01-01T00:00:00Z"
-                        }
+                        "activeProject": { "id": "00000000-0000-0000-0000-000000000001" }
                     }
-                    """.formatted(repoDir, repoDir, repoDir));
+                    """.formatted(repoDir, repoDir));
 
             System.setProperty("user.home", userHome.toString());
             ObjectMapper mapper = ObjectMapperFactory.createJsonMapper();
@@ -138,6 +141,12 @@ class SerializingAppContextTest {
             assertThat(context.getActiveProject()).isNotNull();
             assertThat(context.getActiveProject().getName()).isEqualTo("demo");
             assertThat(context.getActiveProject().getRepoDir()).isEqualTo(repoDir.toAbsolutePath().normalize());
+            // The returned activeProject must be the same instance as the matching entry in projects[].
+            ProjectSpec matchingProject = context.getProjects().stream()
+                    .filter(project -> "demo".equals(project.getName()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(context.getActiveProject()).isSameAs(matchingProject);
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
@@ -173,13 +182,9 @@ class SerializingAppContextTest {
                                 "repoDir": "%s"
                             }
                         ],
-                        "activeProject": {
-                            "id": "00000000-0000-0000-0000-000000000002",
-                            "name": "missing",
-                            "repoDir": "%s"
-                        }
+                        "activeProject": { "id": "00000000-0000-0000-0000-000000000002" }
                     }
-                    """.formatted(healthyRepoDir, missingRepoDir, missingRepoDir));
+                    """.formatted(healthyRepoDir, missingRepoDir));
 
             System.setProperty("user.home", userHome.toString());
             ObjectMapper mapper = ObjectMapperFactory.createJsonMapper();
@@ -195,6 +200,93 @@ class SerializingAppContextTest {
                     .orElseThrow();
             assertThat(missingProject.getHealthStatus()).isEqualTo(ProjectHealthStatus.BROKEN_LOCAL);
             assertThat(missingProject.getHealthMessage()).contains("Local repository missing at");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            System.setProperty("user.home", originalUserHome);
+            FileUtils.deleteDirectory(userHome.resolve(".promptlm").toFile());
+        }
+    }
+
+    @Test
+    @DisplayName("writes activeProject as an id-only reference and keeps full ProjectSpec in projects[]")
+    void writesActiveProjectAsIdOnlyReference(@TempDir Path tempDir) throws Exception {
+        String originalUserHome = System.getProperty("user.home");
+        Path userHome = tempDir.resolve("user.idonly");
+        try {
+            Path repoDir = tempDir.resolve("alpha-repo");
+            Files.createDirectories(repoDir);
+            System.setProperty("user.home", userHome.toString());
+
+            ObjectMapper mapper = ObjectMapperFactory.createJsonMapper();
+            SerializingAppContext context = new SerializingAppContext(mapper);
+            context.afterPropertiesSet();
+
+            ProjectSpec project = new ProjectSpec();
+            project.setName("alpha");
+            project.setRepoDir(repoDir);
+            context.setActiveProject(project);
+            context.destroy();
+
+            Path configPath = userHome.resolve(".promptlm/context.json");
+            JsonNode root = mapper.readTree(configPath.toFile());
+
+            JsonNode activeNode = root.get("activeProject");
+            assertThat(activeNode).isNotNull();
+            assertThat(activeNode.isObject()).isTrue();
+            assertThat(activeNode.size()).isEqualTo(1);
+            assertThat(activeNode.has("id")).isTrue();
+            UUID writtenId = UUID.fromString(activeNode.get("id").asText());
+            assertThat(writtenId).isEqualTo(context.getActiveProject().getId());
+
+            JsonNode projectsNode = root.get("projects");
+            assertThat(projectsNode.isArray()).isTrue();
+            assertThat(projectsNode.size()).isEqualTo(1);
+            assertThat(projectsNode.get(0).get("name").asText()).isEqualTo("alpha");
+            assertThat(projectsNode.get(0).get("id").asText()).isEqualTo(writtenId.toString());
+        } finally {
+            System.setProperty("user.home", originalUserHome);
+            FileUtils.deleteDirectory(userHome.resolve(".promptlm").toFile());
+        }
+    }
+
+    @Test
+    @DisplayName("reads id-only activeProject and resolves it to the same instance as the projects entry")
+    void readsIdOnlyActiveProjectPreservingInstanceIdentity(@TempDir Path tempDir) throws IOException {
+        String originalUserHome = System.getProperty("user.home");
+        Path userHome = tempDir.resolve("user.read-idonly");
+        try {
+            Path configPath = userHome.resolve(".promptlm/context.json");
+            Files.createDirectories(configPath.getParent());
+            Path repoDir = tempDir.resolve("alpha-repo");
+            Files.createDirectories(repoDir);
+            Files.writeString(configPath, """
+                    {
+                        "projects": [
+                            {
+                                "id": "00000000-0000-0000-0000-000000000010",
+                                "name": "alpha",
+                                "repoDir": "%s"
+                            }
+                        ],
+                        "activeProject": { "id": "00000000-0000-0000-0000-000000000010" }
+                    }
+                    """.formatted(repoDir));
+
+            System.setProperty("user.home", userHome.toString());
+            ObjectMapper mapper = ObjectMapperFactory.createJsonMapper();
+            SerializingAppContext context = new SerializingAppContext(mapper);
+            context.afterPropertiesSet();
+
+            ProjectSpec activeProject = context.getActiveProject();
+            assertThat(activeProject).isNotNull();
+            assertThat(activeProject.getId()).isEqualTo(UUID.fromString("00000000-0000-0000-0000-000000000010"));
+            assertThat(activeProject.getName()).isEqualTo("alpha");
+            ProjectSpec fromList = context.getProjects().stream()
+                    .filter(project -> activeProject.getId().equals(project.getId()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(activeProject).isSameAs(fromList);
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {


### PR DESCRIPTION
## Summary

- Reduces `activeProject` in `~/.promptlm/context.json` to `{"id": "<uuid>"}`; the full `ProjectSpec` lives once under `projects[]`.
- `AppContext.getActiveProject()` still returns a full `ProjectSpec`, identity-equal (`isSameAs`) to the matching `projects[]` entry — no caller of the in-memory API changes.
- No legacy-format fallback: there is no released schema to migrate from. A `context.json` whose `activeProject.id` is missing or unresolvable yields `activeProject = null`; a non-UUID `id` fails startup loudly.

## Scope

Changes are confined to the persistence boundary in `SerializingAppContext`. Domain types (`AppContext`, `BasicAppContext`, `ProjectSpec`), controllers, and store-github code are untouched.

## Test plan

- [x] `SerializingAppContextTest` — 6 tests, all pass:
  - `createsDefaultConfigIfNoneExists`
  - `readsConfigIfFound` (id-only fixture)
  - `ignoresUnknownFieldsWhileReadingExistingConfig` (asserts `isSameAs`)
  - `clearsActiveProjectWhenPersistedLocalRepositoryIsMissing`
  - `writesActiveProjectAsIdOnlyReference` (new)
  - `readsIdOnlyActiveProjectPreservingInstanceIdentity` (new)
- [x] Consumer-module regression run: `mvn -pl components/promptlm-domain,components/promptlm-core,components/promptlm-store/promptlm-store-github,components/promptlm-web-api,apps/promptlm-cli,apps/promptlm-webapp -am test` — BUILD SUCCESS.

Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)