### PR TITLE
feat(release): expose Release on prompt detail with no-change gating (#186)

### DIFF
--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/ReleaseMetadata.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/ReleaseMetadata.java
@@ -21,6 +21,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Release operation metadata attached under PromptSpec extensions.
+ *
+ * <p>{@code releasedSemanticHash} captures the {@link PromptSpec#computeSemanticHash()}
+ * value at the moment the release reached the {@link #STATE_RELEASED} state.
+ * The UI compares it against the current spec's {@code semanticHash} to decide
+ * whether the Release action is meaningful (see issue #186). The field is
+ * optional — pre-existing release records that were stamped before #186 will
+ * carry {@code null}, and callers must treat that as "unknown baseline" and
+ * keep Release available rather than locking the user out.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ReleaseMetadata(
@@ -31,7 +39,8 @@ public record ReleaseMetadata(
         @JsonProperty("branch") String branch,
         @JsonProperty("prNumber") Integer prNumber,
         @JsonProperty("prUrl") String prUrl,
-        @JsonProperty("existing") Boolean existing) {
+        @JsonProperty("existing") Boolean existing,
+        @JsonProperty("releasedSemanticHash") String releasedSemanticHash) {
 
     public static final String STATE_REQUESTED = "requested";
     public static final String STATE_RELEASED = "released";
@@ -47,11 +56,37 @@ public record ReleaseMetadata(
         }
     }
 
+    /**
+     * Back-compat constructor used by older call-sites that don't carry the
+     * post-#186 released-content hash. Equivalent to passing {@code null} for
+     * {@link #releasedSemanticHash}.
+     */
+    public ReleaseMetadata(
+            String state,
+            String mode,
+            String version,
+            String tag,
+            String branch,
+            Integer prNumber,
+            String prUrl,
+            Boolean existing) {
+        this(state, mode, version, tag, branch, prNumber, prUrl, existing, null);
+    }
+
     public boolean isRequested() {
         return STATE_REQUESTED.equalsIgnoreCase(state);
     }
 
     public boolean isReleased() {
         return STATE_RELEASED.equalsIgnoreCase(state);
+    }
+
+    /**
+     * Returns a copy with {@code releasedSemanticHash} replaced. Used by the
+     * release lifecycle to stamp the content hash at the moment a release
+     * transitions to {@link #STATE_RELEASED} (see #186).
+     */
+    public ReleaseMetadata withReleasedSemanticHash(String hash) {
+        return new ReleaseMetadata(state, mode, version, tag, branch, prNumber, prUrl, existing, hash);
     }
 }

--- a/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/PromptSpecExtensionsTest.java
+++ b/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/PromptSpecExtensionsTest.java
@@ -173,6 +173,89 @@ class PromptSpecExtensionsTest {
     }
 
     @Test
+    void releaseMetadataCarriesReleasedSemanticHashWhenStamped() {
+        // Issue #186: the lifecycle service stamps the released spec's
+        // semantic hash onto the release metadata so the UI can decide whether
+        // there are changes since the last release.
+        ReleaseMetadata metadata = new ReleaseMetadata(
+                ReleaseMetadata.STATE_RELEASED,
+                ReleaseMetadata.MODE_DIRECT,
+                "1.0.0",
+                "prompt-v1.0.0",
+                "main",
+                null,
+                null,
+                false
+        );
+
+        ReleaseMetadata stamped = metadata.withReleasedSemanticHash("deadbeef");
+
+        assertThat(stamped.releasedSemanticHash()).isEqualTo("deadbeef");
+        // Original record is unchanged — records are immutable.
+        assertThat(metadata.releasedSemanticHash()).isNull();
+        // Other fields are preserved.
+        assertThat(stamped.state()).isEqualTo(ReleaseMetadata.STATE_RELEASED);
+        assertThat(stamped.version()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    void releaseMetadataPreservesReleasedSemanticHashAcrossSerialization() throws Exception {
+        ReleaseMetadata stamped = new ReleaseMetadata(
+                ReleaseMetadata.STATE_RELEASED,
+                ReleaseMetadata.MODE_DIRECT,
+                "1.0.0",
+                "prompt-v1.0.0",
+                "main",
+                null,
+                null,
+                false
+        ).withReleasedSemanticHash("aa11bb22");
+
+        PromptSpec spec = PromptSpec.builder()
+                .withGroup("group")
+                .withName("name")
+                .withVersion("1.0.0")
+                .withRevision(1)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder()
+                        .withType(ChatCompletionRequest.TYPE)
+                        .build())
+                .build()
+                .withReleaseMetadata(stamped);
+
+        String serialized = mapper.writeValueAsString(spec);
+        assertThat(serialized).contains("releasedSemanticHash");
+        assertThat(serialized).contains("aa11bb22");
+
+        PromptSpec roundTripped = mapper.readValue(serialized, PromptSpec.class);
+        assertThat(roundTripped.getReleaseMetadata().releasedSemanticHash())
+                .isEqualTo("aa11bb22");
+    }
+
+    @Test
+    void releaseMetadataReleasedSemanticHashOptionalForBackCompat() throws Exception {
+        // Pre-#186 release records carry no hash; deserialization must accept
+        // them (yielding null), and the UI must conservatively treat them as
+        // "release available".
+        String yaml = """
+                name: Sample
+                group: sample
+                version: 1.0
+                extensions:
+                  x-promptlm:
+                    release:
+                      state: released
+                      mode: direct
+                      version: 1.0
+                      tag: sample-v1.0
+                """;
+
+        PromptSpec spec = mapper.readValue(yaml, PromptSpec.class);
+        assertThat(spec.getReleaseMetadata()).isNotNull();
+        assertThat(spec.getReleaseMetadata().releasedSemanticHash()).isNull();
+    }
+
+    @Test
     void rejectsNonExtensionKey() {
         ObjectNode node = mapper.createObjectNode().put("foo", "bar");
         Map<String, JsonNode> extensions = Map.of("custom", node);

--- a/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleService.java
+++ b/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleService.java
@@ -367,6 +367,7 @@ class DefaultPromptLifecycleService implements PromptLifecycleService {
         if (releaseMetadata.isRequested()) {
             eventPublisher.publishEvent(new PromptReleaseRequestedEvent(released));
         } else if (releaseMetadata.isReleased()) {
+            released = stampReleasedSemanticHash(released);
             eventPublisher.publishEvent(new PromptReleasedEvent(released));
         } else {
             throw new PromptReleaseException("Unsupported release state '%s' for prompt %s"
@@ -499,8 +500,37 @@ class DefaultPromptLifecycleService implements PromptLifecycleService {
                     .formatted(promptSpecId));
         }
 
+        released = stampReleasedSemanticHash(released);
         eventPublisher.publishEvent(new PromptReleasedEvent(released));
         return released;
+    }
+
+    /**
+     * Stamps the prompt's current semantic hash onto the existing
+     * {@link ReleaseMetadata} so the UI can compare future revisions against
+     * the released baseline (see issue #186). The store-level
+     * {@code requestRelease} / {@code completeRelease} implementations don't
+     * know about semantic hashing, so we stamp it here at the lifecycle
+     * boundary where {@link PromptSpec#computeSemanticHash()} is available.
+     *
+     * <p>No-op when there is no release metadata, the hash cannot be computed,
+     * or the metadata already carries a {@code releasedSemanticHash} — we
+     * never overwrite an existing baseline because release re-stamping should
+     * not silently change what "no changes since last release" compares to.
+     */
+    private PromptSpec stampReleasedSemanticHash(PromptSpec released) {
+        ReleaseMetadata metadata = released.getReleaseMetadata();
+        if (metadata == null) {
+            return released;
+        }
+        if (metadata.releasedSemanticHash() != null) {
+            return released;
+        }
+        String hash = released.computeSemanticHash();
+        if (hash == null) {
+            return released;
+        }
+        return released.withReleaseMetadata(metadata.withReleasedSemanticHash(hash));
     }
 
     @Override

--- a/components/promptlm-lifecycle/src/test/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleServiceTest.java
+++ b/components/promptlm-lifecycle/src/test/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleServiceTest.java
@@ -520,6 +520,91 @@ class DefaultPromptLifecycleServiceTest {
     }
 
     @Test
+    void releasePromptStampsReleasedSemanticHashOnReleasedSpec() {
+        // Issue #186: when a release transitions to `released`, the lifecycle
+        // service must stamp the released spec's semantic hash onto the
+        // metadata so the UI can compute "no changes since last release".
+        EvaluationResults successResults = new EvaluationResults(List.of(new EvaluationResult("eval", "type", 1.0, null, null)));
+        PromptSpec evaluated = basePromptSpec.withEvaluationResults(successResults);
+        PromptSpec released = evaluated
+                .withVersion("1.0.0")
+                .withReleaseMetadata(new ReleaseMetadata(
+                        ReleaseMetadata.STATE_RELEASED,
+                        ReleaseMetadata.MODE_DIRECT,
+                        "1.0.0",
+                        "group/name-v1.0.0",
+                        "main",
+                        null,
+                        null,
+                        false
+                ));
+
+        when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(evaluated));
+        when(repository.requestRelease(evaluated)).thenReturn(released);
+
+        PromptSpec result = service.releasePrompt(PROMPT_ID);
+
+        // The hash on the returned metadata matches the released spec's hash.
+        ReleaseMetadata metadata = result.getReleaseMetadata();
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.releasedSemanticHash()).isNotNull();
+        assertThat(metadata.releasedSemanticHash()).isEqualTo(released.computeSemanticHash());
+    }
+
+    @Test
+    void releasePromptPreservesExistingReleasedSemanticHash() {
+        // Pre-stamped hash must not be overwritten — the metadata's hash is
+        // the released-content baseline and must remain stable.
+        EvaluationResults successResults = new EvaluationResults(List.of(new EvaluationResult("eval", "type", 1.0, null, null)));
+        PromptSpec evaluated = basePromptSpec.withEvaluationResults(successResults);
+        ReleaseMetadata preStamped = new ReleaseMetadata(
+                ReleaseMetadata.STATE_RELEASED,
+                ReleaseMetadata.MODE_DIRECT,
+                "1.0.0",
+                "group/name-v1.0.0",
+                "main",
+                null,
+                null,
+                false
+        ).withReleasedSemanticHash("preexisting-hash");
+        PromptSpec released = evaluated.withVersion("1.0.0").withReleaseMetadata(preStamped);
+
+        when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(evaluated));
+        when(repository.requestRelease(evaluated)).thenReturn(released);
+
+        PromptSpec result = service.releasePrompt(PROMPT_ID);
+
+        assertThat(result.getReleaseMetadata().releasedSemanticHash()).isEqualTo("preexisting-hash");
+    }
+
+    @Test
+    void releasePromptDoesNotStampHashWhenStateIsRequested() {
+        // PR-two-phase: the release is requested but not yet released. No
+        // baseline exists to stamp until completion lands.
+        EvaluationResults successResults = new EvaluationResults(List.of(new EvaluationResult("eval", "type", 1.0, null, null)));
+        PromptSpec evaluated = basePromptSpec.withEvaluationResults(successResults);
+        PromptSpec requested = evaluated
+                .withVersion("1.0.0")
+                .withReleaseMetadata(new ReleaseMetadata(
+                        ReleaseMetadata.STATE_REQUESTED,
+                        ReleaseMetadata.MODE_PR_TWO_PHASE,
+                        "1.0.0",
+                        "group/name-v1.0.0",
+                        "release/group-name-1.0.0",
+                        7,
+                        "https://github.com/o/r/pull/7",
+                        false
+                ));
+
+        when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(evaluated));
+        when(repository.requestRelease(evaluated)).thenReturn(requested);
+
+        PromptSpec result = service.releasePrompt(PROMPT_ID);
+
+        assertThat(result.getReleaseMetadata().releasedSemanticHash()).isNull();
+    }
+
+    @Test
     void releasePromptRunsPreReleaseGateWhenEnabled() {
         EvaluationResults successResults = new EvaluationResults(List.of(new EvaluationResult("eval", "type", 1.0, null, null)));
         PromptSpec evaluated = basePromptSpec.withEvaluationResults(successResults);

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/selectReleaseAvailability.test.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/selectReleaseAvailability.test.ts
@@ -1,0 +1,109 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+
+import { selectReleaseAvailability } from '../selectReleaseAvailability';
+
+const withRelease = (release: Record<string, unknown> | null, semanticHash?: string | null) => ({
+  semanticHash: semanticHash ?? null,
+  extensions: release === null
+    ? {}
+    : {
+        'x-promptlm': {
+          release,
+        },
+      },
+});
+
+describe('selectReleaseAvailability (#186)', () => {
+  it('returns available with no reason when the spec has no release metadata', () => {
+    const result = selectReleaseAvailability(withRelease(null, 'aaa'));
+
+    expect(result).toEqual({ available: true, reason: null });
+  });
+
+  it('returns available when extensions are absent entirely', () => {
+    expect(selectReleaseAvailability({ semanticHash: 'aaa' })).toEqual({
+      available: true,
+      reason: null,
+    });
+  });
+
+  it('blocks with "Release in progress" while a release is requested', () => {
+    const result = selectReleaseAvailability(
+      withRelease({ state: 'requested', mode: 'pr_two_phase' }, 'aaa'),
+    );
+
+    expect(result).toEqual({ available: false, reason: 'Release in progress' });
+  });
+
+  it('blocks with "No changes since last release" when hashes match', () => {
+    const result = selectReleaseAvailability(
+      withRelease(
+        { state: 'released', mode: 'direct', releasedSemanticHash: 'bbb' },
+        'bbb',
+      ),
+    );
+
+    expect(result).toEqual({
+      available: false,
+      reason: 'No changes since last release',
+    });
+  });
+
+  it('returns available when current hash differs from the released hash', () => {
+    const result = selectReleaseAvailability(
+      withRelease(
+        { state: 'released', mode: 'direct', releasedSemanticHash: 'bbb' },
+        'ccc',
+      ),
+    );
+
+    expect(result).toEqual({ available: true, reason: null });
+  });
+
+  it('falls through to available when the released-hash baseline is missing (pre-#186)', () => {
+    const result = selectReleaseAvailability(
+      withRelease({ state: 'released', mode: 'direct' }, 'ccc'),
+    );
+
+    expect(result).toEqual({ available: true, reason: null });
+  });
+
+  it('falls through to available when the current semantic hash is missing', () => {
+    const result = selectReleaseAvailability(
+      withRelease(
+        { state: 'released', mode: 'direct', releasedSemanticHash: 'bbb' },
+        null,
+      ),
+    );
+
+    expect(result).toEqual({ available: true, reason: null });
+  });
+
+  it('is defensive against non-object inputs', () => {
+    expect(selectReleaseAvailability(null)).toEqual({ available: true, reason: null });
+    expect(selectReleaseAvailability(undefined)).toEqual({ available: true, reason: null });
+    expect(selectReleaseAvailability('not-a-spec')).toEqual({ available: true, reason: null });
+  });
+
+  it('is defensive against unknown release states', () => {
+    const result = selectReleaseAvailability(
+      withRelease({ state: 'something-weird', mode: 'direct' }, 'aaa'),
+    );
+
+    expect(result).toEqual({ available: true, reason: null });
+  });
+});

--- a/components/promptlm-web-ui/src/features/prompt-editor/selectReleaseAvailability.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/selectReleaseAvailability.ts
@@ -1,0 +1,110 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Selector that decides whether the **Release** action should be enabled for a
+ * prompt detail view, and — when not — surfaces a human-readable reason.
+ *
+ * Implements the gating logic for issue #186 ("Rework the release in UI"):
+ *
+ * - Never released (no `extensions['x-promptlm'].release` entry, or only a
+ *   pending request that has not yet reached `released`) → **available**.
+ * - Already-requested PR-mode release → **not available**, reason "Release in
+ *   progress" (avoids double-triggering).
+ * - Previously released, and the current spec's `semanticHash` matches the
+ *   `releasedSemanticHash` recorded at the moment of release → **not
+ *   available**, reason "No changes since last release".
+ * - Previously released but the hashes differ (or the released hash is absent
+ *   on pre-#186 records) → **available**.
+ *
+ * The selector is deliberately defensive: the OpenAPI-generated
+ * {@code PromptSpec} type does not yet model `releasedSemanticHash`, so we
+ * inspect `extensions` via a narrow {@link unknown}-typed read rather than
+ * relying on a typed surface that may regenerate later. This keeps the call
+ * site stable across regenerations.
+ */
+
+export interface ReleaseAvailability {
+  /** `true` when the Release CTA should be enabled. */
+  available: boolean;
+  /**
+   * Human-readable reason to surface in a tooltip when {@link available} is
+   * `false`. `null` when `available` is `true` (no reason to display).
+   */
+  reason: string | null;
+}
+
+const AVAILABLE: ReleaseAvailability = { available: true, reason: null };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const readRelease = (spec: unknown): Record<string, unknown> | null => {
+  if (!isRecord(spec)) return null;
+  const extensions = spec.extensions;
+  if (!isRecord(extensions)) return null;
+  const promptlm = extensions['x-promptlm'];
+  if (!isRecord(promptlm)) return null;
+  const release = promptlm.release;
+  return isRecord(release) ? release : null;
+};
+
+const readString = (value: unknown): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null;
+
+/**
+ * Compute the {@link ReleaseAvailability} for the given prompt spec.
+ *
+ * Returns a default of `{ available: true, reason: null }` whenever the spec
+ * shape doesn't carry enough info — the server's `POST /release` endpoint is
+ * the authoritative gate and will reject invalid attempts, so the UI choosing
+ * "available" on missing data only ever causes a non-destructive nuisance
+ * click rather than locking users out.
+ */
+export const selectReleaseAvailability = (spec: unknown): ReleaseAvailability => {
+  const release = readRelease(spec);
+  if (release === null) {
+    // Never released — Release is meaningful.
+    return AVAILABLE;
+  }
+
+  const state = readString(release.state);
+  if (state === 'requested') {
+    return { available: false, reason: 'Release in progress' };
+  }
+
+  if (state !== 'released') {
+    // Unknown state — be conservative and let the user try; the server will
+    // reject if it shouldn't proceed.
+    return AVAILABLE;
+  }
+
+  const releasedHash = readString(release.releasedSemanticHash);
+  if (releasedHash === null) {
+    // Pre-#186 release record without a baseline hash. We can't tell whether
+    // the spec has changed — fall through to "available".
+    return AVAILABLE;
+  }
+
+  const currentHash = isRecord(spec) ? readString(spec.semanticHash) : null;
+  if (currentHash === null) {
+    // Current hash unavailable — be conservative.
+    return AVAILABLE;
+  }
+
+  if (currentHash === releasedHash) {
+    return { available: false, reason: 'No changes since last release' };
+  }
+  return AVAILABLE;
+};

--- a/components/promptlm-web-ui/src/pages/PromptDetail.tsx
+++ b/components/promptlm-web-ui/src/pages/PromptDetail.tsx
@@ -32,6 +32,7 @@ import { useActiveProject, usePromptDetails } from '@/api/hooks';
 import { useGeneratedApiClient } from '@api-common/generatedClientProvider';
 import { mapPromptSpecToDetailViewModel } from '@api-common/viewModels/promptsV2';
 import { buildViewOnRemoteUrl } from '@/features/prompt-editor/buildViewOnRemoteUrl';
+import { selectReleaseAvailability } from '@/features/prompt-editor/selectReleaseAvailability';
 import { featureFlags } from '@/lib/featureFlags';
 import { useToast } from '@/hooks/use-toast';
 import { toDisplayError } from '@api-common/apiError';
@@ -47,9 +48,24 @@ interface TopBarProps {
   onRun: () => void;
   /** Client-composed (#188). Renders "View on GitHub" when set; hidden when undefined. */
   viewOnRemoteUrl?: string;
+  /** Release CTA — issue #186. Hidden when `onRelease` is undefined. */
+  onRelease?: () => void;
+  isReleasing?: boolean;
+  releaseAvailable?: boolean;
+  releaseDisabledReason?: string | null;
 }
 
-const TopBar = ({ name, editTo, isRunning, onRun, viewOnRemoteUrl }: TopBarProps) => (
+const TopBar = ({
+  name,
+  editTo,
+  isRunning,
+  onRun,
+  viewOnRemoteUrl,
+  onRelease,
+  isReleasing = false,
+  releaseAvailable = false,
+  releaseDisabledReason = null,
+}: TopBarProps) => (
   <header
     style={{
       height: DETAIL_TOPBAR_HEIGHT,
@@ -107,6 +123,32 @@ const TopBar = ({ name, editTo, isRunning, onRun, viewOnRemoteUrl }: TopBarProps
       <span style={{ fontFamily: 'var(--pl-mono)', fontSize: 11, marginRight: 6 }}>▷</span>
       {isRunning ? 'Running…' : 'Run'}
     </button>
+    {onRelease && (
+      // Issue #186: Release moves out of edit view. Wrapped in a span so the
+      // tooltip surfaces even when the button is disabled (disabled buttons
+      // do not fire pointer events in some browsers).
+      <span
+        title={!releaseAvailable && releaseDisabledReason ? releaseDisabledReason : undefined}
+        style={{ display: 'inline-flex' }}
+      >
+        <button
+          type="button"
+          onClick={onRelease}
+          disabled={!releaseAvailable || isReleasing}
+          className="pl-btn pl-btn-ghost"
+          data-testid="prompt-detail-release-action"
+          aria-disabled={!releaseAvailable || isReleasing}
+          style={{
+            height: 32,
+            padding: '0 14px',
+            fontSize: 13,
+            cursor: !releaseAvailable || isReleasing ? 'not-allowed' : 'pointer',
+          }}
+        >
+          {isReleasing ? 'Releasing…' : 'Release'}
+        </button>
+      </span>
+    )}
     <Link
       to={editTo}
       className="pl-btn pl-btn-primary"
@@ -130,9 +172,14 @@ export default function PromptDetail() {
   const { promptSpecs } = useGeneratedApiClient();
   const { toast } = useToast();
   const [isRunning, setIsRunning] = useState(false);
+  const [isReleasing, setIsReleasing] = useState(false);
   const [highlightedExecutionId, setHighlightedExecutionId] = useState<string | null>(null);
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const view = useMemo(() => (data ? mapPromptSpecToDetailViewModel(data) : null), [data]);
+  // Issue #186: derive Release availability from the spec's release metadata.
+  // The selector is a pure function of the spec — memoizing on `data` keeps
+  // re-renders cheap.
+  const releaseAvailability = useMemo(() => selectReleaseAvailability(data), [data]);
 
   useEffect(() => {
     return () => {
@@ -208,6 +255,39 @@ export default function PromptDetail() {
     }
   }, [focusExecution, id, isRunning, promptSpecs, refresh, toast]);
 
+  /**
+   * Detail-page Release CTA — issue #186.
+   *
+   * Moves the Release action out of the edit view. The Run/Save lifecycle
+   * elsewhere stays unchanged; here we simply call the same `releasePrompt`
+   * endpoint that the edit-view Release rail already uses, then refresh the
+   * detail so the next render reflects the new release metadata (and the
+   * button correctly disables itself with "No changes since last release").
+   */
+  const handleRelease = useCallback(async () => {
+    if (!id || isReleasing || !releaseAvailability.available) {
+      return;
+    }
+    setIsReleasing(true);
+    try {
+      await promptSpecs.releasePrompt(id);
+      await refresh();
+      toast({
+        title: 'Release requested',
+        description: 'The prompt has been released.',
+      });
+    } catch (err) {
+      const display = toDisplayError(err);
+      toast({
+        variant: 'destructive',
+        title: 'Release failed',
+        description: display.message,
+      });
+    } finally {
+      setIsReleasing(false);
+    }
+  }, [id, isReleasing, promptSpecs, refresh, releaseAvailability.available, toast]);
+
   if (!id) {
     return (
       <div style={{ padding: 32, color: 'var(--pl-ink-700)' }}>Missing prompt id.</div>
@@ -274,6 +354,10 @@ export default function PromptDetail() {
           headSha: (data as { headShortSha?: string | null } | null | undefined)?.headShortSha,
           lifecycleState: (data as { lifecycleState?: string | null } | null | undefined)?.lifecycleState,
         })}
+        onRelease={handleRelease}
+        isReleasing={isReleasing}
+        releaseAvailable={releaseAvailability.available}
+        releaseDisabledReason={releaseAvailability.reason}
       />
 
       <PromptDetailHeader

--- a/components/promptlm-web-ui/src/pages/__tests__/PromptDetail.release.test.tsx
+++ b/components/promptlm-web-ui/src/pages/__tests__/PromptDetail.release.test.tsx
@@ -1,0 +1,191 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Tests for the Release CTA on the prompt detail page (issue #186).
+ *
+ * Asserts the HTML markup directly via `renderToString` — same pattern as the
+ * Dashboard test in this directory — so the suite has no DOM dependency and
+ * runs anywhere vitest does. Behavior we care about:
+ *
+ * - Release button exists in the detail-page topbar.
+ * - Button is disabled and surfaces "No changes since last release" when the
+ *   current revision matches the latest released revision.
+ * - Button is enabled for a prompt that has never been released.
+ */
+
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import type { PromptSpec } from '@promptlm/api-client';
+
+const mocks = vi.hoisted(() => ({
+  usePromptDetailsMock: vi.fn(),
+  useActiveProjectMock: vi.fn(),
+  useGeneratedApiClientMock: vi.fn(),
+  useToastMock: vi.fn(),
+  useParamsMock: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: mocks.useParamsMock,
+  Link: ({ children, to, ...rest }: { children: React.ReactNode; to: string } & Record<string, unknown>) =>
+    React.createElement('a', { href: to, ...rest }, children),
+}));
+
+vi.mock('@/api/hooks', () => ({
+  usePromptDetails: mocks.usePromptDetailsMock,
+  useActiveProject: mocks.useActiveProjectMock,
+}));
+
+vi.mock('@api-common/generatedClientProvider', () => ({
+  useGeneratedApiClient: mocks.useGeneratedApiClientMock,
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: mocks.useToastMock,
+}));
+
+const baseSpec = (overrides: Partial<PromptSpec> = {}): PromptSpec =>
+  ({
+    id: 'group/sample',
+    uuid: 'uuid-1',
+    name: 'sample',
+    group: 'group',
+    version: '1.0.0',
+    revision: 1,
+    description: 'A sample prompt',
+    status: 'ACTIVE',
+    request: {
+      type: 'chat/completion',
+      vendor: 'openai',
+      model: 'gpt-4o',
+      messages: [],
+    },
+    placeholders: { list: [] },
+    executions: [],
+    ...overrides,
+  } as unknown as PromptSpec);
+
+import PromptDetail from '../PromptDetail';
+
+const renderPage = () => renderToString(<PromptDetail />);
+
+describe('PromptDetail Release button (#186)', () => {
+  afterEach(() => {
+    mocks.usePromptDetailsMock.mockReset();
+    mocks.useActiveProjectMock.mockReset();
+    mocks.useGeneratedApiClientMock.mockReset();
+    mocks.useToastMock.mockReset();
+    mocks.useParamsMock.mockReset();
+  });
+
+  const mountWithSpec = (spec: PromptSpec) => {
+    mocks.useParamsMock.mockReturnValue({ id: spec.id });
+    mocks.usePromptDetailsMock.mockReturnValue({
+      data: spec,
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+    mocks.useActiveProjectMock.mockReturnValue({ activeProject: null });
+    mocks.useGeneratedApiClientMock.mockReturnValue({
+      promptSpecs: {
+        executeStoredPrompt: vi.fn(),
+        releasePrompt: vi.fn(),
+      },
+    });
+    mocks.useToastMock.mockReturnValue({ toast: vi.fn() });
+  };
+
+  it('renders the Release button on the detail topbar (AC-1)', () => {
+    mountWithSpec(baseSpec());
+
+    const html = renderPage();
+
+    expect(html).toContain('data-testid="prompt-detail-release-action"');
+    expect(html).toContain('Release');
+  });
+
+  it('enables Release for a prompt that has never been released (AC-3)', () => {
+    mountWithSpec(baseSpec());
+
+    const html = renderPage();
+
+    // No `disabled` attribute on the action button.
+    const buttonMatch = html.match(
+      /<button[^>]*data-testid="prompt-detail-release-action"[^>]*>/,
+    );
+    expect(buttonMatch).not.toBeNull();
+    expect(buttonMatch![0]).not.toContain('disabled=""');
+    // No tooltip on the wrapping span.
+    expect(html).not.toContain('No changes since last release');
+  });
+
+  it('disables Release with the canonical tooltip when hashes match (AC-2 + AC-4)', () => {
+    mountWithSpec(
+      baseSpec({
+        semanticHash: 'matching-hash',
+        extensions: {
+          'x-promptlm': {
+            release: {
+              state: 'released',
+              mode: 'direct',
+              version: '1.0.0',
+              releasedSemanticHash: 'matching-hash',
+            },
+          },
+        } as unknown as PromptSpec['extensions'],
+      }),
+    );
+
+    const html = renderPage();
+
+    // Wrapping span surfaces the disabled tooltip.
+    expect(html).toContain('title="No changes since last release"');
+    // The button is rendered as disabled.
+    const buttonMatch = html.match(
+      /<button[^>]*data-testid="prompt-detail-release-action"[^>]*>/,
+    );
+    expect(buttonMatch).not.toBeNull();
+    expect(buttonMatch![0]).toContain('disabled=""');
+  });
+
+  it('enables Release when current revision differs from the released hash (AC-3)', () => {
+    mountWithSpec(
+      baseSpec({
+        semanticHash: 'new-hash',
+        extensions: {
+          'x-promptlm': {
+            release: {
+              state: 'released',
+              mode: 'direct',
+              version: '1.0.0',
+              releasedSemanticHash: 'old-released-hash',
+            },
+          },
+        } as unknown as PromptSpec['extensions'],
+      }),
+    );
+
+    const html = renderPage();
+
+    const buttonMatch = html.match(
+      /<button[^>]*data-testid="prompt-detail-release-action"[^>]*>/,
+    );
+    expect(buttonMatch).not.toBeNull();
+    expect(buttonMatch![0]).not.toContain('disabled=""');
+    expect(html).not.toContain('No changes since last release');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **Release** button to the prompt detail topbar so users can release any persisted revision without entering edit mode (issue #186).
- Disables the button with the tooltip "No changes since last release" when the current revision matches the latest released revision.
- Stamps a `releasedSemanticHash` baseline onto `ReleaseMetadata` at release time so the gate is computable without re-reading historical revisions.
- Save stays on the edit view, unchanged.

## Issue
Closes part of #186 (detail-page Release CTA + gating). Follow-up to remove the in-form Release CTA is recorded below; deferred because PRs #191 and #193 actively edit `PromptFormPage.tsx`.

## Architecture notes
Server-side stamping, client-side gating:

1. `DefaultPromptLifecycleService` writes `releasedSemanticHash` onto `ReleaseMetadata` whenever a release transitions to `released`. Idempotent — never overwrites an existing baseline.
2. The frontend reads `extensions['x-promptlm'].release.releasedSemanticHash` via a defensive `selectReleaseAvailability` selector and compares it against the spec's `semanticHash`. Falls through to "available" on missing fields / unknown states — the server's `POST /release` is the authoritative gate.
3. New `data-testid=prompt-detail-release-action`; distinct from the edit-view's existing `prompt-release-action` / `prompt-editor-release-action`.

## Coordination with open sibling PRs
Branch rebased onto current `main` (which now includes #191, #192, #193). Diff is a clean additive change (8 files, +730/-3) with no overlap with the merged sibling PRs.
- PR #191 (`feat/183-run-uses-form-state`) — merged into main; no conflict after rebase.
- PR #192 (`feat/185-dirty-indicator-and-nav-guard`) — merged into main; no conflict.
- PR #193 (`feat/184-topbar-revision-id`) — merged into main; no conflict.
- PR #194 (`feat/188-view-on-remote-link`) — still open. Conflict surface is contained: this PR adds a new conditional `<button>` (Release) with its own `data-testid` and a separate `onRelease` prop on `PromptDetail`'s `TopBar`; merge resolution is mechanical.

## Test plan
- [x] `./mvnw -pl components/promptlm-domain test` → **55 passed** (incl. tests covering the `releasedSemanticHash` record + serialization round-trip + back-compat).
- [x] `./mvnw -pl components/promptlm-lifecycle -am test` → **77 passed** (incl. tests covering stamping at release / preserve-existing / no-stamp-on-requested).
- [x] `./mvnw -pl components/promptlm-web-api -am test` → **100 passed**.
- [x] `./mvnw -pl components/promptlm-store/promptlm-store-github -am test` → green.
- [x] `npm test -w @promptlm/web-ui` → **152 passed across 28 files** (incl. 9 selector tests + 4 detail-page tests).
- [x] `npm test -w @promptlm/ui` → UI package smoke checks passed.
- [ ] Playwright smoke for click-Release-then-disabled (recommended follow-up — manual verification deferred).

## Acceptance criteria
- [x] AC-1 Release button on prompt detail view — `PromptDetail.release.test.tsx`.
- [x] AC-2 Disabled when current revision == latest release — selector test + detail-page test (disabled attribute + tooltip).
- [x] AC-3 Enabled when never released OR differs from latest — two selector branches + two detail-page tests.
- [x] AC-4 Tooltip "No changes since last release" — exact-string assertion.
- [x] AC-5 Save stays on edit view — no edit-view files modified.

## Follow-ups
- Remove the edit-view Release CTA in `PromptFormPage.tsx` / `ReleaseRail.tsx` (sibling PRs #191/#193 have landed; this cleanup can now proceed).
- Optional: backfill `releasedSemanticHash` for pre-#186 release records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
