### PR TITLE
feat(prompt-editor): unsaved-changes indicator and navigation guard (#185)

### DIFF
--- a/components/promptlm-web-ui/src/features/prompt-editor/PromptFormShell.tsx
+++ b/components/promptlm-web-ui/src/features/prompt-editor/PromptFormShell.tsx
@@ -27,8 +27,18 @@
  * - Tool configs (MCP mocks) and placeholder schema fields (type/required/
  *   description) are surfaced in the rail UI but are client-side-only until
  *   backend support lands; user edits don't round-trip yet.
+ *
+ * Issue #185 — adds:
+ * - Dirty detection via `usePromptFormDirty` (passed to `PromptFormPage` so
+ *   the sticky header can render the "Modified" chip).
+ * - A `beforeunload` listener that prompts on tab close / reload while dirty.
+ * - A `popstate` interceptor (with a sentinel history entry) that catches
+ *   browser back and routes the user through `UnsavedChangesDialog`.
+ * - A guarded Cancel button.
+ * Sidebar/header nav links are *not* guarded by this PR — the app uses
+ * `BrowserRouter` (not a data router) so `useBlocker` is unavailable.
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 
@@ -40,7 +50,7 @@ import {
   type PromptFormToolConfig,
 } from '@promptlm/ui';
 
-import type { PromptEditorMode } from './types';
+import type { PromptEditorMode, PromptEditorState } from './types';
 import {
   createEmptyPromptDraft,
   createPromptDraftFromPrompt,
@@ -48,6 +58,8 @@ import {
 } from './draftState';
 import { releasePromptAction, savePromptDraftAction } from './editorActions';
 import { usePromptEditorData } from './usePromptEditorData';
+import { usePromptFormDirty } from './dirtyState';
+import { UnsavedChangesDialog } from './UnsavedChangesDialog';
 import { useCapabilities } from '@/api/hooks';
 import { useGeneratedApiClient } from '@api-common/generatedClientProvider';
 import { featureFlags } from '@/lib/featureFlags';
@@ -174,6 +186,9 @@ const applyFormDraft = (
   })),
 });
 
+// Issue #185 — popstate sentinel marker.
+const POPSTATE_SENTINEL_KEY = '__promptlmDirtyGuard';
+
 export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
   const navigate = useNavigate();
   const data = usePromptEditorData({ mode, promptId });
@@ -188,20 +203,31 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
   const [editorRunState, setEditorRunState] = useState<'idle' | 'running'>('idle');
   const [lastEditorRun, setLastEditorRun] = useState<EditorRunRecord | null>(null);
 
+  // Issue #185 — baseline (last persisted snapshot) tracking + dialog state.
+  const [baseline, setBaseline] = useState<PromptEditorState | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const pendingNavigationRef = useRef<(() => void) | null>(null);
+
   // Hydrate draft on load. Depend only on the replaceState callback (stable
   // reference from the useReducer dispatch) — depending on `editor` triggers
   // an infinite loop because the memoised actions object changes per render.
   useEffect(() => {
     if (mode === 'edit' && data.prompt) {
-      replaceState(createPromptDraftFromPrompt(data.prompt));
+      const next = createPromptDraftFromPrompt(data.prompt);
+      replaceState(next);
+      setBaseline(next);
       return;
     }
     if (mode === 'create') {
       if (data.promptTemplate) {
-        replaceState(createPromptDraftFromPrompt(data.promptTemplate));
+        const next = createPromptDraftFromPrompt(data.promptTemplate);
+        replaceState(next);
+        setBaseline(next);
         return;
       }
-      replaceState(createEmptyPromptDraft());
+      const empty = createEmptyPromptDraft();
+      replaceState(empty);
+      setBaseline(empty);
     }
   }, [data.prompt, data.promptTemplate, mode, replaceState]);
 
@@ -226,6 +252,9 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
     () => toFormDraft(editor.state, toolConfigs),
     [editor.state, toolConfigs],
   );
+
+  // Issue #185 — dirty signal. Compared against the post-hydration baseline.
+  const isDirty = usePromptFormDirty({ current: editor.state, baseline });
 
   const handleChangeDraft = useCallback(
     (next: PromptFormDraft) => {
@@ -258,13 +287,30 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
     };
   }, [data.activeProject?.repositoryUrl, data.prompt]);
 
+  // Issue #185 — guarded navigation helper. If the form is dirty, defer the
+  // navigation until the user picks Save / Discard / Cancel; otherwise run
+  // immediately.
+  const requestNavigation = useCallback(
+    (perform: () => void) => {
+      if (!isDirty) {
+        perform();
+        return;
+      }
+      pendingNavigationRef.current = perform;
+      setDialogOpen(true);
+    },
+    [isDirty],
+  );
+
   const handleCancel = useCallback(() => {
-    if (mode === 'edit' && promptId) {
-      navigate(`/prompts/${promptId}`);
-      return;
-    }
-    navigate('/prompts');
-  }, [mode, navigate, promptId]);
+    requestNavigation(() => {
+      if (mode === 'edit' && promptId) {
+        navigate(`/prompts/${promptId}`);
+        return;
+      }
+      navigate('/prompts');
+    });
+  }, [mode, navigate, promptId, requestNavigation]);
 
   const evaluationEnabledForPayload = isEvaluationCapabilityEnabled
     ? editor.state.evaluationEnabled
@@ -285,7 +331,9 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
       updatePrompt: data.updatePrompt,
     });
     if (result.updatedPrompt && mode === 'edit') {
-      editor.replaceState(createPromptDraftFromPrompt(result.updatedPrompt));
+      const refreshed = createPromptDraftFromPrompt(result.updatedPrompt);
+      editor.replaceState(refreshed);
+      setBaseline(refreshed);
     }
     if (result.shouldRefreshPrompt) {
       await data.refreshPrompt();
@@ -331,7 +379,9 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
         releasePrompt: data.releasePrompt,
       });
       if (releaseResult.releasedPrompt && mode === 'edit') {
-        editor.replaceState(createPromptDraftFromPrompt(releaseResult.releasedPrompt));
+        const refreshed = createPromptDraftFromPrompt(releaseResult.releasedPrompt);
+        editor.replaceState(refreshed);
+        setBaseline(refreshed);
       }
       if (releaseResult.shouldRefreshPrompt) {
         await data.refreshPrompt();
@@ -389,6 +439,75 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
     }
   }, [effectivePromptId, editorRunState, promptSpecs, formContext.revision]);
 
+  // Issue #185 — `beforeunload`: prompt on tab close / reload while dirty.
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // Older Chrome/Edge require the legacy returnValue setter.
+      event.returnValue = '';
+      return '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isDirty]);
+
+  // Issue #185 — in-app browser-back guard. While dirty, push a sentinel
+  // history entry so the first `popstate` lands on our handler. We swallow
+  // the back navigation, route the user through the dialog, and re-issue
+  // `history.back()` if they confirm. If they cancel, the sentinel stays
+  // in place so the next back press is still intercepted.
+  useEffect(() => {
+    if (!isDirty) return;
+    window.history.pushState({ [POPSTATE_SENTINEL_KEY]: true }, '');
+    const handler = () => {
+      pendingNavigationRef.current = () => {
+        // Step out of the form route. The sentinel entry was already
+        // consumed by the popstate that just fired.
+        window.history.back();
+      };
+      setDialogOpen(true);
+    };
+    window.addEventListener('popstate', handler);
+    return () => {
+      window.removeEventListener('popstate', handler);
+      // Best-effort cleanup: if the sentinel is still the current entry,
+      // pop it so we don't leak history entries when the form unmounts
+      // through a non-back navigation.
+      const state = window.history.state as Record<string, unknown> | null;
+      if (state && state[POPSTATE_SENTINEL_KEY] === true) {
+        window.history.back();
+      }
+    };
+  }, [isDirty]);
+
+  const handleDialogCancel = useCallback(() => {
+    pendingNavigationRef.current = null;
+    setDialogOpen(false);
+  }, []);
+
+  const handleDialogDiscard = useCallback(() => {
+    if (baseline) {
+      editor.replaceState(baseline);
+    }
+    const perform = pendingNavigationRef.current;
+    pendingNavigationRef.current = null;
+    setDialogOpen(false);
+    if (perform) perform();
+  }, [baseline, editor]);
+
+  const handleDialogSave = useCallback(async () => {
+    const result = await persistDraft();
+    if (result.toast.severity === 'error') {
+      // Save failed; keep the dialog open so the user can pick another path.
+      return;
+    }
+    const perform = pendingNavigationRef.current;
+    pendingNavigationRef.current = null;
+    setDialogOpen(false);
+    if (perform) perform();
+  }, [persistDraft]);
+
   if (data.promptError) {
     return (
       <div
@@ -424,24 +543,34 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
   void validationRequested;
 
   return (
-    <PromptFormPage
-      mode={mode}
-      draft={formDraft}
-      context={formContext}
-      evalEnabled={editor.state.evaluationEnabled}
-      evalsAvailable={isEvaluationCapabilityEnabled}
-      isBusy={data.isSaving || isReleasing}
-      isSaving={data.isSaving}
-      onChangeDraft={handleChangeDraft}
-      onToggleEvalEnabled={handleToggleEvalEnabled}
-      onCancel={handleCancel}
-      onSaveDraft={handleSaveDraft}
-      onSubmit={handleSubmit}
-      releaseFlowEnabled={featureFlags.releaseFlow}
-      onEditorRun={effectivePromptId ? handleEditorRun : undefined}
-      editorRunState={editorRunState}
-      lastEditorRun={lastEditorRun}
-    />
+    <>
+      <PromptFormPage
+        mode={mode}
+        draft={formDraft}
+        context={formContext}
+        evalEnabled={editor.state.evaluationEnabled}
+        evalsAvailable={isEvaluationCapabilityEnabled}
+        isBusy={data.isSaving || isReleasing}
+        isSaving={data.isSaving}
+        onChangeDraft={handleChangeDraft}
+        onToggleEvalEnabled={handleToggleEvalEnabled}
+        onCancel={handleCancel}
+        onSaveDraft={handleSaveDraft}
+        onSubmit={handleSubmit}
+        releaseFlowEnabled={featureFlags.releaseFlow}
+        onEditorRun={effectivePromptId ? handleEditorRun : undefined}
+        editorRunState={editorRunState}
+        lastEditorRun={lastEditorRun}
+        isDirty={isDirty}
+      />
+      <UnsavedChangesDialog
+        open={dialogOpen}
+        isSaving={data.isSaving}
+        onSave={handleDialogSave}
+        onDiscard={handleDialogDiscard}
+        onCancel={handleDialogCancel}
+      />
+    </>
   );
 };
 

--- a/components/promptlm-web-ui/src/features/prompt-editor/UnsavedChangesDialog.tsx
+++ b/components/promptlm-web-ui/src/features/prompt-editor/UnsavedChangesDialog.tsx
@@ -1,0 +1,92 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Issue #185 — confirmation dialog shown when the user attempts to leave the
+ * prompt editor with unsaved changes. Offers three branches:
+ *
+ * - **Save changes** — save the draft, then continue the pending navigation.
+ * - **Discard**      — drop edits, then continue the pending navigation.
+ * - **Cancel**       — stay on the page; no navigation, no state change.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+export type UnsavedChangesDialogProps = {
+  open: boolean;
+  isSaving?: boolean;
+  onSave: () => void;
+  onDiscard: () => void;
+  onCancel: () => void;
+};
+
+export const UnsavedChangesDialog = ({
+  open,
+  isSaving = false,
+  onSave,
+  onDiscard,
+  onCancel,
+}: UnsavedChangesDialogProps) => {
+  const handleOpenChange = (next: boolean) => {
+    if (!next) onCancel();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent data-testid="unsaved-changes-dialog">
+        <DialogHeader>
+          <DialogTitle>Unsaved changes</DialogTitle>
+          <DialogDescription>
+            You have unsaved edits to this prompt. What do you want to do?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            variant="outline"
+            onClick={onCancel}
+            disabled={isSaving}
+            data-testid="unsaved-changes-cancel"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            onClick={onDiscard}
+            disabled={isSaving}
+            data-testid="unsaved-changes-discard"
+          >
+            Discard
+          </Button>
+          <Button
+            onClick={onSave}
+            disabled={isSaving}
+            data-testid="unsaved-changes-save"
+          >
+            {isSaving ? 'Saving…' : 'Save changes'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default UnsavedChangesDialog;

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/UnsavedChangesDialog.test.tsx
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/UnsavedChangesDialog.test.tsx
@@ -1,0 +1,138 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @vitest-environment jsdom */
+
+import React, { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { UnsavedChangesDialog } from '../UnsavedChangesDialog';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+type Props = React.ComponentProps<typeof UnsavedChangesDialog>;
+
+const renderDialog = async (props: Props) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => {
+    root.render(<UnsavedChangesDialog {...props} />);
+  });
+  return {
+    container,
+    rerender: async (next: Props) => {
+      await act(async () => {
+        root.render(<UnsavedChangesDialog {...next} />);
+      });
+    },
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const findButton = (label: string): HTMLButtonElement | null => {
+  const buttons = Array.from(document.body.querySelectorAll('button'));
+  return (buttons.find((b) => b.textContent?.trim() === label) as HTMLButtonElement) ?? null;
+};
+
+describe('UnsavedChangesDialog', () => {
+  it('renders nothing in the document when closed', async () => {
+    const harness = await renderDialog({
+      open: false,
+      onSave: vi.fn(),
+      onDiscard: vi.fn(),
+      onCancel: vi.fn(),
+    });
+    try {
+      expect(document.body.querySelector('[data-testid="unsaved-changes-dialog"]')).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  it('renders Save changes / Discard / Cancel buttons when open', async () => {
+    const harness = await renderDialog({
+      open: true,
+      onSave: vi.fn(),
+      onDiscard: vi.fn(),
+      onCancel: vi.fn(),
+    });
+    try {
+      // Radix portals to document.body, so query there.
+      expect(document.body.querySelector('[data-testid="unsaved-changes-dialog"]')).not.toBeNull();
+      expect(findButton('Save changes')).not.toBeNull();
+      expect(findButton('Discard')).not.toBeNull();
+      expect(findButton('Cancel')).not.toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  it('invokes the correct callback on each button click', async () => {
+    const onSave = vi.fn();
+    const onDiscard = vi.fn();
+    const onCancel = vi.fn();
+    const harness = await renderDialog({
+      open: true,
+      onSave,
+      onDiscard,
+      onCancel,
+    });
+    try {
+      await act(async () => {
+        findButton('Save changes')!.click();
+      });
+      expect(onSave).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        findButton('Discard')!.click();
+      });
+      expect(onDiscard).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        findButton('Cancel')!.click();
+      });
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  it('disables all actions while saving', async () => {
+    const harness = await renderDialog({
+      open: true,
+      isSaving: true,
+      onSave: vi.fn(),
+      onDiscard: vi.fn(),
+      onCancel: vi.fn(),
+    });
+    try {
+      expect(findButton('Saving…')?.disabled).toBe(true);
+      expect(findButton('Discard')?.disabled).toBe(true);
+      expect(findButton('Cancel')?.disabled).toBe(true);
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/dirtyState.test.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/dirtyState.test.ts
@@ -1,0 +1,99 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+
+import { arePromptDraftsEqual } from '../dirtyState';
+import { createEmptyPromptDraft, promptEditorReducer } from '../draftState';
+import type { PromptEditorState } from '../types';
+
+const cloneEditorState = (state: PromptEditorState): PromptEditorState =>
+  JSON.parse(JSON.stringify(state));
+
+describe('arePromptDraftsEqual', () => {
+  it('returns true for two freshly-created empty drafts', () => {
+    const a = createEmptyPromptDraft();
+    const b = createEmptyPromptDraft();
+    // Two empty drafts have different message ids (regenerated on each call)
+    // — equality must ignore those.
+    expect(arePromptDraftsEqual(a, b)).toBe(true);
+  });
+
+  it('returns false when the description is edited', () => {
+    const base = createEmptyPromptDraft();
+    const edited = promptEditorReducer(base, {
+      type: 'update-metadata',
+      field: 'description',
+      value: 'something new',
+    });
+    expect(arePromptDraftsEqual(base, edited)).toBe(false);
+  });
+
+  it('returns false when a message body changes', () => {
+    const base = createEmptyPromptDraft();
+    const edited = promptEditorReducer(base, {
+      type: 'update-message',
+      index: 1,
+      field: 'content',
+      value: 'hello',
+    });
+    expect(arePromptDraftsEqual(base, edited)).toBe(false);
+  });
+
+  it('returns true when only whitespace differs in `name` (sanitisation trims)', () => {
+    const base = createEmptyPromptDraft();
+    base.draft.name = 'prompt';
+    const padded = cloneEditorState(base);
+    padded.draft.name = '  prompt  ';
+    expect(arePromptDraftsEqual(base, padded)).toBe(true);
+  });
+
+  it('returns true when only volatile message ids differ', () => {
+    const base = createEmptyPromptDraft();
+    const cloned = cloneEditorState(base);
+    cloned.draft.request.messages = cloned.draft.request.messages.map((m, i) => ({
+      ...m,
+      id: `regenerated-${i}`,
+    }));
+    expect(arePromptDraftsEqual(base, cloned)).toBe(true);
+  });
+
+  it('returns false when evaluationEnabled differs', () => {
+    const base = createEmptyPromptDraft();
+    const toggled: PromptEditorState = { ...base, evaluationEnabled: true };
+    expect(arePromptDraftsEqual(base, toggled)).toBe(false);
+  });
+
+  it('returns false when a placeholder is added and named', () => {
+    const base = createEmptyPromptDraft();
+    const withPlaceholder = promptEditorReducer(base, { type: 'add-placeholder' });
+    const named = promptEditorReducer(withPlaceholder, {
+      type: 'update-placeholder',
+      index: 0,
+      field: 'name',
+      value: 'topic',
+    });
+    expect(arePromptDraftsEqual(base, named)).toBe(false);
+  });
+
+  it('returns false when a model parameter changes', () => {
+    const base = createEmptyPromptDraft();
+    const edited = promptEditorReducer(base, {
+      type: 'update-parameter',
+      field: 'temperature',
+      value: 0.9,
+    });
+    expect(arePromptDraftsEqual(base, edited)).toBe(false);
+  });
+});

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/usePromptFormDirty.test.tsx
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/usePromptFormDirty.test.tsx
@@ -1,0 +1,122 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @vitest-environment jsdom */
+
+import React, { act } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { usePromptFormDirty } from '../dirtyState';
+import { createEmptyPromptDraft, promptEditorReducer } from '../draftState';
+import type { PromptEditorState } from '../types';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const Harness = ({
+  current,
+  baseline,
+  onChange,
+}: {
+  current: PromptEditorState;
+  baseline: PromptEditorState | null;
+  onChange: (isDirty: boolean) => void;
+}) => {
+  const isDirty = usePromptFormDirty({ current, baseline });
+  React.useEffect(() => {
+    onChange(isDirty);
+  }, [isDirty, onChange]);
+  return <span data-testid="dirty">{String(isDirty)}</span>;
+};
+
+type HarnessProps = {
+  current: PromptEditorState;
+  baseline: PromptEditorState | null;
+};
+
+const renderHarness = async (initial: HarnessProps) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  let lastDirty = false;
+  const onChange = (v: boolean) => {
+    lastDirty = v;
+  };
+
+  await act(async () => {
+    root.render(<Harness {...initial} onChange={onChange} />);
+  });
+
+  return {
+    get isDirty() {
+      return lastDirty;
+    },
+    rerender: async (next: HarnessProps) => {
+      await act(async () => {
+        root.render(<Harness {...next} onChange={onChange} />);
+      });
+    },
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('usePromptFormDirty', () => {
+  it('reports clean during hydration (baseline === null)', async () => {
+    const current = createEmptyPromptDraft();
+    const harness = await renderHarness({ current, baseline: null });
+    try {
+      expect(harness.isDirty).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  it('reports clean once baseline matches current state', async () => {
+    const baseline = createEmptyPromptDraft();
+    const current = createEmptyPromptDraft();
+    const harness = await renderHarness({ current, baseline });
+    try {
+      expect(harness.isDirty).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  it('flips to dirty when current diverges from baseline, and clears when baseline catches up', async () => {
+    const baseline = createEmptyPromptDraft();
+    const edited = promptEditorReducer(baseline, {
+      type: 'update-metadata',
+      field: 'description',
+      value: 'changed',
+    });
+
+    const harness = await renderHarness({ current: edited, baseline });
+    try {
+      expect(harness.isDirty).toBe(true);
+      await harness.rerender({ current: edited, baseline: edited });
+      expect(harness.isDirty).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/components/promptlm-web-ui/src/features/prompt-editor/dirtyState.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/dirtyState.ts
@@ -1,0 +1,93 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Issue #185 — detect whether the prompt editor form has unsaved changes.
+ *
+ * Equality is defined in terms of the canonical, on-the-wire shape: the
+ * inputs are first run through `sanitizePromptDraft` so that whitespace
+ * trimming, slug sanitisation, and placeholder ordering don't show up as
+ * spurious dirty signals. Message `id` values are stripped before comparison
+ * because they are regenerated on every hydration (`msg-${Date.now()}-...`)
+ * and have no semantic meaning.
+ *
+ * The `evaluationEnabled` flag is part of the comparison so toggling
+ * evaluations counts as dirty (`set-evaluation-enabled` does not modify any
+ * persisted field by itself, but the user has plainly changed the form).
+ */
+
+import { useEffect, useState } from 'react';
+
+import { sanitizePromptDraft } from './draftState';
+import type { PromptEditorState } from './types';
+import type { EditablePromptMessage, PromptDraftInput } from '@/api/promptPayloads';
+
+const stripMessageIds = (messages: EditablePromptMessage[]) =>
+  messages.map(({ id: _id, ...rest }) => rest);
+
+const canonicaliseDraft = (state: PromptEditorState): unknown => {
+  const sanitized = sanitizePromptDraft(state.draft, state.evaluationEnabled, state.draft.repositoryUrl);
+  // The `id` field on messages is volatile (regenerated on hydration). Strip
+  // it before comparing so equal content doesn't read as dirty.
+  const stripped: PromptDraftInput = {
+    ...sanitized,
+    request: {
+      ...sanitized.request,
+      messages: stripMessageIds(sanitized.request.messages),
+    },
+  };
+  return stripped;
+};
+
+/**
+ * Returns true if two prompt editor states are semantically equal — that is,
+ * if saving either one would produce the same persisted document.
+ */
+export const arePromptDraftsEqual = (a: PromptEditorState, b: PromptEditorState): boolean => {
+  if (a.evaluationEnabled !== b.evaluationEnabled) return false;
+  // Use JSON.stringify as a deep-equality shortcut. Both sides came out of
+  // `sanitizePromptDraft`, so key ordering inside objects is stable enough
+  // for this comparison to be reliable in practice. The function is a hot
+  // path on every keystroke; this trades a small false-negative risk for
+  // simplicity (the user's worst case is a transient "Modified" chip that
+  // disappears on the next keystroke).
+  return JSON.stringify(canonicaliseDraft(a)) === JSON.stringify(canonicaliseDraft(b));
+};
+
+type UsePromptFormDirtyArgs = {
+  current: PromptEditorState;
+  baseline: PromptEditorState | null;
+};
+
+/**
+ * Tracks whether the editor's current state diverges from a baseline.
+ *
+ * `baseline` is `null` while the editor is still hydrating — in that window
+ * we report `isDirty === false` so the "Modified" chip doesn't flash before
+ * the persisted draft arrives. Once a baseline is set, every state change
+ * is compared against it.
+ */
+export const usePromptFormDirty = ({ current, baseline }: UsePromptFormDirtyArgs): boolean => {
+  const [isDirty, setIsDirty] = useState(false);
+
+  useEffect(() => {
+    if (baseline === null) {
+      setIsDirty(false);
+      return;
+    }
+    setIsDirty(!arePromptDraftsEqual(current, baseline));
+  }, [current, baseline]);
+
+  return isDirty;
+};

--- a/components/ui/src/prompts-v2/form/PromptFormPage.tsx
+++ b/components/ui/src/prompts-v2/form/PromptFormPage.tsx
@@ -105,6 +105,13 @@ export interface PromptFormPageProps extends PromptFormReleaseFlowProps {
   editorRunState?: 'idle' | 'running';
   /** Last completed run record for the editor-tab response panel. */
   lastEditorRun?: EditorRunRecord | null;
+  /**
+   * Issue #185 — when `true`, render the "Modified" chip in the sticky
+   * header to signal the form has unsaved changes. The chip sits next to the
+   * existing revision label so issue #184 (topbar revision) can coordinate
+   * with the same signal.
+   */
+  isDirty?: boolean;
 }
 
 const HEADER_HEIGHT = 56;
@@ -166,6 +173,7 @@ const StickyHeader: React.FC<{
   releaseDisabledReason: string | null;
   onEditorRun?: () => void;
   isEditorRunning?: boolean;
+  isDirty?: boolean;
 }> = ({
   mode,
   draft,
@@ -180,6 +188,7 @@ const StickyHeader: React.FC<{
   releaseDisabledReason,
   onEditorRun,
   isEditorRunning,
+  isDirty = false,
 }) => {
   const isCreate = mode === 'create';
   const totalErrors =
@@ -264,6 +273,28 @@ const StickyHeader: React.FC<{
           </>
         )}
       </FormMono>
+
+      {isDirty && (
+        <span
+          data-testid="prompt-editor-dirty-indicator"
+          aria-label="Form has unsaved changes"
+          title="Form has unsaved changes"
+          style={{
+            padding: '2px 7px',
+            background: 'oklch(0.94 0.05 80)',
+            color: 'oklch(0.42 0.13 70)',
+            fontFamily: 'var(--pl-mono)',
+            fontSize: 10,
+            letterSpacing: '0.10em',
+            textTransform: 'uppercase',
+            borderRadius: 3,
+            fontWeight: 500,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          Modified
+        </span>
+      )}
 
       <FormMono
         size={11}
@@ -356,6 +387,7 @@ export const PromptFormPage: React.FC<PromptFormPageProps> = ({
   onEditorRun,
   editorRunState = 'idle',
   lastEditorRun = null,
+  isDirty = false,
 }) => {
   const errors = React.useMemo(
     () => validateDraft(draft, evalEnabled),
@@ -462,6 +494,7 @@ export const PromptFormPage: React.FC<PromptFormPageProps> = ({
         }
         onEditorRun={onEditorRun}
         isEditorRunning={editorRunState === 'running'}
+        isDirty={isDirty}
       />
 
       {releaseFlowEnabled ? (


### PR DESCRIPTION
## Summary
- Detects when the v2 prompt editor form diverges from the persisted state, surfaces a "Modified" chip in the sticky header, and prompts the user before navigation that would lose edits.
- New `dirtyState.ts` compares sanitised drafts (ignoring volatile message ids); `PromptFormShell` tracks a baseline, plumbs `isDirty` to `PromptFormPage`, installs a `beforeunload` listener, swallows browser back via a sentinel history entry, and routes the Cancel button through `UnsavedChangesDialog`.
- Dialog branches match the issue verbatim: **Save changes** / **Discard** / **Cancel**.

Closes #185 once merged.

## Coordination with #184
This PR exposes the dirty signal as a new `isDirty` prop on `PromptFormPage`. The "Modified" chip is rendered next to the existing revision label so the topbar revision identifier from #184 can coordinate with the same signal. No revision-label text is changed here.

## Known limitation
Sidebar / header nav-link clicks remain unguarded — the app uses `BrowserRouter` (not a data router) so `useBlocker` is unavailable. Tracked as a follow-up; could be addressed by migrating to `createBrowserRouter` or lifting a `NavigationGuard` context into `App.tsx`.

## Test plan
- [x] `npm --workspace @promptlm/web-ui test` — 127 tests pass (15 new tests across `dirtyState.test.ts`, `usePromptFormDirty.test.tsx`, `UnsavedChangesDialog.test.tsx`).
- [x] `npm --workspace @promptlm/ui test` — UI smoke pass.
- [x] `npm --workspace @promptlm/web-ui run lint` — 0 errors (pre-existing warnings only).
- [ ] Manual: open `/prompts/<id>/edit`, edit a field → "Modified" chip appears → Cancel → dialog appears with three actions → Discard returns to the detail page.
- [ ] Manual: same flow, browser back → dialog appears.
- [ ] Manual: same flow, reload page → browser's native unsaved-changes confirmation fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)