### PR TITLE
feat(prompt-editor): link prompt to GitHub when pushed (#188)

### DIFF
--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
@@ -364,6 +364,38 @@ class PromptSpecControllerWebMvcTest {
     }
 
     @Test
+    void viewOnRemoteUrlFieldIsNotPresentOnPromptSpecBoundary() throws Exception {
+        // The View-on-GitHub link is composed by the frontend from the
+        // project's remote URL + the spec's path + headShortSha (see #188's
+        // refactor). The server therefore no longer attaches a viewOnRemoteUrl
+        // field to PromptSpec. Hardening: a client write carrying that field
+        // is silently dropped by Jackson, and read responses never emit it.
+        String promptId = "welcome";
+        PromptSpec stored = baseSpec("support/" + promptId);
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
+
+        mockMvc.perform(get("/api/prompts/{promptSpecId}", promptId))
+                .andExpect(status().isOk())
+                .andExpect(content().string(not(containsString("\"viewOnRemoteUrl\""))));
+
+        String payload = """
+                {
+                  "name": "welcome",
+                  "group": "support",
+                  "viewOnRemoteUrl": "https://evil.example/inject"
+                }
+                """;
+        // Sanity: deserialisation succeeds and the unknown property is
+        // ignored. The field is gone from the type, so there's no getter to
+        // assert against — instead re-serialising and confirming the URL is
+        // not echoed back gives equivalent coverage.
+        PromptSpec readBack = objectMapper.readValue(payload, PromptSpec.class);
+        String roundTripped = objectMapper.writeValueAsString(readBack);
+        assertThat(roundTripped).doesNotContain("viewOnRemoteUrl");
+        assertThat(roundTripped).doesNotContain("evil.example");
+    }
+
+    @Test
     void completeReleaseEndpointDelegatesToLifecycleAndSetsReleaseStateHeader() throws Exception {
         String promptId = "support/welcome";
         PromptSpec stored = PromptSpec.builder()

--- a/components/promptlm-web-ui/src/features/prompt-editor/PromptFormShell.tsx
+++ b/components/promptlm-web-ui/src/features/prompt-editor/PromptFormShell.tsx
@@ -59,6 +59,7 @@ import {
 import { buildEditorRunRequest } from './buildEditorRunRequest';
 import { releasePromptAction, savePromptDraftAction } from './editorActions';
 import { selectRevisionId } from './selectRevisionId';
+import { buildViewOnRemoteUrl } from './buildViewOnRemoteUrl';
 import { usePromptEditorData } from './usePromptEditorData';
 import { usePromptFormDirty } from './dirtyState';
 import { UnsavedChangesDialog } from './UnsavedChangesDialog';
@@ -291,12 +292,32 @@ export const PromptFormShell = ({ mode, promptId }: PromptFormShellProps) => {
         | (typeof data.prompt & { releaseTag?: string | null; headShortSha?: string | null })
         | null,
     );
+    // Issue #188: compose the "View on GitHub" URL client-side from the
+    // project's remote (project-level concern, can change), the spec's path,
+    // and the head SHA. The backend no longer attaches a viewOnRemoteUrl to
+    // the spec — see buildViewOnRemoteUrl for the gating rules. Empty in
+    // create mode (no prompt loaded yet) and whenever the project's remote
+    // is not a recognised GitHub URL.
+    const specView = data.prompt as
+      | (typeof data.prompt & {
+          path?: string | null;
+          headShortSha?: string | null;
+          lifecycleState?: string | null;
+        })
+      | null;
+    const viewOnRemoteUrl = buildViewOnRemoteUrl({
+      projectRemoteUrl: data.activeProject?.repositoryUrl,
+      specPath: specView?.path,
+      headSha: specView?.headShortSha,
+      lifecycleState: specView?.lifecycleState,
+    });
     return {
       version: data.prompt?.version ?? FALLBACK_VERSION,
       revision: data.prompt?.revision ? `r${data.prompt.revision}` : FALLBACK_REVISION,
       repositoryUrl,
       branch: 'main',
       revisionId,
+      viewOnRemoteUrl,
     };
   }, [data.activeProject?.repositoryUrl, data.prompt]);
 

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/buildViewOnRemoteUrl.test.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/buildViewOnRemoteUrl.test.ts
@@ -1,0 +1,197 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildViewOnRemoteUrl,
+  parseGithubOwnerRepo,
+} from '../buildViewOnRemoteUrl';
+
+describe('buildViewOnRemoteUrl', () => {
+  const base = {
+    projectRemoteUrl: 'https://github.com/acme/agents',
+    specPath: 'prompts/support/welcome.yml',
+    headSha: 'abc1234',
+    lifecycleState: 'pushed' as const,
+  };
+
+  it('composes a /blob/<sha>/<path> URL when all inputs are present and lifecycle is pushed', () => {
+    expect(buildViewOnRemoteUrl(base)).toBe(
+      'https://github.com/acme/agents/blob/abc1234/prompts/support/welcome.yml',
+    );
+  });
+
+  it('accepts a full-length SHA (GitHub /blob accepts both short and full)', () => {
+    expect(
+      buildViewOnRemoteUrl({
+        ...base,
+        headSha: 'abcdef1234567890abcdef1234567890abcdef12',
+      }),
+    ).toBe(
+      'https://github.com/acme/agents/blob/abcdef1234567890abcdef1234567890abcdef12/prompts/support/welcome.yml',
+    );
+  });
+
+  it('accepts SSH remotes (git@github.com:owner/repo[.git])', () => {
+    expect(
+      buildViewOnRemoteUrl({
+        ...base,
+        projectRemoteUrl: 'git@github.com:acme/agents.git',
+      }),
+    ).toBe(
+      'https://github.com/acme/agents/blob/abc1234/prompts/support/welcome.yml',
+    );
+  });
+
+  it('strips a trailing .git on HTTPS remotes', () => {
+    expect(
+      buildViewOnRemoteUrl({
+        ...base,
+        projectRemoteUrl: 'https://github.com/acme/agents.git',
+      }),
+    ).toBe(
+      'https://github.com/acme/agents/blob/abc1234/prompts/support/welcome.yml',
+    );
+  });
+
+  it('percent-encodes path segments so spaces and unicode produce a valid URL', () => {
+    expect(
+      buildViewOnRemoteUrl({
+        ...base,
+        specPath: 'prompts/customer support/héllo.yml',
+      }),
+    ).toBe(
+      'https://github.com/acme/agents/blob/abc1234/prompts/customer%20support/h%C3%A9llo.yml',
+    );
+  });
+
+  it('does not double-encode forward slashes between segments', () => {
+    const url = buildViewOnRemoteUrl({
+      ...base,
+      specPath: 'a/b/c.yml',
+    });
+    expect(url).toBe('https://github.com/acme/agents/blob/abc1234/a/b/c.yml');
+  });
+
+  it('normalises Windows-style backslashes to forward slashes', () => {
+    expect(
+      buildViewOnRemoteUrl({
+        ...base,
+        specPath: 'prompts\\support\\welcome.yml',
+      }),
+    ).toBe(
+      'https://github.com/acme/agents/blob/abc1234/prompts/support/welcome.yml',
+    );
+  });
+
+  describe('gating — lifecycleState', () => {
+    it('returns undefined when lifecycleState is draft', () => {
+      expect(buildViewOnRemoteUrl({ ...base, lifecycleState: 'draft' })).toBeUndefined();
+    });
+    it('returns undefined when lifecycleState is saved', () => {
+      expect(buildViewOnRemoteUrl({ ...base, lifecycleState: 'saved' })).toBeUndefined();
+    });
+    it('returns undefined when lifecycleState is committed (not yet pushed)', () => {
+      expect(buildViewOnRemoteUrl({ ...base, lifecycleState: 'committed' })).toBeUndefined();
+    });
+    it('returns undefined when lifecycleState is missing', () => {
+      expect(buildViewOnRemoteUrl({ ...base, lifecycleState: null })).toBeUndefined();
+      expect(buildViewOnRemoteUrl({ ...base, lifecycleState: undefined })).toBeUndefined();
+    });
+  });
+
+  describe('gating — remote URL', () => {
+    it('returns undefined when the remote is not a GitHub URL (GitLab)', () => {
+      expect(
+        buildViewOnRemoteUrl({
+          ...base,
+          projectRemoteUrl: 'https://gitlab.com/acme/agents',
+        }),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when the remote is Bitbucket', () => {
+      expect(
+        buildViewOnRemoteUrl({
+          ...base,
+          projectRemoteUrl: 'https://bitbucket.org/acme/agents',
+        }),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when the remote URL is missing or blank', () => {
+      expect(buildViewOnRemoteUrl({ ...base, projectRemoteUrl: null })).toBeUndefined();
+      expect(buildViewOnRemoteUrl({ ...base, projectRemoteUrl: undefined })).toBeUndefined();
+      expect(buildViewOnRemoteUrl({ ...base, projectRemoteUrl: '   ' })).toBeUndefined();
+    });
+
+    it('returns undefined when the remote URL is malformed', () => {
+      expect(
+        buildViewOnRemoteUrl({ ...base, projectRemoteUrl: 'not a url' }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('gating — spec path', () => {
+    it('returns undefined when the path is missing', () => {
+      expect(buildViewOnRemoteUrl({ ...base, specPath: null })).toBeUndefined();
+      expect(buildViewOnRemoteUrl({ ...base, specPath: undefined })).toBeUndefined();
+    });
+    it('returns undefined when the path is blank', () => {
+      expect(buildViewOnRemoteUrl({ ...base, specPath: '   ' })).toBeUndefined();
+    });
+  });
+
+  describe('gating — head SHA', () => {
+    it('returns undefined when the SHA is missing or blank', () => {
+      expect(buildViewOnRemoteUrl({ ...base, headSha: null })).toBeUndefined();
+      expect(buildViewOnRemoteUrl({ ...base, headSha: undefined })).toBeUndefined();
+      expect(buildViewOnRemoteUrl({ ...base, headSha: '' })).toBeUndefined();
+    });
+  });
+});
+
+describe('parseGithubOwnerRepo', () => {
+  it('parses https://github.com/owner/repo', () => {
+    expect(parseGithubOwnerRepo('https://github.com/acme/agents')).toEqual({
+      owner: 'acme',
+      repo: 'agents',
+    });
+  });
+
+  it('parses https://github.com/owner/repo.git', () => {
+    expect(parseGithubOwnerRepo('https://github.com/acme/agents.git')).toEqual({
+      owner: 'acme',
+      repo: 'agents',
+    });
+  });
+
+  it('parses git@github.com:owner/repo.git', () => {
+    expect(parseGithubOwnerRepo('git@github.com:acme/agents.git')).toEqual({
+      owner: 'acme',
+      repo: 'agents',
+    });
+  });
+
+  it('returns undefined for non-GitHub URLs', () => {
+    expect(parseGithubOwnerRepo('https://gitlab.com/acme/agents')).toBeUndefined();
+  });
+
+  it('returns undefined for empty / null input', () => {
+    expect(parseGithubOwnerRepo(null)).toBeUndefined();
+    expect(parseGithubOwnerRepo(undefined)).toBeUndefined();
+    expect(parseGithubOwnerRepo('')).toBeUndefined();
+  });
+});

--- a/components/promptlm-web-ui/src/features/prompt-editor/buildViewOnRemoteUrl.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/buildViewOnRemoteUrl.ts
@@ -1,0 +1,113 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Composes the "View on GitHub" URL on the client.
+ *
+ * The remote URL is a project-level concern, not a prompt-spec concern (it can
+ * change when the project is re-pointed at a different host), so the URL is
+ * not exposed on the {@code PromptSpec} boundary. Instead, the client takes
+ * the three inputs it already has — the active project's {@code repositoryUrl},
+ * the spec's {@code path}, and the spec's {@code headShortSha} (from #184) —
+ * and assembles
+ *
+ *   https://github.com/<owner>/<repo>/blob/<sha>/<encoded-path>
+ *
+ * Gating rules (all must hold; otherwise returns `undefined` and the caller
+ * hides the link):
+ *
+ * 1. `projectRemoteUrl` parses as a recognised GitHub URL (HTTPS
+ *    `https://github.com/owner/repo[.git]` or SSH
+ *    `git@github.com:owner/repo[.git]`).
+ * 2. `specPath` is a non-empty, repo-relative path.
+ * 3. `headSha` is a non-empty Git SHA (short or full — GitHub's
+ *    `/blob/<sha>` accepts both).
+ * 4. `lifecycleState === 'pushed'`. Drafts, saved, and committed (but not yet
+ *    pushed) revisions have no immutable remote URL.
+ *
+ * Each path segment is percent-encoded so spaces and non-ASCII characters in
+ * the spec path produce a valid URL — no user-controlled string is smuggled
+ * verbatim into the URL.
+ *
+ * @see https://github.com/promptLM/promptlm-app/issues/188
+ */
+
+const GITHUB_HTTPS = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s?#.]+)(?:\.git)?\/?(?:[?#].*)?$/;
+const GITHUB_SSH = /^git@github\.com:([^/\s]+)\/([^/\s.]+)(?:\.git)?$/;
+
+export type PromptLifecycleState =
+  | 'draft'
+  | 'saved'
+  | 'committed'
+  | 'pushed'
+  | (string & {});
+
+export interface ViewOnRemoteInputs {
+  /** Active project's remote URL (e.g. `https://github.com/acme/agents`). */
+  projectRemoteUrl: string | null | undefined;
+  /** Spec's on-disk path relative to the repository root. */
+  specPath: string | null | undefined;
+  /** Git short or full SHA of the commit currently carrying the spec. */
+  headSha: string | null | undefined;
+  /** Server-derived lifecycle state. Only `'pushed'` yields a URL. */
+  lifecycleState: PromptLifecycleState | null | undefined;
+}
+
+interface OwnerRepo {
+  owner: string;
+  repo: string;
+}
+
+const stripGitSuffix = (value: string): string =>
+  value.endsWith('.git') ? value.slice(0, -4) : value;
+
+/**
+ * Parses a remote URL into `{owner, repo}` when it is a recognised GitHub
+ * HTTPS or SSH URL, otherwise returns `undefined`. Exported for unit tests.
+ */
+export const parseGithubOwnerRepo = (
+  remoteUrl: string | null | undefined,
+): OwnerRepo | undefined => {
+  if (!remoteUrl) return undefined;
+  const trimmed = remoteUrl.trim();
+  if (trimmed.length === 0) return undefined;
+  const https = GITHUB_HTTPS.exec(trimmed);
+  if (https) return { owner: https[1], repo: stripGitSuffix(https[2]) };
+  const ssh = GITHUB_SSH.exec(trimmed);
+  if (ssh) return { owner: ssh[1], repo: stripGitSuffix(ssh[2]) };
+  return undefined;
+};
+
+const encodePath = (specPath: string): string =>
+  specPath
+    .split('/')
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+
+export const buildViewOnRemoteUrl = ({
+  projectRemoteUrl,
+  specPath,
+  headSha,
+  lifecycleState,
+}: ViewOnRemoteInputs): string | undefined => {
+  if (lifecycleState !== 'pushed') return undefined;
+  if (typeof specPath !== 'string' || specPath.trim().length === 0) return undefined;
+  if (typeof headSha !== 'string' || headSha.trim().length === 0) return undefined;
+  const ownerRepo = parseGithubOwnerRepo(projectRemoteUrl);
+  if (!ownerRepo) return undefined;
+  const encoded = encodePath(specPath.trim().replace(/\\/g, '/'));
+  if (encoded.length === 0) return undefined;
+  return `https://github.com/${ownerRepo.owner}/${ownerRepo.repo}/blob/${headSha.trim()}/${encoded}`;
+};

--- a/components/promptlm-web-ui/src/pages/PromptDetail.tsx
+++ b/components/promptlm-web-ui/src/pages/PromptDetail.tsx
@@ -28,9 +28,10 @@ import {
   SpecBlock,
   ToastAction,
 } from '@promptlm/ui';
-import { usePromptDetails } from '@/api/hooks';
+import { useActiveProject, usePromptDetails } from '@/api/hooks';
 import { useGeneratedApiClient } from '@api-common/generatedClientProvider';
 import { mapPromptSpecToDetailViewModel } from '@api-common/viewModels/promptsV2';
+import { buildViewOnRemoteUrl } from '@/features/prompt-editor/buildViewOnRemoteUrl';
 import { featureFlags } from '@/lib/featureFlags';
 import { useToast } from '@/hooks/use-toast';
 import { toDisplayError } from '@api-common/apiError';
@@ -44,9 +45,11 @@ interface TopBarProps {
   editTo: string;
   isRunning: boolean;
   onRun: () => void;
+  /** Client-composed (#188). Renders "View on GitHub" when set; hidden when undefined. */
+  viewOnRemoteUrl?: string;
 }
 
-const TopBar = ({ name, editTo, isRunning, onRun }: TopBarProps) => (
+const TopBar = ({ name, editTo, isRunning, onRun, viewOnRemoteUrl }: TopBarProps) => (
   <header
     style={{
       height: DETAIL_TOPBAR_HEIGHT,
@@ -62,6 +65,32 @@ const TopBar = ({ name, editTo, isRunning, onRun }: TopBarProps) => (
       prompts / <span style={{ color: 'var(--pl-ink-800)' }}>{name}</span>
     </Mono>
     <div style={{ flex: 1 }} />
+    {viewOnRemoteUrl && (
+      <a
+        href={viewOnRemoteUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="prompt-detail-view-on-remote"
+        title="Open this prompt on GitHub"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          height: 32,
+          padding: '0 12px',
+          fontSize: 13,
+          color: 'var(--pl-ink-700)',
+          textDecoration: 'none',
+          border: '1px solid var(--pl-ink-200)',
+          borderRadius: 4,
+          background: 'transparent',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <span aria-hidden="true" style={{ fontFamily: 'var(--pl-mono)', fontSize: 11 }}>↗</span>
+        View on GitHub
+      </a>
+    )}
     <button
       type="button"
       onClick={onRun}
@@ -97,6 +126,7 @@ const TopBar = ({ name, editTo, isRunning, onRun }: TopBarProps) => (
 export default function PromptDetail() {
   const { id } = useParams<{ id: string }>();
   const { data, isLoading, error, refresh } = usePromptDetails(id ?? null);
+  const { activeProject } = useActiveProject();
   const { promptSpecs } = useGeneratedApiClient();
   const { toast } = useToast();
   const [isRunning, setIsRunning] = useState(false);
@@ -233,7 +263,18 @@ export default function PromptDetail() {
         flexDirection: 'column',
       }}
     >
-      <TopBar name={view.name} editTo={editTo} isRunning={isRunning} onRun={handleRun} />
+      <TopBar
+        name={view.name}
+        editTo={editTo}
+        isRunning={isRunning}
+        onRun={handleRun}
+        viewOnRemoteUrl={buildViewOnRemoteUrl({
+          projectRemoteUrl: activeProject?.repositoryUrl,
+          specPath: (data as { path?: string | null } | null | undefined)?.path,
+          headSha: (data as { headShortSha?: string | null } | null | undefined)?.headShortSha,
+          lifecycleState: (data as { lifecycleState?: string | null } | null | undefined)?.lifecycleState,
+        })}
+      />
 
       <PromptDetailHeader
         name={view.name}

--- a/components/ui/src/prompts-v2/form/PromptFormPage.tsx
+++ b/components/ui/src/prompts-v2/form/PromptFormPage.tsx
@@ -316,6 +316,33 @@ const StickyHeader: React.FC<{
       >
         {errors.hasErrors ? <>! {totalErrors} errors</> : '✓ ready to save'}
       </FormMono>
+      {context.viewOnRemoteUrl && (
+        <a
+          href={context.viewOnRemoteUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid="prompt-editor-view-on-remote"
+          title="Open this prompt on GitHub"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 5,
+            height: 28,
+            padding: '0 10px',
+            fontFamily: 'var(--pl-display)',
+            fontSize: 12,
+            color: 'var(--pl-ink-700)',
+            textDecoration: 'none',
+            border: '1px solid var(--pl-ink-200)',
+            borderRadius: 4,
+            background: 'transparent',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <span aria-hidden="true" style={{ fontFamily: 'var(--pl-mono)', fontSize: 11 }}>↗</span>
+          View on GitHub
+        </a>
+      )}
       {onEditorRun && (
         <GhostButton
           onClick={onEditorRun}

--- a/components/ui/src/prompts-v2/form/types.ts
+++ b/components/ui/src/prompts-v2/form/types.ts
@@ -109,6 +109,13 @@ export interface PromptFormContext {
    * "next will bump · {branch}" copy. See issue #184.
    */
   revisionId?: string;
+  /**
+   * Absolute URL to the prompt on its remote (GitHub-only for v1). When set,
+   * the editor topbar renders a "View on GitHub" link; when undefined the
+   * link is hidden. Composed client-side from project + spec inputs — see
+   * `buildViewOnRemoteUrl` in the web-ui app for the gating rules (#188).
+   */
+  viewOnRemoteUrl?: string;
 }
 
 export interface PromptFormErrors {


### PR DESCRIPTION
## Summary
- Adds a **View on GitHub** link in the prompt detail topbar and the editor topbar when the active project's remote is a recognised GitHub URL and the spec is `pushed` (per #189).
- Deep-links to `https://github.com/<owner>/<repo>/blob/<sha>/<path>` — opens in a new tab, `rel="noopener noreferrer"`.
- Hidden (not disabled) when there's no remote, the remote is non-GitHub, or the revision is not pushed.

## Architecture (revised on post-review feedback)

The remote URL is a **project-level concern, not a prompt-spec concern**. It can change when the project is re-pointed at a different host. So the URL is **not** attached to `PromptSpec`. Instead, the client composes it from three inputs it already has:

| Input | Source |
| --- | --- |
| `projectRemoteUrl` | `activeProject.repositoryUrl` from the project store |
| `specPath` | `PromptSpec.path` (already on the boundary) |
| `headSha` | `PromptSpec.headShortSha` (from #184) |
| `lifecycleState` | `PromptSpec.lifecycleState` (from #189) |

Server boundary stays domain-pure: `PromptSpec` only exposes things that belong to the spec itself.

## Implementation notes

- New helper **`buildViewOnRemoteUrl`** (`components/promptlm-web-ui/src/features/prompt-editor/buildViewOnRemoteUrl.ts`) takes the four inputs above and returns a URL or `undefined`. Gating, GitHub URL parsing (HTTPS + SSH + `.git`), and per-segment percent-encoding all live here.
- `PromptFormShell` and `PromptDetail` call the helper with project + spec inputs; the UI package's `PromptFormContext.viewOnRemoteUrl` field stays as a plain string contract.
- **No backend resolver, no `PromptSpec.viewOnRemoteUrl` field, no `withViewOnRemoteUrl` method, no `PromptSpecApiView` resolver collaborator, no `PromptSpecController` resolver wiring.**
- Path-traversal / URL-injection safety preserved: the GitHub regex restricts owner/repo to non-slash/non-whitespace, path segments are `encodeURIComponent`'d, SHA is trimmed.

## What changed vs. the first version of this PR

Removed (server):
- `PromptSpecViewOnRemoteResolver` + its 295-line resolver test.
- `viewOnRemoteUrl` field on `PromptSpec` (`@JsonProperty(READ_ONLY)`, `@JsonInclude(NON_NULL)`) + `getViewOnRemoteUrl` + `withViewOnRemoteUrl`.
- 4th tail parameter (`viewOnRemoteUrl`) on the full-args private constructor.
- `PromptSpecApiView`'s 3-arg `toApiView(spec, deriver, resolver)` overload — collapses back to `toApiView(spec, deriver)`.
- `viewOnRemoteResolver` field + constructor arg on `PromptSpecController`.
- 3 boundary tests (resolver-returns-URL, resolver-returns-null, write-ignores-injected-URL).

Added (server):
- 1 regression test asserting the field is absent from both read responses and write round-trips, so a future regression that re-introduces it would fail loudly.

Removed (client):
- `selectViewOnRemoteUrl.ts` + its 6-test file.

Added (client):
- `buildViewOnRemoteUrl.ts` (composer + gating).
- `buildViewOnRemoteUrl.test.ts` (23 tests — happy paths, SSH/HTTPS/.git variants, percent-encoding, all four gating clauses, malformed input).

## Test plan
- [x] `./mvnw -pl components/promptlm-domain,components/promptlm-web-api test` — 101 pass, 0 failures, 0 errors.
- [x] `npx vitest run buildViewOnRemoteUrl.test.ts` (web-ui) — 23/23 pass. 19 pre-existing module-resolution test-file failures in the local worktree env are unchanged; same suite is green in CI.
- [x] `npm test -w @promptlm/ui` — smoke green.
- [ ] Manual: open a pushed prompt in a GitHub-backed project → both editor and detail topbars show the link; click opens `/blob/<sha>/<path>` in a new tab.
- [ ] Manual: edit and save without releasing → link disappears (lifecycle ≠ pushed).
- [ ] Manual: switch to a project with a GitLab remote → link hidden (helper returns `undefined`).
- [ ] Manual: re-point the project's remote to a non-GitHub host without restarting the app → link disappears on the next render (since composition is client-side).

## Dependencies
- Builds on #189 (lifecycle state) and #184 (headShortSha) — both merged.
- Independent of #191 / #192 / #193.

## Coordination with #193
Both PRs touched `PromptSpec.java`, `PromptSpecApiView.java`, `PromptFormShell.tsx`, `PromptFormPage.tsx`, and `types.ts`. With this refactor, the boundary fields are now strictly disjoint: this PR adds **nothing** to `PromptSpec`; #193's `releaseTag` / `headShortSha` / `revisionId` stand alone.

## Out of scope (per #188)
- Non-GitHub remotes (GitLab / Bitbucket / GitHub Enterprise) — follow-up.
- Linking to historical revisions other than the current one being viewed.
- Tag-based deep links (`/blob/v1.4/...`) — SHA deep links are immutable, which is the v1 contract.

Closes #188 (do not auto-close on merge; user owns closure).

Generated with [Claude Code](https://claude.com/claude-code)
