### PR TITLE
feat(prompt-editor): show revision identifier in topbar (#184)

### DIFF
--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpec.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpec.java
@@ -174,6 +174,37 @@ public class PromptSpec {
             accessMode = Schema.AccessMode.READ_ONLY)
     private final PromptSpecLifecycleState lifecycleState;
 
+    /**
+     * Short SHA (7 chars) of the Git commit that currently carries the spec
+     * content. Server-derived only; never accepted from clients on writes.
+     * Empty when the spec is not yet committed or when the active project has
+     * no Git context.
+     *
+     * <p>Surfaces to the UI as the fallback revision identifier when no
+     * release tag is present (see issue #184).
+     */
+    @JsonProperty("headShortSha")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "Server-derived Git short SHA (7 chars) of HEAD when the working tree matches a commit. Omitted otherwise.",
+            nullable = true,
+            accessMode = Schema.AccessMode.READ_ONLY,
+            example = "a1b2c3d")
+    private final String headShortSha;
+
+    /**
+     * Flat-field projection of the release tag stored under the
+     * {@code x-release} extension. Server-derived only; never accepted from
+     * clients on writes. The UI uses this as the preferred revision
+     * identifier in the editor topbar (see issue #184).
+     */
+    @JsonProperty("releaseTag")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "Server-derived release tag for the current revision. Omitted when the spec has not been released.",
+            nullable = true,
+            accessMode = Schema.AccessMode.READ_ONLY,
+            example = "v1.4")
+    private final String releaseTag;
+
     public String getRepositoryUrl() {
         return repositoryUrl;
     }
@@ -301,16 +332,19 @@ public class PromptSpec {
                 path,
                 executions,
                 semanticHash,
+                null,
+                null,
                 null
         );
     }
 
     /**
-     * Full-args constructor including the derived {@link #lifecycleState}.
-     * The {@code lifecycleState} parameter is intentionally <em>not</em> part
-     * of the {@code @JsonCreator} signature — the API derives the value at the
-     * boundary (see {@code PromptSpecLifecycleDeriver}) and any incoming JSON
-     * value is silently ignored on deserialization.
+     * Full-args constructor including the derived {@link #lifecycleState},
+     * {@link #headShortSha}, and {@link #releaseTag}. These boundary-only
+     * parameters are intentionally <em>not</em> part of the {@code @JsonCreator}
+     * signature — the API derives the values at the boundary (see
+     * {@code PromptSpecLifecycleDeriver}) and any incoming JSON value is
+     * silently ignored on deserialization.
      */
     private PromptSpec(
             String specVersion,
@@ -336,7 +370,9 @@ public class PromptSpec {
             Path path,
             List<Execution> executions,
             String semanticHash,
-            PromptSpecLifecycleState lifecycleState) {
+            PromptSpecLifecycleState lifecycleState,
+            String headShortSha,
+            String releaseTag) {
 
         this.specVersion = specVersion;
         this.uuid = uuid;
@@ -362,6 +398,8 @@ public class PromptSpec {
         this.executions = executions;
         this.semanticHash = semanticHash;
         this.lifecycleState = lifecycleState;
+        this.headShortSha = headShortSha;
+        this.releaseTag = releaseTag;
     }
 
     public PromptSpec(
@@ -567,11 +605,91 @@ public class PromptSpec {
                 this.path,
                 this.executions,
                 this.semanticHash,
-                lifecycleState);
+                lifecycleState,
+                this.headShortSha,
+                this.releaseTag);
+    }
+
+    /**
+     * Returns a copy with the given Git short SHA attached. Intended for use
+     * at the API boundary only — see {@link #withLifecycleState} for the same
+     * "never persist this to disk" warning.
+     */
+    public PromptSpec withHeadShortSha(String headShortSha) {
+        return Objects.equals(this.headShortSha, headShortSha) ? this : new PromptSpec(
+                this.specVersion,
+                this.uuid,
+                this.id,
+                this.name,
+                this.group,
+                this.version,
+                this.revision,
+                this.description,
+                this.authors,
+                this.purpose,
+                this.repositoryUrl,
+                this.status,
+                this.createdAt,
+                this.updatedAt,
+                this.retiredAt,
+                this.retiredReason,
+                this.request,
+                this.placeholders,
+                this.response,
+                this.extensions,
+                this.path,
+                this.executions,
+                this.semanticHash,
+                this.lifecycleState,
+                headShortSha,
+                this.releaseTag);
+    }
+
+    /**
+     * Returns a copy with the given release tag attached. Intended for use at
+     * the API boundary only — see {@link #withLifecycleState} for the same
+     * "never persist this to disk" warning.
+     */
+    public PromptSpec withReleaseTag(String releaseTag) {
+        return Objects.equals(this.releaseTag, releaseTag) ? this : new PromptSpec(
+                this.specVersion,
+                this.uuid,
+                this.id,
+                this.name,
+                this.group,
+                this.version,
+                this.revision,
+                this.description,
+                this.authors,
+                this.purpose,
+                this.repositoryUrl,
+                this.status,
+                this.createdAt,
+                this.updatedAt,
+                this.retiredAt,
+                this.retiredReason,
+                this.request,
+                this.placeholders,
+                this.response,
+                this.extensions,
+                this.path,
+                this.executions,
+                this.semanticHash,
+                this.lifecycleState,
+                this.headShortSha,
+                releaseTag);
     }
 
     public PromptSpecLifecycleState getLifecycleState() {
         return lifecycleState;
+    }
+
+    public String getHeadShortSha() {
+        return headShortSha;
+    }
+
+    public String getReleaseTag() {
+        return releaseTag;
     }
 
     @JsonIgnore

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecApiView.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecApiView.java
@@ -18,7 +18,7 @@ package dev.promptlm.web;
 
 import dev.promptlm.domain.promptspec.Execution;
 import dev.promptlm.domain.promptspec.PromptSpec;
-import dev.promptlm.domain.promptspec.PromptSpecLifecycleState;
+import dev.promptlm.domain.promptspec.ReleaseMetadata;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -57,7 +57,8 @@ final class PromptSpecApiView {
             return null;
         }
         PromptSpec withExecutions = sortExecutionsNewestFirst(spec);
-        return withLifecycleState(withExecutions, deriver);
+        PromptSpec withRevision = withRevisionMetadata(withExecutions, deriver);
+        return withReleaseTagAttached(withRevision);
     }
 
     static List<PromptSpec> toApiView(List<PromptSpec> specs) {
@@ -85,15 +86,37 @@ final class PromptSpecApiView {
         return spec.withExecutions(sorted);
     }
 
-    private static PromptSpec withLifecycleState(PromptSpec spec, PromptSpecLifecycleDeriver deriver) {
+    private static PromptSpec withRevisionMetadata(PromptSpec spec, PromptSpecLifecycleDeriver deriver) {
         if (deriver == null) {
             return spec;
         }
-        PromptSpecLifecycleState state = deriver.derive(spec);
-        if (state == null) {
+        PromptSpecLifecycleDeriver.Result result = deriver.deriveResult(spec);
+        if (result == null) {
             return spec;
         }
-        return spec.withLifecycleState(state);
+        PromptSpec updated = spec;
+        if (result.state() != null) {
+            updated = updated.withLifecycleState(result.state());
+        }
+        if (result.headShortSha() != null) {
+            updated = updated.withHeadShortSha(result.headShortSha());
+        }
+        return updated;
+    }
+
+    private static PromptSpec withReleaseTagAttached(PromptSpec spec) {
+        if (spec == null) {
+            return null;
+        }
+        ReleaseMetadata release = spec.getReleaseMetadata();
+        if (release == null) {
+            return spec;
+        }
+        String tag = release.tag();
+        if (tag == null || tag.isBlank()) {
+            return spec;
+        }
+        return spec.withReleaseTag(tag);
     }
 
     private static Instant timestampOrEpoch(Execution execution) {

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecLifecycleDeriver.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecLifecycleDeriver.java
@@ -52,12 +52,37 @@ import java.util.Arrays;
  * derivation falls through to {@code null}. The lifecycle field is decorative
  * metadata for the UI; a Git read hiccup must not break the {@code GET}.
  *
+ * <p>Issue #184 extends the deriver to also surface the Git short SHA of the
+ * commit that currently carries the spec content (HEAD when the working tree
+ * matches HEAD). The UI uses this as the fallback revision identifier when no
+ * release tag is present in the spec extensions.
+ *
  * @see <a href="https://github.com/promptLM/promptlm-app/issues/189">Issue #189</a>
+ * @see <a href="https://github.com/promptLM/promptlm-app/issues/184">Issue #184</a>
  */
 @Component
 class PromptSpecLifecycleDeriver {
 
+    /**
+     * Result of a single derivation pass. {@link #state} captures the
+     * lifecycle classification; {@link #headShortSha} carries the 7-char
+     * abbreviation of HEAD when the working tree matches a commit (i.e. for
+     * {@link PromptSpecLifecycleState#COMMITTED} and
+     * {@link PromptSpecLifecycleState#PUSHED}). For
+     * {@link PromptSpecLifecycleState#SAVED} the SHA is {@code null} because
+     * the on-disk content is not represented by any commit yet.
+     */
+    record Result(PromptSpecLifecycleState state, String headShortSha) {
+
+        static final Result EMPTY = new Result(null, null);
+
+        static Result onlyState(PromptSpecLifecycleState state) {
+            return new Result(state, null);
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(PromptSpecLifecycleDeriver.class);
+    private static final int SHORT_SHA_LENGTH = 7;
 
     private final AppContext appContext;
 
@@ -68,24 +93,35 @@ class PromptSpecLifecycleDeriver {
     /**
      * Returns the lifecycle state of the given spec, or {@code null} when it
      * cannot be derived.
+     *
+     * <p>Retained as a convenience for callers that only care about the state
+     * classification. Prefer {@link #deriveResult(PromptSpec)} when the short
+     * SHA is also useful.
      */
     PromptSpecLifecycleState derive(PromptSpec spec) {
+        return deriveResult(spec).state();
+    }
+
+    /**
+     * Returns the full derivation result — state plus optional short SHA.
+     */
+    Result deriveResult(PromptSpec spec) {
         if (spec == null) {
-            return null;
+            return Result.EMPTY;
         }
         Path repoDir = resolveRepoDir();
         if (repoDir == null) {
-            return null;
+            return Result.EMPTY;
         }
         Path specPath = resolveSpecPath(spec, repoDir);
         if (specPath == null) {
-            return null;
+            return Result.EMPTY;
         }
         try (Git git = Git.open(repoDir.toFile())) {
             Repository repo = git.getRepository();
             String relativeGitPath = toGitPath(repoDir, specPath);
             if (relativeGitPath == null) {
-                return null;
+                return Result.EMPTY;
             }
 
             byte[] workingTreeContent = Files.exists(specPath)
@@ -96,19 +132,22 @@ class PromptSpecLifecycleDeriver {
             if (!Arrays.equals(workingTreeContent, headContent)) {
                 // Working tree differs from HEAD (or HEAD has no blob yet for
                 // this path). The change has been "saved" to disk but is not
-                // captured by a commit yet.
-                return PromptSpecLifecycleState.SAVED;
+                // captured by a commit yet. No short SHA — the on-disk content
+                // is not represented by any commit.
+                return Result.onlyState(PromptSpecLifecycleState.SAVED);
             }
 
-            // Working tree matches HEAD; differentiate committed vs pushed.
+            // Working tree matches HEAD; HEAD's short SHA identifies the
+            // current revision regardless of pushed-or-not.
+            String shortSha = shortShaOfHead(repo);
             if (isHeadReachableFromOrigin(repo)) {
-                return PromptSpecLifecycleState.PUSHED;
+                return new Result(PromptSpecLifecycleState.PUSHED, shortSha);
             }
-            return PromptSpecLifecycleState.COMMITTED;
+            return new Result(PromptSpecLifecycleState.COMMITTED, shortSha);
         } catch (IOException | RuntimeException e) {
             log.warn("Failed to derive lifecycle state for prompt {}/{} at {}: {}",
                     spec.getGroup(), spec.getName(), specPath, e.toString());
-            return null;
+            return Result.EMPTY;
         }
     }
 
@@ -208,5 +247,21 @@ class PromptSpecLifecycleDeriver {
             }
             return walk.isMergedInto(headCommit, originCommit);
         }
+    }
+
+    /**
+     * Returns the 7-char abbreviation of HEAD's commit SHA, or {@code null}
+     * when HEAD cannot be resolved.
+     */
+    private String shortShaOfHead(Repository repo) throws IOException {
+        ObjectId headId = repo.resolve("HEAD");
+        if (headId == null) {
+            return null;
+        }
+        String full = headId.getName();
+        if (full.length() <= SHORT_SHA_LENGTH) {
+            return full;
+        }
+        return full.substring(0, SHORT_SHA_LENGTH);
     }
 }

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
@@ -281,8 +281,9 @@ class PromptSpecControllerWebMvcTest {
         String promptId = "welcome";
         PromptSpec stored = baseSpec("support/" + promptId);
         when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
-        when(lifecycleDeriver.derive(any(PromptSpec.class)))
-                .thenReturn(dev.promptlm.domain.promptspec.PromptSpecLifecycleState.PUSHED);
+        when(lifecycleDeriver.deriveResult(any(PromptSpec.class)))
+                .thenReturn(new PromptSpecLifecycleDeriver.Result(
+                        dev.promptlm.domain.promptspec.PromptSpecLifecycleState.PUSHED, null));
 
         mockMvc.perform(get("/api/prompts/{promptSpecId}", promptId))
                 .andExpect(status().isOk())
@@ -290,15 +291,17 @@ class PromptSpecControllerWebMvcTest {
     }
 
     @Test
-    void getByIdOmitsLifecycleStateWhenDeriverReturnsNull() throws Exception {
+    void getByIdOmitsLifecycleStateWhenDeriverReturnsEmpty() throws Exception {
         String promptId = "welcome";
         PromptSpec stored = baseSpec("support/" + promptId);
         when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
-        when(lifecycleDeriver.derive(any(PromptSpec.class))).thenReturn(null);
+        when(lifecycleDeriver.deriveResult(any(PromptSpec.class)))
+                .thenReturn(PromptSpecLifecycleDeriver.Result.EMPTY);
 
         mockMvc.perform(get("/api/prompts/{promptSpecId}", promptId))
                 .andExpect(status().isOk())
-                .andExpect(content().string(not(containsString("\"lifecycleState\""))));
+                .andExpect(content().string(not(containsString("\"lifecycleState\""))))
+                .andExpect(content().string(not(containsString("\"headShortSha\""))));
     }
 
     @Test
@@ -311,12 +314,51 @@ class PromptSpecControllerWebMvcTest {
         String promptId = "welcome";
         PromptSpec stored = baseSpec("support/" + promptId);
         when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
-        when(lifecycleDeriver.derive(any(PromptSpec.class)))
-                .thenReturn(dev.promptlm.domain.promptspec.PromptSpecLifecycleState.SAVED);
+        when(lifecycleDeriver.deriveResult(any(PromptSpec.class)))
+                .thenReturn(new PromptSpecLifecycleDeriver.Result(
+                        dev.promptlm.domain.promptspec.PromptSpecLifecycleState.SAVED, null));
 
         mockMvc.perform(get("/api/prompts/{promptSpecId}", promptId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.lifecycleState").value("saved"));
+    }
+
+    @Test
+    void getByIdIncludesHeadShortShaWhenDeriverProvidesIt() throws Exception {
+        String promptId = "welcome";
+        PromptSpec stored = baseSpec("support/" + promptId);
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
+        when(lifecycleDeriver.deriveResult(any(PromptSpec.class)))
+                .thenReturn(new PromptSpecLifecycleDeriver.Result(
+                        dev.promptlm.domain.promptspec.PromptSpecLifecycleState.PUSHED, "a1b2c3d"));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}", promptId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lifecycleState").value("pushed"))
+                .andExpect(jsonPath("$.headShortSha").value("a1b2c3d"));
+    }
+
+    @Test
+    void getByIdExposesReleaseTagWhenExtensionPresent() throws Exception {
+        String promptId = "welcome";
+        ReleaseMetadata release = new ReleaseMetadata(
+                ReleaseMetadata.STATE_RELEASED,
+                ReleaseMetadata.MODE_DIRECT,
+                "1.4.0",
+                "v1.4",
+                "main",
+                null,
+                null,
+                null);
+        PromptSpec stored = baseSpec("support/" + promptId)
+                .withReleaseMetadata(release);
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
+        when(lifecycleDeriver.deriveResult(any(PromptSpec.class)))
+                .thenReturn(PromptSpecLifecycleDeriver.Result.EMPTY);
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}", promptId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.releaseTag").value("v1.4"));
     }
 
     @Test

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecLifecycleDeriverTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecLifecycleDeriverTest.java
@@ -86,6 +86,69 @@ class PromptSpecLifecycleDeriverTest {
     }
 
     @Test
+    void deriveResultIncludesShortShaForPushedSpec(@TempDir Path tempDir) throws Exception {
+        Path local = initRepoWithPromptCommit(tempDir.resolve("local"));
+        Path remote = initBareRemote(tempDir.resolve("remote.git"));
+        configureRemoteAndPush(local, remote);
+
+        wireActiveProject(local);
+        PromptSpec spec = newSpecWithPath(Path.of(SPEC_RELATIVE_PATH));
+
+        PromptSpecLifecycleDeriver.Result result = deriver.deriveResult(spec);
+
+        assertThat(result.state()).isEqualTo(PromptSpecLifecycleState.PUSHED);
+        assertThat(result.headShortSha()).matches("^[0-9a-f]{7}$");
+        assertThat(result.headShortSha()).isEqualTo(headFullShaOf(local).substring(0, 7));
+    }
+
+    @Test
+    void deriveResultIncludesShortShaForCommittedSpec(@TempDir Path tempDir) throws Exception {
+        Path local = initRepoWithPromptCommit(tempDir.resolve("local"));
+        // No remote → committed but not pushed.
+
+        wireActiveProject(local);
+        PromptSpec spec = newSpecWithPath(Path.of(SPEC_RELATIVE_PATH));
+
+        PromptSpecLifecycleDeriver.Result result = deriver.deriveResult(spec);
+
+        assertThat(result.state()).isEqualTo(PromptSpecLifecycleState.COMMITTED);
+        assertThat(result.headShortSha()).isEqualTo(headFullShaOf(local).substring(0, 7));
+    }
+
+    @Test
+    void deriveResultOmitsShortShaForSavedSpec(@TempDir Path tempDir) throws Exception {
+        Path local = initRepoWithPromptCommit(tempDir.resolve("local"));
+        // Mutate the working tree without committing → SAVED.
+        Files.writeString(local.resolve(SPEC_RELATIVE_PATH), SPEC_YAML + "description: edited\n");
+
+        wireActiveProject(local);
+        PromptSpec spec = newSpecWithPath(Path.of(SPEC_RELATIVE_PATH));
+
+        PromptSpecLifecycleDeriver.Result result = deriver.deriveResult(spec);
+
+        assertThat(result.state()).isEqualTo(PromptSpecLifecycleState.SAVED);
+        assertThat(result.headShortSha()).as("SAVED state has no representative commit").isNull();
+    }
+
+    @Test
+    void deriveResultIsEmptyWhenActiveProjectAbsent() {
+        when(appContext.getActiveProject()).thenReturn(null);
+
+        PromptSpec spec = newSpecWithPath(Path.of(SPEC_RELATIVE_PATH));
+
+        PromptSpecLifecycleDeriver.Result result = deriver.deriveResult(spec);
+
+        assertThat(result.state()).isNull();
+        assertThat(result.headShortSha()).isNull();
+    }
+
+    private static String headFullShaOf(Path local) throws Exception {
+        try (Git git = Git.open(local.toFile())) {
+            return git.getRepository().resolve("HEAD").getName();
+        }
+    }
+
+    @Test
     void returnsCommittedWhenWorkingTreeMatchesHeadButOriginIsBehind(@TempDir Path tempDir) throws Exception {
         Path local = initRepoWithPromptCommit(tempDir.resolve("local"));
         Path remote = initBareRemote(tempDir.resolve("remote.git"));

--- a/components/promptlm-web-ui/src/features/prompt-editor/PromptFormShell.tsx
+++ b/components/promptlm-web-ui/src/features/prompt-editor/PromptFormShell.tsx
@@ -47,6 +47,7 @@ import {
   usePromptEditorDraft,
 } from './draftState';
 import { releasePromptAction, savePromptDraftAction } from './editorActions';
+import { selectRevisionId } from './selectRevisionId';
 import { usePromptEditorData } from './usePromptEditorData';
 import { useCapabilities } from '@/api/hooks';
 import { useGeneratedApiClient } from '@api-common/generatedClientProvider';
@@ -250,11 +251,22 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
       data.activeProject?.repositoryUrl ??
       data.prompt?.repositoryUrl ??
       'local repository';
+    // Issue #184: prefer the release tag, otherwise the Git short SHA. Both
+    // fields are server-derived (see PromptSpecApiView) and may be absent —
+    // in which case the topbar falls back to the legacy "next will bump"
+    // copy. Selection logic lives in `selectRevisionId` so it can be tested
+    // independently of the React component.
+    const revisionId = selectRevisionId(
+      data.prompt as
+        | (typeof data.prompt & { releaseTag?: string | null; headShortSha?: string | null })
+        | null,
+    );
     return {
       version: data.prompt?.version ?? FALLBACK_VERSION,
       revision: data.prompt?.revision ? `r${data.prompt.revision}` : FALLBACK_REVISION,
       repositoryUrl,
       branch: 'main',
+      revisionId,
     };
   }, [data.activeProject?.repositoryUrl, data.prompt]);
 

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/selectRevisionId.test.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/selectRevisionId.test.ts
@@ -1,0 +1,54 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+import { selectRevisionId } from '../selectRevisionId';
+
+describe('selectRevisionId', () => {
+  it('prefers the release tag when present', () => {
+    expect(selectRevisionId({ releaseTag: 'v1.4', headShortSha: 'a1b2c3d' })).toBe('v1.4');
+  });
+
+  it('falls back to the short SHA when no tag is present', () => {
+    expect(selectRevisionId({ releaseTag: undefined, headShortSha: 'a1b2c3d' })).toBe('a1b2c3d');
+  });
+
+  it('returns undefined when neither field is set', () => {
+    expect(selectRevisionId({})).toBeUndefined();
+  });
+
+  it('returns undefined when the source itself is null', () => {
+    expect(selectRevisionId(null)).toBeUndefined();
+  });
+
+  it('returns undefined when the source is undefined', () => {
+    expect(selectRevisionId(undefined)).toBeUndefined();
+  });
+
+  it('treats blank tag as absent and falls back to the SHA', () => {
+    expect(selectRevisionId({ releaseTag: '   ', headShortSha: 'a1b2c3d' })).toBe('a1b2c3d');
+  });
+
+  it('treats blank SHA as absent and returns undefined when no tag', () => {
+    expect(selectRevisionId({ releaseTag: null, headShortSha: '' })).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace from the tag', () => {
+    expect(selectRevisionId({ releaseTag: '  v2.0 ' })).toBe('v2.0');
+  });
+
+  it('trims surrounding whitespace from the SHA', () => {
+    expect(selectRevisionId({ headShortSha: '\ta1b2c3d\n' })).toBe('a1b2c3d');
+  });
+});

--- a/components/promptlm-web-ui/src/features/prompt-editor/selectRevisionId.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/selectRevisionId.ts
@@ -1,0 +1,54 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Picks the user-visible revision identifier for the editor topbar.
+ *
+ * Resolution order, per issue #184:
+ *   1. `releaseTag` — present when the spec has been released with a tag
+ *      (e.g. "v1.4").
+ *   2. `headShortSha` — fallback when no tag is available (e.g. "a1b2c3d").
+ *   3. `undefined` — the spec cannot be matched to a committed revision;
+ *      the topbar must fall back to its legacy copy.
+ *
+ * Both source fields are server-derived (see `PromptSpecApiView.java`) and
+ * read here through a structural shape so the helper does not depend on the
+ * api-client TS regen cycle for #189 + #184.
+ *
+ * Blank / whitespace-only inputs are treated as absent so a stray empty
+ * string from the backend can't pin the topbar to a meaningless label.
+ */
+export type RevisionSource = {
+  releaseTag?: string | null;
+  headShortSha?: string | null;
+} | null | undefined;
+
+export const selectRevisionId = (source: RevisionSource): string | undefined => {
+  if (!source) {
+    return undefined;
+  }
+  const tag = nonBlank(source.releaseTag);
+  if (tag) {
+    return tag;
+  }
+  return nonBlank(source.headShortSha);
+};
+
+const nonBlank = (value: string | null | undefined): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};

--- a/components/ui/src/prompts-v2/form/PromptFormPage.tsx
+++ b/components/ui/src/prompts-v2/form/PromptFormPage.tsx
@@ -258,6 +258,20 @@ const StickyHeader: React.FC<{
             v<span style={{ color: 'var(--pl-ink-700)' }}>{context.version}</span> ·{' '}
             <span style={{ color: 'var(--pl-ink-700)' }}>{context.revision}</span>
           </>
+        ) : context.revisionId ? (
+          // Issue #184: when the backend supplies a revision identifier
+          // (release tag or short SHA), surface it as the primary indicator
+          // of which committed revision the user is editing against. Rendered
+          // in its own span so #185's "modified" chip can render adjacent.
+          <>
+            v<span style={{ color: 'var(--pl-ink-700)' }}>{context.version}</span> ·{' '}
+            <span
+              style={{ color: 'var(--pl-ink-700)' }}
+              data-testid="prompt-editor-revision-id"
+            >
+              {context.revisionId}
+            </span>
+          </>
         ) : (
           <>
             v<span style={{ color: 'var(--pl-ink-700)' }}>{context.version}</span> → next will bump · {context.branch}

--- a/components/ui/src/prompts-v2/form/types.ts
+++ b/components/ui/src/prompts-v2/form/types.ts
@@ -102,6 +102,13 @@ export interface PromptFormContext {
   repositoryUrl: string;
   /** "main" — branch name from git. */
   branch: string;
+  /**
+   * Identifier of the committed/pushed revision currently being edited —
+   * a release tag (e.g. "v1.4") when available, else the Git short SHA
+   * (e.g. "a1b2c3d"). When undefined the topbar falls back to the legacy
+   * "next will bump · {branch}" copy. See issue #184.
+   */
+  revisionId?: string;
 }
 
 export interface PromptFormErrors {


### PR DESCRIPTION
## Summary
- Edit-mode topbar shows the prompt's revision identifier: release tag (e.g. `v1.4`) when available, otherwise the Git short SHA (e.g. `a1b2c3d`). Falls back gracefully to the existing copy when neither is derivable.
- Backend extends `PromptSpecLifecycleDeriver` with a `Result` record (state + short SHA) and attaches two new boundary-only fields to `PromptSpec` at the API view: `releaseTag` (from the `x-release` extension) and `headShortSha` (from the deriver). Both follow the existing `lifecycleState` pattern (`@JsonInclude(NON_NULL)`, never accepted on writes, never persisted).
- Frontend `PromptFormContext` gains an optional `revisionId`. `PromptFormPage` renders it in its own `data-testid="prompt-editor-revision-id"` span so the dirty-marker work in #185 can attach a chip alongside without further refactor.

## Test plan
- [x] `./mvnw -pl components/promptlm-domain test` — 52/52 pass.
- [x] `./mvnw -pl components/promptlm-web-api test` — 97/97 pass (4 new boundary tests).
- [x] `npm test -w @promptlm/web-ui` — 121/121 pass (9 new tests for `selectRevisionId`).
- [x] `npm test -w @promptlm/ui` — smoke green.
- [ ] Manual: open an existing released prompt — topbar shows `v{version} · v{tag}`.
- [ ] Manual: open an existing unreleased committed prompt — topbar shows `v{version} · {shortSha}`.
- [ ] Manual: open `/prompts/new` — create-mode copy unchanged.

## Dependencies
Depends on #189 (`PromptSpecLifecycleDeriver` infrastructure). Branched off `main` because both #184 and #185 are siblings of #189.

## Coordination with #185
The revision identifier lives in its own span. PR #185 attaches the "Modified" chip adjacent to the same span; the two PRs converge on `PromptFormPage.tsx` but on different render expressions. A small merge interleaving is expected.

## Follow-ups
Regenerate `@promptlm/api-client` once both #189 and #184 land on main, then simplify the structural augmentation in `PromptFormShell.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)