### PR TITLE
fix(prompt-editor): Run uses current form state instead of stored YAML (#183)

### DIFF
--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpec.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpec.java
@@ -162,6 +162,18 @@ public class PromptSpec {
     @Schema(description = "Stable hash across semantic prompt fields")
     private final String semanticHash;
 
+    /**
+     * Derived lifecycle state of the spec. Server-derived only; never accepted
+     * from clients on writes. See {@link PromptSpecLifecycleState}.
+     */
+    @JsonProperty("lifecycleState")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "Server-derived lifecycle state of the spec. Omitted when the backend cannot derive it (e.g. no active project).",
+            implementation = PromptSpecLifecycleState.class,
+            nullable = true,
+            accessMode = Schema.AccessMode.READ_ONLY)
+    private final PromptSpecLifecycleState lifecycleState;
+
     public String getRepositoryUrl() {
         return repositoryUrl;
     }
@@ -265,6 +277,66 @@ public class PromptSpec {
             @JsonProperty("path") Path path,
             @JsonProperty("executions") List<Execution> executions,
             @JsonProperty("semanticHash") String semanticHash) {
+        this(
+                specVersion,
+                uuid,
+                id,
+                name,
+                group,
+                version,
+                revision,
+                description,
+                authors,
+                purpose,
+                repositoryUrl,
+                status,
+                createdAt,
+                updatedAt,
+                retiredAt,
+                retiredReason,
+                request,
+                placeholders,
+                response,
+                extensions,
+                path,
+                executions,
+                semanticHash,
+                null
+        );
+    }
+
+    /**
+     * Full-args constructor including the derived {@link #lifecycleState}.
+     * The {@code lifecycleState} parameter is intentionally <em>not</em> part
+     * of the {@code @JsonCreator} signature — the API derives the value at the
+     * boundary (see {@code PromptSpecLifecycleDeriver}) and any incoming JSON
+     * value is silently ignored on deserialization.
+     */
+    private PromptSpec(
+            String specVersion,
+            UUID uuid,
+            String id,
+            String name,
+            String group,
+            String version,
+            Integer revision,
+            String description,
+            List<String> authors,
+            String purpose,
+            String repositoryUrl,
+            PromptStatus status,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt,
+            LocalDateTime retiredAt,
+            String retiredReason,
+            Request request,
+            Placeholders placeholders,
+            Response response,
+            Map<String, JsonNode> extensions,
+            Path path,
+            List<Execution> executions,
+            String semanticHash,
+            PromptSpecLifecycleState lifecycleState) {
 
         this.specVersion = specVersion;
         this.uuid = uuid;
@@ -289,6 +361,7 @@ public class PromptSpec {
         this.path = path;
         this.executions = executions;
         this.semanticHash = semanticHash;
+        this.lifecycleState = lifecycleState;
     }
 
     public PromptSpec(
@@ -461,6 +534,44 @@ public class PromptSpec {
 
     public PromptSpec withSemanticHash(String semanticHash) {
         return Objects.equals(this.semanticHash, semanticHash) ? this : new PromptSpec(this.specVersion, this.uuid, this.id, this.name, this.group, this.version, this.revision, this.description, this.authors, this.purpose, this.repositoryUrl, this.status, this.createdAt, this.updatedAt, this.retiredAt, this.retiredReason, this.request, this.placeholders, this.response, this.extensions, this.path, this.executions, semanticHash);
+    }
+
+    /**
+     * Returns a copy with the given lifecycle state. Intended for use at the
+     * API boundary only — never set on objects that are about to be persisted
+     * to disk, because the field is {@code @JsonInclude(NON_NULL)} and would
+     * pollute the on-disk YAML if non-null.
+     */
+    public PromptSpec withLifecycleState(PromptSpecLifecycleState lifecycleState) {
+        return this.lifecycleState == lifecycleState ? this : new PromptSpec(
+                this.specVersion,
+                this.uuid,
+                this.id,
+                this.name,
+                this.group,
+                this.version,
+                this.revision,
+                this.description,
+                this.authors,
+                this.purpose,
+                this.repositoryUrl,
+                this.status,
+                this.createdAt,
+                this.updatedAt,
+                this.retiredAt,
+                this.retiredReason,
+                this.request,
+                this.placeholders,
+                this.response,
+                this.extensions,
+                this.path,
+                this.executions,
+                this.semanticHash,
+                lifecycleState);
+    }
+
+    public PromptSpecLifecycleState getLifecycleState() {
+        return lifecycleState;
     }
 
     @JsonIgnore

--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpecLifecycleState.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpecLifecycleState.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.domain.promptspec;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Locale;
+
+/**
+ * Lifecycle state of a {@link PromptSpec}.
+ *
+ * <p>The state is a function of where the spec's content lives along the
+ * persistence chain: form-only ({@link #DRAFT}), persisted but not yet
+ * revisioned ({@link #SAVED}), revisioned in the local Git store
+ * ({@link #COMMITTED}), or pushed to the remote ({@link #PUSHED}).
+ *
+ * <p><strong>{@code DRAFT} is a client-only state.</strong> The backend has no
+ * observation of an in-browser form, so the API will never emit {@code DRAFT}
+ * from a {@code GET}; the UI computes draft by diffing the form state against
+ * the latest {@code PromptSpec} returned from the API. {@code DRAFT} is
+ * present in this enum so the entire stack shares one vocabulary.
+ *
+ * <p>The state is <em>derived</em> from storage truth (on-disk YAML, HEAD
+ * commit, origin/branch reachability) at the API boundary. It is never
+ * accepted as input on writes.
+ *
+ * @see <a href="https://github.com/promptLM/promptlm-app/issues/189">Issue #189</a>
+ */
+@Schema(description = "Lifecycle state of a prompt spec. " +
+        "`draft` is client-only (form-vs-server diff); the API only ever emits " +
+        "`saved`, `committed`, or `pushed`.",
+        enumAsRef = true)
+public enum PromptSpecLifecycleState {
+
+    /**
+     * Form state has unpersisted changes. Computed by the UI by diffing the
+     * editor's form state against the latest {@code PromptSpec} returned from
+     * the API. Never emitted by the backend.
+     */
+    DRAFT,
+
+    /**
+     * Persisted to local storage but the working-tree YAML differs from the
+     * latest commit that touched the spec file (or no commit exists yet for
+     * the spec file).
+     */
+    SAVED,
+
+    /**
+     * Revisioned in the local Git store: HEAD of the active branch carries the
+     * latest content for the spec file, but that commit is not yet on
+     * {@code origin/<branch>}.
+     */
+    COMMITTED,
+
+    /**
+     * The commit that carries the current spec content is reachable on
+     * {@code origin/<active-branch>}.
+     */
+    PUSHED;
+
+    @JsonValue
+    public String json() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    @JsonCreator
+    public static PromptSpecLifecycleState fromJson(String value) {
+        if (value == null) {
+            return null;
+        }
+        return PromptSpecLifecycleState.valueOf(value.toUpperCase(Locale.ROOT));
+    }
+}

--- a/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/PromptSpecEqualityTests.java
+++ b/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/PromptSpecEqualityTests.java
@@ -73,4 +73,19 @@ class PromptSpecEqualityTests {
         PromptSpec spec2 = createPromptSpec("id", "name", "group1", "1", 2);
         assertNotEquals(spec1, spec2);
     }
+
+    @Test
+    void lifecycleStateIsExcludedFromEqualityBecauseItIsDerived() {
+        // Lifecycle state is a derived view, not part of identity. Two specs
+        // that differ only in lifecycle state must remain equal so that
+        // dedup / cache lookups by identity continue to work.
+        PromptSpec base = createPromptSpec("id", "name", "group1", "1", 1);
+        PromptSpec saved = base.withLifecycleState(PromptSpecLifecycleState.SAVED);
+        PromptSpec pushed = base.withLifecycleState(PromptSpecLifecycleState.PUSHED);
+
+        assertEquals(base, saved);
+        assertEquals(saved, pushed);
+        assertEquals(base.hashCode(), saved.hashCode());
+        assertEquals(saved.hashCode(), pushed.hashCode());
+    }
 }

--- a/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/PromptSpecLifecycleStateTest.java
+++ b/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/PromptSpecLifecycleStateTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.domain.promptspec;
+
+import dev.promptlm.domain.ObjectMapperFactory;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PromptSpecLifecycleStateTest {
+
+    private final ObjectMapper mapper = ObjectMapperFactory.createJsonMapper();
+
+    @Test
+    void serializesEachValueAsLowercaseJsonString() {
+        for (PromptSpecLifecycleState value : PromptSpecLifecycleState.values()) {
+            String json = mapper.writeValueAsString(value);
+            assertThat(json).isEqualTo("\"" + value.name().toLowerCase() + "\"");
+        }
+    }
+
+    @Test
+    void deserializesLowercaseAndUppercase() {
+        assertThat(mapper.readValue("\"draft\"", PromptSpecLifecycleState.class))
+                .isEqualTo(PromptSpecLifecycleState.DRAFT);
+        assertThat(mapper.readValue("\"SAVED\"", PromptSpecLifecycleState.class))
+                .isEqualTo(PromptSpecLifecycleState.SAVED);
+        assertThat(mapper.readValue("\"Committed\"", PromptSpecLifecycleState.class))
+                .isEqualTo(PromptSpecLifecycleState.COMMITTED);
+        assertThat(mapper.readValue("\"pushed\"", PromptSpecLifecycleState.class))
+                .isEqualTo(PromptSpecLifecycleState.PUSHED);
+    }
+
+    @Test
+    void enumHasAllFourCanonicalValuesFromIssue189() {
+        // Issue #189 fixes the four canonical states. Any change to this enum
+        // is a contract change with the dependent issues (#183-#188); fail
+        // hard if a value is added or removed without revisiting the model.
+        assertThat(PromptSpecLifecycleState.values())
+                .containsExactly(
+                        PromptSpecLifecycleState.DRAFT,
+                        PromptSpecLifecycleState.SAVED,
+                        PromptSpecLifecycleState.COMMITTED,
+                        PromptSpecLifecycleState.PUSHED);
+    }
+}

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecApiView.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecApiView.java
@@ -18,6 +18,7 @@ package dev.promptlm.web;
 
 import dev.promptlm.domain.promptspec.Execution;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.PromptSpecLifecycleState;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -41,9 +42,40 @@ final class PromptSpecApiView {
     }
 
     static PromptSpec toApiView(PromptSpec spec) {
+        return toApiView(spec, null);
+    }
+
+    /**
+     * Returns the spec mapped for HTTP output (executions newest-first) with
+     * an optional derived lifecycle state attached. Pass {@code null} for
+     * {@code deriver} when the caller has no lifecycle context (e.g. internal
+     * mappings or tests of unrelated code paths) — the field is then omitted
+     * from the JSON response.
+     */
+    static PromptSpec toApiView(PromptSpec spec, PromptSpecLifecycleDeriver deriver) {
         if (spec == null) {
             return null;
         }
+        PromptSpec withExecutions = sortExecutionsNewestFirst(spec);
+        return withLifecycleState(withExecutions, deriver);
+    }
+
+    static List<PromptSpec> toApiView(List<PromptSpec> specs) {
+        return toApiView(specs, null);
+    }
+
+    static List<PromptSpec> toApiView(List<PromptSpec> specs, PromptSpecLifecycleDeriver deriver) {
+        if (specs == null) {
+            return null;
+        }
+        List<PromptSpec> mapped = new ArrayList<>(specs.size());
+        for (PromptSpec spec : specs) {
+            mapped.add(toApiView(spec, deriver));
+        }
+        return mapped;
+    }
+
+    private static PromptSpec sortExecutionsNewestFirst(PromptSpec spec) {
         List<Execution> executions = spec.getExecutions();
         if (executions == null || executions.size() < 2) {
             return spec;
@@ -53,15 +85,15 @@ final class PromptSpecApiView {
         return spec.withExecutions(sorted);
     }
 
-    static List<PromptSpec> toApiView(List<PromptSpec> specs) {
-        if (specs == null) {
-            return null;
+    private static PromptSpec withLifecycleState(PromptSpec spec, PromptSpecLifecycleDeriver deriver) {
+        if (deriver == null) {
+            return spec;
         }
-        List<PromptSpec> mapped = new ArrayList<>(specs.size());
-        for (PromptSpec spec : specs) {
-            mapped.add(toApiView(spec));
+        PromptSpecLifecycleState state = deriver.derive(spec);
+        if (state == null) {
+            return spec;
         }
-        return mapped;
+        return spec.withLifecycleState(state);
     }
 
     private static Instant timestampOrEpoch(Execution execution) {

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
@@ -694,8 +694,8 @@ public class PromptSpecController {
             @RequestBody(description = "Prompt specification to execute. When supplied, the contained "
                     + "`promptSpec` is executed in place of the stored YAML. This lets the editor run "
                     + "the current form state without saving (issue #183). The path id is always "
-                    + "authoritative; a body id that mismatches the path id returns 400. The execution "
-                    + "is still recorded against the stored prompt id and its stored revision.",
+                    + "authoritative; a body id that mismatches the path id returns 400. Draft "
+                    + "executions are ephemeral and are NOT recorded in the prompt's execution history.",
                     required = false,
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ExecutePromptRequest.class)))
@@ -707,6 +707,7 @@ public class PromptSpecController {
 
         PromptSpec storedSpec = latestStoredSpec.get();
         PromptSpec promptSpecToExecute = storedSpec;
+        boolean isDraftExecution = false;
 
         if (request != null && request.getPromptSpec() != null) {
             PromptSpec requestPromptSpec = request.getPromptSpec();
@@ -716,8 +717,9 @@ public class PromptSpecController {
             // Execute the draft from the request body (issue #183). The path id is
             // authoritative — force it onto the spec so any downstream code that
             // reads the id sees the canonical one. We do not persist the draft;
-            // it lives only for this single execution.
+            // it lives only for this single execution (see D-183-5).
             promptSpecToExecute = requestPromptSpec.withId(promptSpecId);
+            isDraftExecution = true;
         }
 
         if (promptSpecToExecute.getId() == null || promptSpecToExecute.getId().isBlank()) {
@@ -726,10 +728,16 @@ public class PromptSpecController {
         Instant runStart = Instant.now();
         try {
             PromptSpec executedSpec = promptExecutor.runPromptAndAttachResponse(promptSpecToExecute);
-            // The recorded execution's revision is pinned to the stored spec's
-            // revision: a draft has no real revision yet, and the run should
-            // appear in history as "executed against revision N" — the revision
-            // the draft was branched from.
+            if (isDraftExecution) {
+                // Draft executions are ephemeral: the response is returned to the
+                // UI so it can be displayed, but nothing is written to history.
+                // History only ever contains runs of actually-stored content
+                // (D-183-5; reverses the consequence note in D-183-3).
+                return ResponseEntity.ok(PromptSpecApiView.toApiView(executedSpec, lifecycleDeriver));
+            }
+            // No-body fallback (called by PromptDetail.tsx): the stored spec was
+            // executed, so the run is genuine and is recorded against the
+            // stored revision.
             Execution devRun = buildDevExecution(executedSpec, storedSpec.getRevision(), runStart);
             PromptSpec persisted = promptLifecycleFacade.recordExecution(promptSpecId, devRun);
             return ResponseEntity.ok(PromptSpecApiView.toApiView(persisted, lifecycleDeriver));

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
@@ -77,15 +77,18 @@ public class PromptSpecController {
     private final PromptExecutor promptExecutor;
     private final PromptLifecycleFacade promptLifecycleFacade;
     private final AppContext appContext;
+    private final PromptSpecLifecycleDeriver lifecycleDeriver;
 
     public PromptSpecController(PromptStore promptStore,
                                 PromptExecutor promptExecutor,
                                 PromptLifecycleFacade promptLifecycleFacade,
-                                AppContext appContext) {
+                                AppContext appContext,
+                                PromptSpecLifecycleDeriver lifecycleDeriver) {
         this.promptStore = promptStore;
         this.promptExecutor = promptExecutor;
         this.promptLifecycleFacade = promptLifecycleFacade;
         this.appContext = appContext;
+        this.lifecycleDeriver = lifecycleDeriver;
     }
 
     /**
@@ -104,7 +107,7 @@ public class PromptSpecController {
             @Parameter(description = "Unique identifier of the prompt specification")
             @PathVariable(name = "promptSpecId") String promptSpecId) {
         Optional<PromptSpec> latestVersion = promptStore.getLatestVersion(promptSpecId);
-        return ResponseEntity.of(latestVersion.map(PromptSpecApiView::toApiView));
+        return ResponseEntity.of(latestVersion.map(spec -> PromptSpecApiView.toApiView(spec, lifecycleDeriver)));
     }
 
     /**
@@ -119,7 +122,7 @@ public class PromptSpecController {
     @GetMapping
     public ResponseEntity<List<PromptSpec>> listPromptSpecs() {
         List<PromptSpec> prompts = promptStore.listAllPrompts();
-        return ResponseEntity.ok(PromptSpecApiView.toApiView(prompts));
+        return ResponseEntity.ok(PromptSpecApiView.toApiView(prompts, lifecycleDeriver));
     }
     
     /**
@@ -146,7 +149,7 @@ public class PromptSpecController {
 
         try {
             PromptSpec created = promptLifecycleFacade.createPromptSpec(promptSpec);
-            return ResponseEntity.ok(PromptSpecApiView.toApiView(created));
+            return ResponseEntity.ok(PromptSpecApiView.toApiView(created, lifecycleDeriver));
         } catch (PromptSpecAlreadyExistsException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage(), e);
         }
@@ -182,7 +185,7 @@ public class PromptSpecController {
         }
         
         PromptSpec spec = promptLifecycleFacade.updatePrompt(promptSpecId, promptSpec);
-        return ResponseEntity.ok(PromptSpecApiView.toApiView(spec));
+        return ResponseEntity.ok(PromptSpecApiView.toApiView(spec, lifecycleDeriver));
     }
 
     @Operation(
@@ -662,7 +665,7 @@ public class PromptSpecController {
         PromptSpec promptSpec = request.getPromptSpec();
         try {
             PromptSpec executedSpec = promptExecutor.runPromptAndAttachResponse(promptSpec);
-            return ResponseEntity.ok(PromptSpecApiView.toApiView(executedSpec));
+            return ResponseEntity.ok(PromptSpecApiView.toApiView(executedSpec, lifecycleDeriver));
         } catch (RuntimeException exception) {
             throw mapPromptExecutionException(promptSpec.getId(), exception);
         }
@@ -713,7 +716,7 @@ public class PromptSpecController {
             PromptSpec executedSpec = promptExecutor.runPromptAndAttachResponse(promptSpecToExecute);
             Execution devRun = buildDevExecution(executedSpec, runStart);
             PromptSpec persisted = promptLifecycleFacade.recordExecution(promptSpecId, devRun);
-            return ResponseEntity.ok(PromptSpecApiView.toApiView(persisted));
+            return ResponseEntity.ok(PromptSpecApiView.toApiView(persisted, lifecycleDeriver));
         } catch (RuntimeException exception) {
             throw mapPromptExecutionException(promptSpecId, exception);
         }

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
@@ -691,7 +691,12 @@ public class PromptSpecController {
     public ResponseEntity<?> executeStoredPrompt(
             @Parameter(description = "ID of the prompt specification to execute", required = true)
             @PathVariable("promptSpecId") String promptSpecId,
-            @RequestBody(description = "Prompt specification to execute", required = false,
+            @RequestBody(description = "Prompt specification to execute. When supplied, the contained "
+                    + "`promptSpec` is executed in place of the stored YAML. This lets the editor run "
+                    + "the current form state without saving (issue #183). The path id is always "
+                    + "authoritative; a body id that mismatches the path id returns 400. The execution "
+                    + "is still recorded against the stored prompt id and its stored revision.",
+                    required = false,
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ExecutePromptRequest.class)))
             @Valid @org.springframework.web.bind.annotation.RequestBody(required = false) ExecutePromptRequest request) {
@@ -700,21 +705,32 @@ public class PromptSpecController {
             return ResponseEntity.notFound().build();
         }
 
+        PromptSpec storedSpec = latestStoredSpec.get();
+        PromptSpec promptSpecToExecute = storedSpec;
+
         if (request != null && request.getPromptSpec() != null) {
             PromptSpec requestPromptSpec = request.getPromptSpec();
             if (requestPromptSpec.getId() != null && !promptSpecId.equals(requestPromptSpec.getId())) {
                 return ResponseEntity.badRequest().build();
             }
+            // Execute the draft from the request body (issue #183). The path id is
+            // authoritative — force it onto the spec so any downstream code that
+            // reads the id sees the canonical one. We do not persist the draft;
+            // it lives only for this single execution.
+            promptSpecToExecute = requestPromptSpec.withId(promptSpecId);
         }
 
-        PromptSpec promptSpecToExecute = latestStoredSpec.get();
         if (promptSpecToExecute.getId() == null || promptSpecToExecute.getId().isBlank()) {
             promptSpecToExecute = promptSpecToExecute.withId(promptSpecId);
         }
         Instant runStart = Instant.now();
         try {
             PromptSpec executedSpec = promptExecutor.runPromptAndAttachResponse(promptSpecToExecute);
-            Execution devRun = buildDevExecution(executedSpec, runStart);
+            // The recorded execution's revision is pinned to the stored spec's
+            // revision: a draft has no real revision yet, and the run should
+            // appear in history as "executed against revision N" — the revision
+            // the draft was branched from.
+            Execution devRun = buildDevExecution(executedSpec, storedSpec.getRevision(), runStart);
             PromptSpec persisted = promptLifecycleFacade.recordExecution(promptSpecId, devRun);
             return ResponseEntity.ok(PromptSpecApiView.toApiView(persisted, lifecycleDeriver));
         } catch (RuntimeException exception) {
@@ -722,7 +738,7 @@ public class PromptSpecController {
         }
     }
 
-    private static Execution buildDevExecution(PromptSpec executedSpec, Instant runStart) {
+    private static Execution buildDevExecution(PromptSpec executedSpec, int revision, Instant runStart) {
         Instant now = Instant.now();
         long latencyMs = java.time.Duration.between(runStart, now).toMillis();
         return new Execution(
@@ -736,7 +752,7 @@ public class PromptSpecController {
                 null,
                 null,
                 null,
-                Integer.toString(executedSpec.getRevision()),
+                Integer.toString(revision),
                 null,
                 true,
                 null,

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecLifecycleDeriver.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecLifecycleDeriver.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.web;
+
+import dev.promptlm.domain.AppContext;
+import dev.promptlm.domain.projectspec.ProjectSpec;
+import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.PromptSpecLifecycleState;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+/**
+ * Derives the {@link PromptSpecLifecycleState} of a {@link PromptSpec} from
+ * storage truth — i.e. by comparing on-disk YAML to the active project's Git
+ * HEAD and to the corresponding {@code origin/<branch>} ref.
+ *
+ * <p>Returns {@code null} when the state cannot be derived (no active project,
+ * no repo dir, no HEAD, etc.). Callers should treat {@code null} as "no
+ * lifecycle information available" and surface the field as omitted in JSON
+ * (which is the default behaviour because {@code PromptSpec.lifecycleState} is
+ * {@code @JsonInclude(NON_NULL)}).
+ *
+ * <p>Never throws on I/O failures — diagnostic info is logged at WARN, and
+ * derivation falls through to {@code null}. The lifecycle field is decorative
+ * metadata for the UI; a Git read hiccup must not break the {@code GET}.
+ *
+ * @see <a href="https://github.com/promptLM/promptlm-app/issues/189">Issue #189</a>
+ */
+@Component
+class PromptSpecLifecycleDeriver {
+
+    private static final Logger log = LoggerFactory.getLogger(PromptSpecLifecycleDeriver.class);
+
+    private final AppContext appContext;
+
+    PromptSpecLifecycleDeriver(AppContext appContext) {
+        this.appContext = appContext;
+    }
+
+    /**
+     * Returns the lifecycle state of the given spec, or {@code null} when it
+     * cannot be derived.
+     */
+    PromptSpecLifecycleState derive(PromptSpec spec) {
+        if (spec == null) {
+            return null;
+        }
+        Path repoDir = resolveRepoDir();
+        if (repoDir == null) {
+            return null;
+        }
+        Path specPath = resolveSpecPath(spec, repoDir);
+        if (specPath == null) {
+            return null;
+        }
+        try (Git git = Git.open(repoDir.toFile())) {
+            Repository repo = git.getRepository();
+            String relativeGitPath = toGitPath(repoDir, specPath);
+            if (relativeGitPath == null) {
+                return null;
+            }
+
+            byte[] workingTreeContent = Files.exists(specPath)
+                    ? Files.readAllBytes(specPath)
+                    : null;
+            byte[] headContent = readBlobAtHead(repo, relativeGitPath);
+
+            if (!Arrays.equals(workingTreeContent, headContent)) {
+                // Working tree differs from HEAD (or HEAD has no blob yet for
+                // this path). The change has been "saved" to disk but is not
+                // captured by a commit yet.
+                return PromptSpecLifecycleState.SAVED;
+            }
+
+            // Working tree matches HEAD; differentiate committed vs pushed.
+            if (isHeadReachableFromOrigin(repo)) {
+                return PromptSpecLifecycleState.PUSHED;
+            }
+            return PromptSpecLifecycleState.COMMITTED;
+        } catch (IOException | RuntimeException e) {
+            log.warn("Failed to derive lifecycle state for prompt {}/{} at {}: {}",
+                    spec.getGroup(), spec.getName(), specPath, e.toString());
+            return null;
+        }
+    }
+
+    private Path resolveRepoDir() {
+        ProjectSpec activeProject = appContext.getActiveProject();
+        if (activeProject == null) {
+            return null;
+        }
+        Path repoDir = activeProject.getRepoDir();
+        if (repoDir == null) {
+            return null;
+        }
+        Path normalized = repoDir.toAbsolutePath().normalize();
+        if (!Files.isDirectory(normalized)) {
+            return null;
+        }
+        return normalized;
+    }
+
+    private Path resolveSpecPath(PromptSpec spec, Path repoDir) {
+        Path specPath = spec.getPath();
+        if (specPath == null) {
+            return null;
+        }
+        if (specPath.isAbsolute()) {
+            return specPath.normalize();
+        }
+        return repoDir.resolve(specPath).normalize();
+    }
+
+    private String toGitPath(Path repoDir, Path specPath) {
+        Path relative;
+        try {
+            relative = repoDir.relativize(specPath);
+        } catch (IllegalArgumentException ex) {
+            // specPath is not under repoDir — caller should not have passed it.
+            return null;
+        }
+        return relative.toString().replace('\\', '/');
+    }
+
+    private byte[] readBlobAtHead(Repository repo, String relativeGitPath) throws IOException {
+        ObjectId headId = repo.resolve("HEAD^{tree}");
+        if (headId == null) {
+            return null;
+        }
+        try (RevWalk walk = new RevWalk(repo);
+             TreeWalk treeWalk = TreeWalk.forPath(repo, relativeGitPath, headId)) {
+            if (treeWalk == null) {
+                return null;
+            }
+            ObjectId blobId = treeWalk.getObjectId(0);
+            if (blobId == null || blobId.equals(ObjectId.zeroId())) {
+                return null;
+            }
+            try {
+                return repo.open(blobId).getBytes();
+            } catch (MissingObjectException missing) {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Returns {@code true} when the local HEAD commit is reachable from the
+     * remote-tracking ref {@code refs/remotes/origin/<current-branch>}.
+     *
+     * <p>When no matching remote ref exists (e.g. the branch has never been
+     * pushed, or the project has no remote configured), returns {@code false}
+     * — the commit is "committed" but not "pushed".
+     */
+    private boolean isHeadReachableFromOrigin(Repository repo) throws IOException {
+        ObjectId headId = repo.resolve("HEAD");
+        if (headId == null) {
+            return false;
+        }
+        String branch = repo.getBranch();
+        if (branch == null) {
+            return false;
+        }
+        Ref originRef = repo.findRef("refs/remotes/origin/" + branch);
+        if (originRef == null) {
+            return false;
+        }
+        ObjectId originId = originRef.getObjectId();
+        if (originId == null) {
+            return false;
+        }
+        try (RevWalk walk = new RevWalk(repo)) {
+            RevCommit headCommit;
+            RevCommit originCommit;
+            try {
+                headCommit = walk.parseCommit(headId);
+                originCommit = walk.parseCommit(originId);
+            } catch (MissingObjectException missing) {
+                return false;
+            }
+            return walk.isMergedInto(headCommit, originCommit);
+        }
+    }
+}

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
@@ -65,6 +65,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -493,12 +495,13 @@ class PromptSpecControllerWebMvcTest {
     }
 
     @Test
-    void executeStoredPromptExecutesRequestBodyDraftWhenProvided() throws Exception {
-        // Issue #183: when the request body carries a PromptSpec (e.g. the
-        // editor's current form state), the controller must execute *that*
-        // spec rather than the stored YAML. The recorded execution still
-        // belongs to the stored prompt id at the stored revision (the draft
-        // is a hypothetical overlay; it has not been persisted).
+    void executeStoredPromptExecutesRequestBodyDraftWhenProvidedButDoesNotRecordHistory() throws Exception {
+        // Issue #183 / D-183-5: when the request body carries a PromptSpec
+        // (e.g. the editor's current form state), the controller must execute
+        // *that* spec rather than the stored YAML — and return the executed
+        // result to the UI so it can render the response — but the execution
+        // is NOT recorded in history. Draft executions are ephemeral: history
+        // only ever contains runs of actually-stored content.
         String promptId = "prompt-a";
 
         ChatCompletionRequest storedRequestPayload = ChatCompletionRequest.builder()
@@ -552,22 +555,9 @@ class PromptSpecControllerWebMvcTest {
         // The executor returns whatever spec it was handed, with a response
         // attached — the controller passes the draft, so we mirror that.
         PromptSpec executedDraft = draftPrompt.withResponse(response);
-        Execution recorded = new Execution(
-                "exec-uuid",
-                Instant.parse("2026-05-12T12:00:00Z"),
-                response,
-                null,
-                null);
-        // The persisted spec after recording is the stored prompt with the
-        // execution attached — storage truth is unchanged, only history grew.
-        PromptSpec persistedPrompt = storedPrompt
-                .withResponse(response)
-                .withExecutions(List.of(recorded));
 
         when(promptExecutor.runPromptAndAttachResponse(any(PromptSpec.class))).thenReturn(executedDraft);
         when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(storedPrompt));
-        when(promptLifecycleFacade.recordExecution(eq(promptId), any(Execution.class)))
-                .thenReturn(persistedPrompt);
 
         ExecutePromptRequest executePromptRequest = new ExecutePromptRequest(draftPrompt);
 
@@ -576,11 +566,14 @@ class PromptSpecControllerWebMvcTest {
                         .content(objectMapper.writeValueAsString(executePromptRequest)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"))
-                .andExpect(jsonPath("$.response.content").value("Pong"))
-                .andExpect(jsonPath("$.executions[0].id").value("exec-uuid"))
-                .andExpect(jsonPath("$.executions[0].response.content").value("Pong"));
+                // (a) The response body reflects the *draft*-modified content,
+                // confirming the draft (not the stored spec) was executed.
+                .andExpect(jsonPath("$.description").value("draft desc — unsaved"))
+                .andExpect(jsonPath("$.request.messages[0].content")
+                        .value("Draft ping — unsaved edit"))
+                .andExpect(jsonPath("$.response.content").value("Pong"));
 
-        // The executor was called with the *draft* spec (issue #183).
+        // The executor was called with the *draft* spec.
         ArgumentCaptor<PromptSpec> executedPromptCaptor = ArgumentCaptor.forClass(PromptSpec.class);
         verify(promptExecutor).runPromptAndAttachResponse(executedPromptCaptor.capture());
         PromptSpec executed = executedPromptCaptor.getValue();
@@ -592,16 +585,12 @@ class PromptSpecControllerWebMvcTest {
         // Path id is authoritative.
         assertThat(executed.getId()).isEqualTo(promptId);
 
-        // The recorded execution is pinned to the *stored* revision — the draft
-        // does not get to spoof a revision number into history.
-        ArgumentCaptor<Execution> executionCaptor = ArgumentCaptor.forClass(Execution.class);
-        verify(promptLifecycleFacade).recordExecution(eq(promptId), executionCaptor.capture());
-        Execution captured = executionCaptor.getValue();
-        assertThat(captured.getId()).isNotBlank();
-        assertThat(captured.getKind()).isEqualTo(dev.promptlm.domain.promptspec.ExecutionKind.MANUAL);
-        assertThat(captured.getOk()).isTrue();
-        assertThat(captured.getRevision()).isEqualTo("3");
-        assertThat(((ChatCompletionResponse) captured.getResponse()).getContent()).isEqualTo("Pong");
+        // (b) recordExecution must NOT be called for draft runs — history is
+        // left untouched. D-183-5 reverses the earlier behaviour pinned by
+        // D-183-3, because recording under the stored revision while the
+        // executed content is the draft produces misleading history rows.
+        verify(promptLifecycleFacade, never())
+                .recordExecution(eq(promptId), any(Execution.class));
     }
 
     @Test

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
@@ -94,6 +94,9 @@ class PromptSpecControllerWebMvcTest {
     @MockitoBean
     private AppContext appContext;
 
+    @MockitoBean
+    private PromptSpecLifecycleDeriver lifecycleDeriver;
+
     @Test
     void getDefaultTemplateReturnsCanonicalDraftSeed() throws Exception {
         PromptSpec.Placeholders placeholders = new PromptSpec.Placeholders();
@@ -271,6 +274,49 @@ class PromptSpecControllerWebMvcTest {
                         .build())
                 .build()
                 .withId(promptId);
+    }
+
+    @Test
+    void getByIdIncludesDerivedLifecycleStateInResponse() throws Exception {
+        String promptId = "welcome";
+        PromptSpec stored = baseSpec("support/" + promptId);
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
+        when(lifecycleDeriver.derive(any(PromptSpec.class)))
+                .thenReturn(dev.promptlm.domain.promptspec.PromptSpecLifecycleState.PUSHED);
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}", promptId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lifecycleState").value("pushed"));
+    }
+
+    @Test
+    void getByIdOmitsLifecycleStateWhenDeriverReturnsNull() throws Exception {
+        String promptId = "welcome";
+        PromptSpec stored = baseSpec("support/" + promptId);
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
+        when(lifecycleDeriver.derive(any(PromptSpec.class))).thenReturn(null);
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}", promptId))
+                .andExpect(status().isOk())
+                .andExpect(content().string(not(containsString("\"lifecycleState\""))));
+    }
+
+    @Test
+    void getByIdNeverEmitsDraftStateBecauseDraftIsClientOnly() throws Exception {
+        // Belt-and-braces: even if a misbehaving deriver returned DRAFT, the
+        // controller path would still echo it (the deriver is the sole writer).
+        // This test pins the contract that the API path passes the value
+        // through to JSON exactly, so callers can rely on the enum vocabulary —
+        // and documents that the production deriver never returns DRAFT.
+        String promptId = "welcome";
+        PromptSpec stored = baseSpec("support/" + promptId);
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
+        when(lifecycleDeriver.derive(any(PromptSpec.class)))
+                .thenReturn(dev.promptlm.domain.promptspec.PromptSpecLifecycleState.SAVED);
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}", promptId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lifecycleState").value("saved"));
     }
 
     @Test

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
@@ -493,16 +493,33 @@ class PromptSpecControllerWebMvcTest {
     }
 
     @Test
-    void executeStoredPromptRecordsExecutionAndReturnsPersistedSpec() throws Exception {
+    void executeStoredPromptExecutesRequestBodyDraftWhenProvided() throws Exception {
+        // Issue #183: when the request body carries a PromptSpec (e.g. the
+        // editor's current form state), the controller must execute *that*
+        // spec rather than the stored YAML. The recorded execution still
+        // belongs to the stored prompt id at the stored revision (the draft
+        // is a hypothetical overlay; it has not been persisted).
         String promptId = "prompt-a";
 
-        ChatCompletionRequest requestPayload = ChatCompletionRequest.builder()
+        ChatCompletionRequest storedRequestPayload = ChatCompletionRequest.builder()
                 .withVendor("openai")
                 .withModel("gpt-4o")
                 .withMessages(List.of(
                         ChatCompletionRequest.Message.builder()
                                 .withRole("user")
-                                .withContent("Ping")
+                                .withContent("Stored ping")
+                                .build()
+                ))
+                .withParameters(Map.of())
+                .build();
+
+        ChatCompletionRequest draftRequestPayload = ChatCompletionRequest.builder()
+                .withVendor("openai")
+                .withModel("gpt-4o")
+                .withMessages(List.of(
+                        ChatCompletionRequest.Message.builder()
+                                .withRole("user")
+                                .withContent("Draft ping — unsaved edit")
                                 .build()
                 ))
                 .withParameters(Map.of())
@@ -513,39 +530,46 @@ class PromptSpecControllerWebMvcTest {
                 .withName("prompt-a")
                 .withVersion("1.0.0")
                 .withRevision(3)
-                .withDescription("desc")
-                .withRequest(requestPayload)
+                .withDescription("stored desc")
+                .withRequest(storedRequestPayload)
                 .build()
                 .withId(promptId);
 
-        PromptSpec requestBodyPrompt = PromptSpec.builder()
-                .withGroup("malicious")
-                .withName("override")
-                .withVersion("9.9.9")
-                .withRevision(999)
-                .withDescription("request body should not be executed")
-                .withRequest(requestPayload)
+        // Draft uses the same id and group/name (the form does not let users
+        // mutate those once edit mode is open), but its request content is
+        // different from what is on disk.
+        PromptSpec draftPrompt = PromptSpec.builder()
+                .withGroup("support")
+                .withName("prompt-a")
+                .withVersion("1.0.0")
+                .withRevision(3)
+                .withDescription("draft desc — unsaved")
+                .withRequest(draftRequestPayload)
                 .build()
                 .withId(promptId);
 
         ChatCompletionResponse response = new ChatCompletionResponse(10L, null, "Pong");
-        PromptSpec executedPrompt = storedPrompt.withResponse(response);
+        // The executor returns whatever spec it was handed, with a response
+        // attached — the controller passes the draft, so we mirror that.
+        PromptSpec executedDraft = draftPrompt.withResponse(response);
         Execution recorded = new Execution(
                 "exec-uuid",
                 Instant.parse("2026-05-12T12:00:00Z"),
                 response,
                 null,
                 null);
+        // The persisted spec after recording is the stored prompt with the
+        // execution attached — storage truth is unchanged, only history grew.
         PromptSpec persistedPrompt = storedPrompt
                 .withResponse(response)
                 .withExecutions(List.of(recorded));
 
-        when(promptExecutor.runPromptAndAttachResponse(any(PromptSpec.class))).thenReturn(executedPrompt);
+        when(promptExecutor.runPromptAndAttachResponse(any(PromptSpec.class))).thenReturn(executedDraft);
         when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(storedPrompt));
         when(promptLifecycleFacade.recordExecution(eq(promptId), any(Execution.class)))
                 .thenReturn(persistedPrompt);
 
-        ExecutePromptRequest executePromptRequest = new ExecutePromptRequest(requestBodyPrompt);
+        ExecutePromptRequest executePromptRequest = new ExecutePromptRequest(draftPrompt);
 
         mockMvc.perform(post("/api/prompts/{promptSpecId}/execute", promptId)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -556,13 +580,20 @@ class PromptSpecControllerWebMvcTest {
                 .andExpect(jsonPath("$.executions[0].id").value("exec-uuid"))
                 .andExpect(jsonPath("$.executions[0].response.content").value("Pong"));
 
+        // The executor was called with the *draft* spec (issue #183).
         ArgumentCaptor<PromptSpec> executedPromptCaptor = ArgumentCaptor.forClass(PromptSpec.class);
         verify(promptExecutor).runPromptAndAttachResponse(executedPromptCaptor.capture());
-        assertThat(executedPromptCaptor.getValue().getGroup()).isEqualTo("support");
-        assertThat(executedPromptCaptor.getValue().getName()).isEqualTo("prompt-a");
-        assertThat(executedPromptCaptor.getValue().getVersion()).isEqualTo("1.0.0");
-        assertThat(executedPromptCaptor.getValue().getRevision()).isEqualTo(3);
+        PromptSpec executed = executedPromptCaptor.getValue();
+        assertThat(executed.getDescription()).isEqualTo("draft desc — unsaved");
+        ChatCompletionRequest executedRequest = (ChatCompletionRequest) executed.getRequest();
+        assertThat(executedRequest.getMessages())
+                .extracting(ChatCompletionRequest.Message::getContent)
+                .containsExactly("Draft ping — unsaved edit");
+        // Path id is authoritative.
+        assertThat(executed.getId()).isEqualTo(promptId);
 
+        // The recorded execution is pinned to the *stored* revision — the draft
+        // does not get to spoof a revision number into history.
         ArgumentCaptor<Execution> executionCaptor = ArgumentCaptor.forClass(Execution.class);
         verify(promptLifecycleFacade).recordExecution(eq(promptId), executionCaptor.capture());
         Execution captured = executionCaptor.getValue();
@@ -571,6 +602,161 @@ class PromptSpecControllerWebMvcTest {
         assertThat(captured.getOk()).isTrue();
         assertThat(captured.getRevision()).isEqualTo("3");
         assertThat(((ChatCompletionResponse) captured.getResponse()).getContent()).isEqualTo("Pong");
+    }
+
+    @Test
+    void executeStoredPromptForcesPathIdOntoBodySpecWhenBodyIdIsBlank() throws Exception {
+        // Issue #183: a draft body might omit the spec id (the editor doesn't
+        // always populate it). The controller must still execute it, with the
+        // path id forced onto the spec.
+        String promptId = "prompt-b";
+
+        ChatCompletionRequest payload = ChatCompletionRequest.builder()
+                .withVendor("openai")
+                .withModel("gpt-4o")
+                .withMessages(List.of(
+                        ChatCompletionRequest.Message.builder()
+                                .withRole("user")
+                                .withContent("Draft body, no id")
+                                .build()
+                ))
+                .withParameters(Map.of())
+                .build();
+
+        PromptSpec storedPrompt = PromptSpec.builder()
+                .withGroup("support")
+                .withName("prompt-b")
+                .withVersion("1.0.0")
+                .withRevision(2)
+                .withDescription("stored")
+                .withRequest(payload)
+                .build()
+                .withId(promptId);
+
+        // Note: no .withId(...) on the draft — id is null in the request body.
+        PromptSpec draftPrompt = PromptSpec.builder()
+                .withGroup("support")
+                .withName("prompt-b")
+                .withVersion("1.0.0")
+                .withRevision(2)
+                .withDescription("draft, no id")
+                .withRequest(payload)
+                .build();
+
+        ChatCompletionResponse response = new ChatCompletionResponse(5L, null, "Pong");
+        PromptSpec executedDraft = draftPrompt.withId(promptId).withResponse(response);
+        PromptSpec persisted = storedPrompt.withResponse(response);
+
+        when(promptExecutor.runPromptAndAttachResponse(any(PromptSpec.class))).thenReturn(executedDraft);
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(storedPrompt));
+        when(promptLifecycleFacade.recordExecution(eq(promptId), any(Execution.class)))
+                .thenReturn(persisted);
+
+        mockMvc.perform(post("/api/prompts/{promptSpecId}/execute", promptId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ExecutePromptRequest(draftPrompt))))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<PromptSpec> executedCaptor = ArgumentCaptor.forClass(PromptSpec.class);
+        verify(promptExecutor).runPromptAndAttachResponse(executedCaptor.capture());
+        assertThat(executedCaptor.getValue().getId()).isEqualTo(promptId);
+        assertThat(executedCaptor.getValue().getDescription()).isEqualTo("draft, no id");
+    }
+
+    @Test
+    void executeStoredPromptFallsBackToStoredSpecWhenNoRequestBody() throws Exception {
+        // No request body at all — the controller executes the stored spec.
+        // This preserves the legacy `executeStoredPrompt(id)` call site in
+        // PromptDetail.tsx and any future no-body callers.
+        String promptId = "prompt-c";
+
+        ChatCompletionRequest payload = ChatCompletionRequest.builder()
+                .withVendor("openai")
+                .withModel("gpt-4o")
+                .withMessages(List.of(
+                        ChatCompletionRequest.Message.builder()
+                                .withRole("user")
+                                .withContent("Stored only")
+                                .build()
+                ))
+                .withParameters(Map.of())
+                .build();
+
+        PromptSpec storedPrompt = PromptSpec.builder()
+                .withGroup("support")
+                .withName("prompt-c")
+                .withVersion("1.0.0")
+                .withRevision(7)
+                .withDescription("stored")
+                .withRequest(payload)
+                .build()
+                .withId(promptId);
+
+        ChatCompletionResponse response = new ChatCompletionResponse(5L, null, "Pong");
+        PromptSpec executed = storedPrompt.withResponse(response);
+        PromptSpec persisted = storedPrompt.withResponse(response);
+
+        when(promptExecutor.runPromptAndAttachResponse(any(PromptSpec.class))).thenReturn(executed);
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(storedPrompt));
+        when(promptLifecycleFacade.recordExecution(eq(promptId), any(Execution.class)))
+                .thenReturn(persisted);
+
+        // No body — sending an empty content (Spring treats `required=false`).
+        mockMvc.perform(post("/api/prompts/{promptSpecId}/execute", promptId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<PromptSpec> executedCaptor = ArgumentCaptor.forClass(PromptSpec.class);
+        verify(promptExecutor).runPromptAndAttachResponse(executedCaptor.capture());
+        assertThat(executedCaptor.getValue().getDescription()).isEqualTo("stored");
+        assertThat(executedCaptor.getValue().getId()).isEqualTo(promptId);
+    }
+
+    @Test
+    void executeStoredPromptRejectsBodyWithMismatchedId() throws Exception {
+        // Path id is authoritative. A draft body carrying a different id is a
+        // 400. Pins the existing safeguard against id-smuggling.
+        String pathId = "prompt-d";
+        String otherId = "prompt-e";
+
+        ChatCompletionRequest payload = ChatCompletionRequest.builder()
+                .withVendor("openai")
+                .withModel("gpt-4o")
+                .withMessages(List.of(
+                        ChatCompletionRequest.Message.builder()
+                                .withRole("user")
+                                .withContent("Mismatched id")
+                                .build()
+                ))
+                .withParameters(Map.of())
+                .build();
+
+        PromptSpec stored = PromptSpec.builder()
+                .withGroup("support")
+                .withName("prompt-d")
+                .withVersion("1.0.0")
+                .withRevision(1)
+                .withDescription("stored")
+                .withRequest(payload)
+                .build()
+                .withId(pathId);
+
+        PromptSpec mismatchedDraft = PromptSpec.builder()
+                .withGroup("support")
+                .withName("prompt-e")
+                .withVersion("1.0.0")
+                .withRevision(1)
+                .withDescription("draft with wrong id")
+                .withRequest(payload)
+                .build()
+                .withId(otherId);
+
+        when(promptStore.getLatestVersion(pathId)).thenReturn(Optional.of(stored));
+
+        mockMvc.perform(post("/api/prompts/{promptSpecId}/execute", pathId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ExecutePromptRequest(mismatchedDraft))))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecLifecycleDeriverTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecLifecycleDeriverTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.web;
+
+import dev.promptlm.domain.AppContext;
+import dev.promptlm.domain.projectspec.ProjectSpec;
+import dev.promptlm.domain.promptspec.ChatCompletionRequest;
+import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.PromptSpecLifecycleState;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Ref;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PromptSpecLifecycleDeriverTest {
+
+    private static final String SPEC_RELATIVE_PATH = "prompts/support/welcome/promptlm.yml";
+    private static final String SPEC_YAML = "id: welcome\nname: welcome\ngroup: support\n";
+
+    private AppContext appContext;
+    private ProjectSpec activeProject;
+    private PromptSpecLifecycleDeriver deriver;
+
+    @BeforeEach
+    void setUp() {
+        appContext = mock(AppContext.class);
+        activeProject = mock(ProjectSpec.class);
+        deriver = new PromptSpecLifecycleDeriver(appContext);
+    }
+
+    @Test
+    void returnsNullWhenActiveProjectIsAbsent(@TempDir Path tempDir) {
+        when(appContext.getActiveProject()).thenReturn(null);
+
+        PromptSpec spec = newSpecWithPath(Path.of(SPEC_RELATIVE_PATH));
+
+        assertThat(deriver.derive(spec)).isNull();
+    }
+
+    @Test
+    void returnsNullWhenRepoDirIsMissing(@TempDir Path tempDir) {
+        when(appContext.getActiveProject()).thenReturn(activeProject);
+        when(activeProject.getRepoDir()).thenReturn(tempDir.resolve("does-not-exist"));
+
+        PromptSpec spec = newSpecWithPath(Path.of(SPEC_RELATIVE_PATH));
+
+        assertThat(deriver.derive(spec)).isNull();
+    }
+
+    @Test
+    void returnsPushedWhenWorkingTreeMatchesHeadAndOriginIsUpToDate(@TempDir Path tempDir) throws Exception {
+        Path local = initRepoWithPromptCommit(tempDir.resolve("local"));
+        Path remote = initBareRemote(tempDir.resolve("remote.git"));
+        configureRemoteAndPush(local, remote);
+
+        wireActiveProject(local);
+        PromptSpec spec = newSpecWithPath(Path.of(SPEC_RELATIVE_PATH));
+
+        assertThat(deriver.derive(spec)).isEqualTo(PromptSpecLifecycleState.PUSHED);
+    }
+
+    @Test
+    void returnsCommittedWhenWorkingTreeMatchesHeadButOriginIsBehind(@TempDir Path tempDir) throws Exception {
+        Path local = initRepoWithPromptCommit(tempDir.resolve("local"));
+        Path remote = initBareRemote(tempDir.resolve("remote.git"));
+        configureRemoteAndPush(local, remote);
+
+        // Add a second, unpushed commit so origin/main is behind local main.
+        Path promptFile = local.resolve(SPEC_RELATIVE_PATH);
+        Files.writeString(promptFile, SPEC_YAML + "description: updated\n");
+        try (Git git = Git.open(local.toFile())) {
+            git.add().addFilepattern(SPEC_RELATIVE_PATH).call();
+            git.commit()
+                    .setMessage("Update prompt")
+                    .setAuthor(testIdent())
+                    .setCommitter(testIdent())
+                    .call();
+        }
+
+        wireActiveProject(local);
+        PromptSpec spec = newSpecWithPath(Path.of(SPEC_RELATIVE_PATH));
+
+        assertThat(deriver.derive(spec)).isEqualTo(PromptSpecLifecycleState.COMMITTED);
+    }
+
+    @Test
+    void returnsCommittedWhenRemoteTrackingBranchIsAbsent(@TempDir Path tempDir) throws Exception {
+        Path local = initRepoWithPromptCommit(tempDir.resolve("local"));
+        // No remote configured / no push performed.
+
+        wireActiveProject(local);
+        PromptSpec spec = newSpecWithPath(Path.of(SPEC_RELATIVE_PATH));
+
+        assertThat(deriver.derive(spec)).isEqualTo(PromptSpecLifecycleState.COMMITTED);
+    }
+
+    @Test
+    void returnsSavedWhenWorkingTreeDiffersFromHead(@TempDir Path tempDir) throws Exception {
+        Path local = initRepoWithPromptCommit(tempDir.resolve("local"));
+        // Mutate the working tree without committing.
+        Files.writeString(local.resolve(SPEC_RELATIVE_PATH), SPEC_YAML + "description: edited\n");
+
+        wireActiveProject(local);
+        PromptSpec spec = newSpecWithPath(Path.of(SPEC_RELATIVE_PATH));
+
+        assertThat(deriver.derive(spec)).isEqualTo(PromptSpecLifecycleState.SAVED);
+    }
+
+    @Test
+    void returnsSavedWhenPathHasNoBlobAtHead(@TempDir Path tempDir) throws Exception {
+        Path local = initRepoWithPromptCommit(tempDir.resolve("local"));
+        // Add a brand-new spec file to disk that was never committed.
+        Path newSpec = local.resolve("prompts/support/new-thing/promptlm.yml");
+        Files.createDirectories(newSpec.getParent());
+        Files.writeString(newSpec, "id: new-thing\n");
+
+        wireActiveProject(local);
+        PromptSpec spec = newSpecWithPath(Path.of("prompts/support/new-thing/promptlm.yml"));
+
+        assertThat(deriver.derive(spec)).isEqualTo(PromptSpecLifecycleState.SAVED);
+    }
+
+    @Test
+    void returnsNullWhenSpecPathIsNotConfigured(@TempDir Path tempDir) throws Exception {
+        Path local = initRepoWithPromptCommit(tempDir.resolve("local"));
+        wireActiveProject(local);
+
+        PromptSpec spec = PromptSpec.builder()
+                .withGroup("support")
+                .withName("welcome")
+                .withVersion("1.0.0")
+                .withRevision(1)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder().withModel("m").withVendor("v").build())
+                .build();
+
+        assertThat(deriver.derive(spec)).isNull();
+    }
+
+    private void wireActiveProject(Path repoDir) {
+        when(appContext.getActiveProject()).thenReturn(activeProject);
+        when(activeProject.getRepoDir()).thenReturn(repoDir);
+    }
+
+    private PromptSpec newSpecWithPath(Path relativePath) {
+        return PromptSpec.builder()
+                .withGroup("support")
+                .withName("welcome")
+                .withVersion("1.0.0")
+                .withRevision(1)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder().withModel("m").withVendor("v").build())
+                .withPath(relativePath)
+                .build();
+    }
+
+    private static Path initRepoWithPromptCommit(Path repoDir) throws Exception {
+        Files.createDirectories(repoDir);
+        try (Git git = Git.init()
+                .setInitialBranch("main")
+                .setDirectory(repoDir.toFile())
+                .call()) {
+            Path promptFile = repoDir.resolve(SPEC_RELATIVE_PATH);
+            Files.createDirectories(promptFile.getParent());
+            Files.writeString(promptFile, SPEC_YAML);
+            git.add().addFilepattern(SPEC_RELATIVE_PATH).call();
+            git.commit()
+                    .setMessage("Add prompt")
+                    .setAuthor(testIdent())
+                    .setCommitter(testIdent())
+                    .call();
+        }
+        return repoDir;
+    }
+
+    private static Path initBareRemote(Path remoteDir) throws Exception {
+        Files.createDirectories(remoteDir);
+        try (Git ignored = Git.init()
+                .setBare(true)
+                .setInitialBranch("main")
+                .setDirectory(remoteDir.toFile())
+                .call()) {
+            // bare repo, nothing else to do
+        }
+        return remoteDir;
+    }
+
+    private static void configureRemoteAndPush(Path local, Path remote) throws Exception {
+        try (Git git = Git.open(local.toFile())) {
+            git.remoteAdd()
+                    .setName("origin")
+                    .setUri(new org.eclipse.jgit.transport.URIish(remote.toUri().toString()))
+                    .call();
+            git.push().setRemote("origin").add("main").call();
+            // Verify the remote-tracking ref is in place.
+            Ref originMain = git.getRepository().findRef("refs/remotes/origin/main");
+            assertThat(originMain).isNotNull();
+        }
+    }
+
+    private static PersonIdent testIdent() {
+        return new PersonIdent(
+                "PromptLM Test",
+                "promptlm@example.com",
+                Date.from(Instant.parse("2026-05-18T12:00:00Z")),
+                TimeZone.getTimeZone("UTC"));
+    }
+}

--- a/components/promptlm-web-ui/src/features/prompt-editor/PromptFormShell.tsx
+++ b/components/promptlm-web-ui/src/features/prompt-editor/PromptFormShell.tsx
@@ -46,6 +46,7 @@ import {
   createPromptDraftFromPrompt,
   usePromptEditorDraft,
 } from './draftState';
+import { buildEditorRunRequest } from './buildEditorRunRequest';
 import { releasePromptAction, savePromptDraftAction } from './editorActions';
 import { usePromptEditorData } from './usePromptEditorData';
 import { useCapabilities } from '@/api/hooks';
@@ -351,7 +352,16 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
     setEditorRunState('running');
     const startMs = Date.now();
     try {
-      const result = await promptSpecs.executeStoredPrompt(effectivePromptId);
+      // Issue #183: send the current form-state draft as the request body so
+      // the backend executes what the user sees in the editor, not the stored
+      // YAML. The path id remains authoritative — the controller forces it
+      // onto the spec and records the execution under the stored prompt id.
+      const executeRequest = buildEditorRunRequest({
+        draft: editor.state.draft,
+        evaluationEnabled: evaluationEnabledForPayload,
+        repositoryUrl: data.activeProject?.repositoryUrl,
+      });
+      const result = await promptSpecs.executeStoredPrompt(effectivePromptId, executeRequest);
       const exec = result?.executions?.[0];
       const ms = Date.now() - startMs;
       const userMessagePh = (exec?.placeholders ?? []).find((ph) => ph.name === 'user_message');
@@ -387,7 +397,15 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
     } finally {
       setEditorRunState('idle');
     }
-  }, [effectivePromptId, editorRunState, promptSpecs, formContext.revision]);
+  }, [
+    effectivePromptId,
+    editorRunState,
+    promptSpecs,
+    formContext.revision,
+    editor.state.draft,
+    evaluationEnabledForPayload,
+    data.activeProject?.repositoryUrl,
+  ]);
 
   if (data.promptError) {
     return (

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/buildEditorRunRequest.test.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/buildEditorRunRequest.test.ts
@@ -1,0 +1,139 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+
+import type { PromptDraftInput } from '@/api/promptPayloads';
+import { buildEditorRunRequest } from '../buildEditorRunRequest';
+
+const baseDraft = (): PromptDraftInput => ({
+  id: 'support/prompt-a',
+  name: 'prompt-a',
+  group: 'support',
+  description: 'stored desc',
+  authors: [],
+  version: '1.0.0',
+  revision: 3,
+  repositoryUrl: 'https://example.test/repo.git',
+  request: {
+    type: 'chat/completion',
+    vendor: 'openai',
+    model: 'gpt-4o',
+    url: '',
+    modelSnapshot: '',
+    parameters: {
+      temperature: 0.2,
+      topP: 1,
+      maxTokens: 1024,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      stream: false,
+    },
+    messages: [
+      { id: 'sys', role: 'system', content: 'You are helpful.' },
+      { id: 'usr', role: 'user', content: 'Stored body content' },
+    ],
+  },
+  placeholders: {
+    startPattern: '{{',
+    endPattern: '}}',
+    list: [],
+    defaults: {},
+  },
+  evaluations: [],
+  extensions: undefined,
+});
+
+describe('buildEditorRunRequest (issue #183)', () => {
+  it('puts the unsaved draft body into the request payload, not the stored content', () => {
+    // Simulate the user typing a new user message into the editor — the
+    // form-state draft now diverges from whatever is on disk. Run must carry
+    // *this* content.
+    const draft: PromptDraftInput = baseDraft();
+    draft.request.messages = [
+      { id: 'sys', role: 'system', content: 'You are helpful.' },
+      { id: 'usr', role: 'user', content: 'Unsaved edit — this must reach the server' },
+    ];
+
+    const payload = buildEditorRunRequest({
+      draft,
+      evaluationEnabled: false,
+      repositoryUrl: 'https://example.test/repo.git',
+    });
+
+    expect(payload.promptSpec).toBeDefined();
+    const spec = payload.promptSpec;
+    // The draft's request body is what the backend will execute. The
+    // serialiser upper-cases roles to match the backend enum.
+    expect(spec?.request?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'USER',
+          content: 'Unsaved edit — this must reach the server',
+        }),
+      ]),
+    );
+    // The id from the stored prompt is preserved so the backend's id-match
+    // check passes and the execution is recorded under the right prompt.
+    expect(spec?.id).toBe('support/prompt-a');
+    expect(spec?.group).toBe('support');
+    expect(spec?.name).toBe('prompt-a');
+  });
+
+  it('reflects placeholder edits from the form state', () => {
+    const draft: PromptDraftInput = baseDraft();
+    draft.placeholders = {
+      startPattern: '{{',
+      endPattern: '}}',
+      list: [{ name: 'user_message', value: 'edited default' }],
+      defaults: { user_message: 'edited default' },
+    };
+
+    const payload = buildEditorRunRequest({
+      draft,
+      evaluationEnabled: false,
+      repositoryUrl: 'https://example.test/repo.git',
+    });
+
+    const placeholders = payload.promptSpec?.placeholders;
+    expect(placeholders).toBeDefined();
+    // The placeholder list carries the edited default — this is what the
+    // backend uses to substitute into the prompt template. The serialiser
+    // maps the draft's `value` to the API's `defaultValue` field.
+    expect(placeholders).toEqual(
+      expect.objectContaining({
+        list: expect.arrayContaining([
+          expect.objectContaining({ name: 'user_message', defaultValue: 'edited default' }),
+        ]),
+      }),
+    );
+  });
+
+  it('survives a draft that has not yet been saved (no id)', () => {
+    // Edge case: an editor session opened from a template might not have an
+    // id yet. `buildEditorRunRequest` should still produce a usable payload;
+    // the path-id check on the controller handles authority.
+    const draft: PromptDraftInput = baseDraft();
+    draft.id = undefined;
+
+    const payload = buildEditorRunRequest({
+      draft,
+      evaluationEnabled: false,
+      repositoryUrl: 'https://example.test/repo.git',
+    });
+
+    expect(payload.promptSpec).toBeDefined();
+    expect(payload.promptSpec?.id).toBeUndefined();
+  });
+});

--- a/components/promptlm-web-ui/src/features/prompt-editor/buildEditorRunRequest.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/buildEditorRunRequest.ts
@@ -1,0 +1,45 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Build the request body for the editor's "Run" action on `/prompts/<id>/edit`.
+ *
+ * Issue #183: Run must execute the *current form state*, not the stored YAML.
+ * The form state lives in `editor.state.draft`; this helper sanitises it the
+ * same way the Save path does, then maps it to the
+ * `ExecutePromptRequest` shape the backend expects.
+ *
+ * The companion backend change in `PromptSpecController.executeStoredPrompt`
+ * makes the body authoritative when supplied. The path id remains the source
+ * of truth for which prompt's history the execution is recorded under.
+ */
+import type { ExecutePromptRequest } from '@promptlm/api-client';
+
+import { buildExecutePromptRequest, type PromptDraftInput } from '@/api/promptPayloads';
+import { sanitizePromptDraft } from './draftState';
+
+export type BuildEditorRunRequestInput = {
+  draft: PromptDraftInput;
+  evaluationEnabled: boolean;
+  repositoryUrl?: string | null;
+};
+
+export const buildEditorRunRequest = ({
+  draft,
+  evaluationEnabled,
+  repositoryUrl,
+}: BuildEditorRunRequestInput): ExecutePromptRequest => {
+  const sanitized = sanitizePromptDraft(draft, evaluationEnabled, repositoryUrl);
+  return buildExecutePromptRequest(sanitized);
+};


### PR DESCRIPTION
Closes #183. **Depends on #189 / PR #190** — branch base is
`feat/189-prompt-spec-lifecycle-state`; retarget to `main` after #190 lands.

## Summary
- Backend: `POST /api/prompts/{id}/execute` now honours the request body's
  `promptSpec` when supplied, executing the draft in place of the stored
  YAML. The path id remains authoritative and the recorded
  `Execution.revision` is pinned to the stored spec's revision so a draft
  cannot smuggle a fabricated revision into history.
- Frontend: `PromptFormShell.handleEditorRun` sends the current form-state
  draft as the request body. Payload construction is isolated in a new
  `buildEditorRunRequest` helper for direct unit-testability.
- Backward compatibility: no-body callers (e.g. `PromptDetail.tsx`) still
  hit the stored-spec fallback unchanged.

## Why it matters
Before this fix the editor's Run button silently ignored any unsaved edits
and ran the persisted YAML. The user saw a response that didn't match the
form. With #189 modelling `draft` as a first-class lifecycle state, that
behavior is now provably wrong — the draft form is the authoritative input
for Run.

## Security notes
The request body now actually influences the executor, so this PR closes
two latent paths:

- **Revision smuggling.** `Execution.revision` is sourced from the stored
  spec, not the body.
- **Id smuggling.** Pre-existing 400-on-mismatch check is preserved and
  pinned with a new test; the path id is also force-set onto the spec via
  `withId(promptSpecId)` so downstream callers can't see a stale id.

Content injection through the prompt body is unchanged — the existing
`POST /api/prompts/execute` route already accepts arbitrary specs from
authenticated clients.

## Test plan
- [x] `./mvnw -pl components/promptlm-web-api -Dtest=PromptSpecControllerWebMvcTest test` — 46 pass (incl. 4 new/modified tests)
- [x] `npm --workspace @promptlm/web-ui test` — 115 pass (incl. 3 new tests in `buildEditorRunRequest.test.ts`)
- [x] `npm --workspace @promptlm/web-ui run build` — succeeds
- [x] `npm --workspace @promptlm/web-ui run lint` — 0 errors (only pre-existing warnings)
- [ ] Manual: open `/prompts/<id>/edit`, edit the user message, click Run, verify the response reflects the edit.

## Files changed
- `components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java`
- `components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java`
- `components/promptlm-web-ui/src/features/prompt-editor/PromptFormShell.tsx`
- `components/promptlm-web-ui/src/features/prompt-editor/buildEditorRunRequest.ts` (new)
- `components/promptlm-web-ui/src/features/prompt-editor/__tests__/buildEditorRunRequest.test.ts` (new)

Generated with Claude Code.