### PR TITLE
refactor(api): return PromptSpecResponseDto from toApiView, keep domain pure

### DIFF
--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpec.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpec.java
@@ -162,49 +162,6 @@ public class PromptSpec {
     @Schema(description = "Stable hash across semantic prompt fields")
     private final String semanticHash;
 
-    /**
-     * Derived lifecycle state of the spec. Server-derived only; never accepted
-     * from clients on writes. See {@link PromptSpecLifecycleState}.
-     */
-    @JsonProperty("lifecycleState")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Schema(description = "Server-derived lifecycle state of the spec. Omitted when the backend cannot derive it (e.g. no active project).",
-            implementation = PromptSpecLifecycleState.class,
-            nullable = true,
-            accessMode = Schema.AccessMode.READ_ONLY)
-    private final PromptSpecLifecycleState lifecycleState;
-
-    /**
-     * Short SHA (7 chars) of the Git commit that currently carries the spec
-     * content. Server-derived only; never accepted from clients on writes.
-     * Empty when the spec is not yet committed or when the active project has
-     * no Git context.
-     *
-     * <p>Surfaces to the UI as the fallback revision identifier when no
-     * release tag is present (see issue #184).
-     */
-    @JsonProperty("headShortSha")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Schema(description = "Server-derived Git short SHA (7 chars) of HEAD when the working tree matches a commit. Omitted otherwise.",
-            nullable = true,
-            accessMode = Schema.AccessMode.READ_ONLY,
-            example = "a1b2c3d")
-    private final String headShortSha;
-
-    /**
-     * Flat-field projection of the release tag stored under the
-     * {@code x-release} extension. Server-derived only; never accepted from
-     * clients on writes. The UI uses this as the preferred revision
-     * identifier in the editor topbar (see issue #184).
-     */
-    @JsonProperty("releaseTag")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Schema(description = "Server-derived release tag for the current revision. Omitted when the spec has not been released.",
-            nullable = true,
-            accessMode = Schema.AccessMode.READ_ONLY,
-            example = "v1.4")
-    private final String releaseTag;
-
     public String getRepositoryUrl() {
         return repositoryUrl;
     }
@@ -308,71 +265,6 @@ public class PromptSpec {
             @JsonProperty("path") Path path,
             @JsonProperty("executions") List<Execution> executions,
             @JsonProperty("semanticHash") String semanticHash) {
-        this(
-                specVersion,
-                uuid,
-                id,
-                name,
-                group,
-                version,
-                revision,
-                description,
-                authors,
-                purpose,
-                repositoryUrl,
-                status,
-                createdAt,
-                updatedAt,
-                retiredAt,
-                retiredReason,
-                request,
-                placeholders,
-                response,
-                extensions,
-                path,
-                executions,
-                semanticHash,
-                null,
-                null,
-                null
-        );
-    }
-
-    /**
-     * Full-args constructor including the derived {@link #lifecycleState},
-     * {@link #headShortSha}, and {@link #releaseTag}. These boundary-only
-     * parameters are intentionally <em>not</em> part of the {@code @JsonCreator}
-     * signature — the API derives the values at the boundary (see
-     * {@code PromptSpecLifecycleDeriver}) and any incoming JSON value is
-     * silently ignored on deserialization.
-     */
-    private PromptSpec(
-            String specVersion,
-            UUID uuid,
-            String id,
-            String name,
-            String group,
-            String version,
-            Integer revision,
-            String description,
-            List<String> authors,
-            String purpose,
-            String repositoryUrl,
-            PromptStatus status,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            LocalDateTime retiredAt,
-            String retiredReason,
-            Request request,
-            Placeholders placeholders,
-            Response response,
-            Map<String, JsonNode> extensions,
-            Path path,
-            List<Execution> executions,
-            String semanticHash,
-            PromptSpecLifecycleState lifecycleState,
-            String headShortSha,
-            String releaseTag) {
 
         this.specVersion = specVersion;
         this.uuid = uuid;
@@ -397,9 +289,6 @@ public class PromptSpec {
         this.path = path;
         this.executions = executions;
         this.semanticHash = semanticHash;
-        this.lifecycleState = lifecycleState;
-        this.headShortSha = headShortSha;
-        this.releaseTag = releaseTag;
     }
 
     public PromptSpec(
@@ -572,124 +461,6 @@ public class PromptSpec {
 
     public PromptSpec withSemanticHash(String semanticHash) {
         return Objects.equals(this.semanticHash, semanticHash) ? this : new PromptSpec(this.specVersion, this.uuid, this.id, this.name, this.group, this.version, this.revision, this.description, this.authors, this.purpose, this.repositoryUrl, this.status, this.createdAt, this.updatedAt, this.retiredAt, this.retiredReason, this.request, this.placeholders, this.response, this.extensions, this.path, this.executions, semanticHash);
-    }
-
-    /**
-     * Returns a copy with the given lifecycle state. Intended for use at the
-     * API boundary only — never set on objects that are about to be persisted
-     * to disk, because the field is {@code @JsonInclude(NON_NULL)} and would
-     * pollute the on-disk YAML if non-null.
-     */
-    public PromptSpec withLifecycleState(PromptSpecLifecycleState lifecycleState) {
-        return this.lifecycleState == lifecycleState ? this : new PromptSpec(
-                this.specVersion,
-                this.uuid,
-                this.id,
-                this.name,
-                this.group,
-                this.version,
-                this.revision,
-                this.description,
-                this.authors,
-                this.purpose,
-                this.repositoryUrl,
-                this.status,
-                this.createdAt,
-                this.updatedAt,
-                this.retiredAt,
-                this.retiredReason,
-                this.request,
-                this.placeholders,
-                this.response,
-                this.extensions,
-                this.path,
-                this.executions,
-                this.semanticHash,
-                lifecycleState,
-                this.headShortSha,
-                this.releaseTag);
-    }
-
-    /**
-     * Returns a copy with the given Git short SHA attached. Intended for use
-     * at the API boundary only — see {@link #withLifecycleState} for the same
-     * "never persist this to disk" warning.
-     */
-    public PromptSpec withHeadShortSha(String headShortSha) {
-        return Objects.equals(this.headShortSha, headShortSha) ? this : new PromptSpec(
-                this.specVersion,
-                this.uuid,
-                this.id,
-                this.name,
-                this.group,
-                this.version,
-                this.revision,
-                this.description,
-                this.authors,
-                this.purpose,
-                this.repositoryUrl,
-                this.status,
-                this.createdAt,
-                this.updatedAt,
-                this.retiredAt,
-                this.retiredReason,
-                this.request,
-                this.placeholders,
-                this.response,
-                this.extensions,
-                this.path,
-                this.executions,
-                this.semanticHash,
-                this.lifecycleState,
-                headShortSha,
-                this.releaseTag);
-    }
-
-    /**
-     * Returns a copy with the given release tag attached. Intended for use at
-     * the API boundary only — see {@link #withLifecycleState} for the same
-     * "never persist this to disk" warning.
-     */
-    public PromptSpec withReleaseTag(String releaseTag) {
-        return Objects.equals(this.releaseTag, releaseTag) ? this : new PromptSpec(
-                this.specVersion,
-                this.uuid,
-                this.id,
-                this.name,
-                this.group,
-                this.version,
-                this.revision,
-                this.description,
-                this.authors,
-                this.purpose,
-                this.repositoryUrl,
-                this.status,
-                this.createdAt,
-                this.updatedAt,
-                this.retiredAt,
-                this.retiredReason,
-                this.request,
-                this.placeholders,
-                this.response,
-                this.extensions,
-                this.path,
-                this.executions,
-                this.semanticHash,
-                this.lifecycleState,
-                this.headShortSha,
-                releaseTag);
-    }
-
-    public PromptSpecLifecycleState getLifecycleState() {
-        return lifecycleState;
-    }
-
-    public String getHeadShortSha() {
-        return headShortSha;
-    }
-
-    public String getReleaseTag() {
-        return releaseTag;
     }
 
     @JsonIgnore

--- a/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/PromptSpecEqualityTests.java
+++ b/components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/PromptSpecEqualityTests.java
@@ -74,18 +74,4 @@ class PromptSpecEqualityTests {
         assertNotEquals(spec1, spec2);
     }
 
-    @Test
-    void lifecycleStateIsExcludedFromEqualityBecauseItIsDerived() {
-        // Lifecycle state is a derived view, not part of identity. Two specs
-        // that differ only in lifecycle state must remain equal so that
-        // dedup / cache lookups by identity continue to work.
-        PromptSpec base = createPromptSpec("id", "name", "group1", "1", 1);
-        PromptSpec saved = base.withLifecycleState(PromptSpecLifecycleState.SAVED);
-        PromptSpec pushed = base.withLifecycleState(PromptSpecLifecycleState.PUSHED);
-
-        assertEquals(base, saved);
-        assertEquals(saved, pushed);
-        assertEquals(base.hashCode(), saved.hashCode());
-        assertEquals(saved.hashCode(), pushed.hashCode());
-    }
 }

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecApiView.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecApiView.java
@@ -18,6 +18,7 @@ package dev.promptlm.web;
 
 import dev.promptlm.domain.promptspec.Execution;
 import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.PromptSpecLifecycleState;
 import dev.promptlm.domain.promptspec.ReleaseMetadata;
 
 import java.time.Instant;
@@ -26,12 +27,18 @@ import java.util.Comparator;
 import java.util.List;
 
 /**
- * API-boundary view of {@link PromptSpec}. The domain object stays order-agnostic for
- * {@code executions[]}; this helper presents them newest-first when the spec is
- * returned to HTTP callers, matching the {@link RepoHistoryAssembler} contract.
+ * API-boundary assembler that turns a domain {@link PromptSpec} into the
+ * dedicated {@link PromptSpecResponseDto} returned by the HTTP controllers.
  *
- * <p>Apply at every controller return path that surfaces a {@link PromptSpec} so the
- * frontend can rely on {@code executions[0]} being the most recent run.
+ * <p>The DTO holds the server-derived UI hints (lifecycle state, HEAD short
+ * SHA, release tag) that used to be stamped onto {@link PromptSpec} via
+ * withers. Keeping them on the DTO means the domain type stays free of
+ * API-only fields while the JSON wire format consumed by the frontend stays
+ * byte-identical.
+ *
+ * <p>Apply at every controller return path that surfaces a {@link PromptSpec}
+ * so the frontend can rely on {@code executions[0]} being the most recent
+ * run and on the boundary hints being present when derivable.
  */
 final class PromptSpecApiView {
 
@@ -41,35 +48,44 @@ final class PromptSpecApiView {
     private PromptSpecApiView() {
     }
 
-    static PromptSpec toApiView(PromptSpec spec) {
+    static PromptSpecResponseDto toApiView(PromptSpec spec) {
         return toApiView(spec, null);
     }
 
     /**
      * Returns the spec mapped for HTTP output (executions newest-first) with
-     * an optional derived lifecycle state attached. Pass {@code null} for
-     * {@code deriver} when the caller has no lifecycle context (e.g. internal
-     * mappings or tests of unrelated code paths) — the field is then omitted
-     * from the JSON response.
+     * the derived lifecycle state, HEAD short SHA, and release tag attached
+     * to the DTO. Pass {@code null} for {@code deriver} when the caller has
+     * no lifecycle context (e.g. internal mappings or tests of unrelated
+     * code paths) — the lifecycle and SHA fields are then omitted from JSON.
      */
-    static PromptSpec toApiView(PromptSpec spec, PromptSpecLifecycleDeriver deriver) {
+    static PromptSpecResponseDto toApiView(PromptSpec spec, PromptSpecLifecycleDeriver deriver) {
         if (spec == null) {
             return null;
         }
-        PromptSpec withExecutions = sortExecutionsNewestFirst(spec);
-        PromptSpec withRevision = withRevisionMetadata(withExecutions, deriver);
-        return withReleaseTagAttached(withRevision);
+        PromptSpec sorted = sortExecutionsNewestFirst(spec);
+        PromptSpecLifecycleState lifecycleState = null;
+        String headShortSha = null;
+        if (deriver != null) {
+            PromptSpecLifecycleDeriver.Result result = deriver.deriveResult(sorted);
+            if (result != null) {
+                lifecycleState = result.state();
+                headShortSha = result.headShortSha();
+            }
+        }
+        String releaseTag = releaseTagOrNull(sorted);
+        return new PromptSpecResponseDto(sorted, lifecycleState, headShortSha, releaseTag);
     }
 
-    static List<PromptSpec> toApiView(List<PromptSpec> specs) {
+    static List<PromptSpecResponseDto> toApiView(List<PromptSpec> specs) {
         return toApiView(specs, null);
     }
 
-    static List<PromptSpec> toApiView(List<PromptSpec> specs, PromptSpecLifecycleDeriver deriver) {
+    static List<PromptSpecResponseDto> toApiView(List<PromptSpec> specs, PromptSpecLifecycleDeriver deriver) {
         if (specs == null) {
             return null;
         }
-        List<PromptSpec> mapped = new ArrayList<>(specs.size());
+        List<PromptSpecResponseDto> mapped = new ArrayList<>(specs.size());
         for (PromptSpec spec : specs) {
             mapped.add(toApiView(spec, deriver));
         }
@@ -86,37 +102,16 @@ final class PromptSpecApiView {
         return spec.withExecutions(sorted);
     }
 
-    private static PromptSpec withRevisionMetadata(PromptSpec spec, PromptSpecLifecycleDeriver deriver) {
-        if (deriver == null) {
-            return spec;
-        }
-        PromptSpecLifecycleDeriver.Result result = deriver.deriveResult(spec);
-        if (result == null) {
-            return spec;
-        }
-        PromptSpec updated = spec;
-        if (result.state() != null) {
-            updated = updated.withLifecycleState(result.state());
-        }
-        if (result.headShortSha() != null) {
-            updated = updated.withHeadShortSha(result.headShortSha());
-        }
-        return updated;
-    }
-
-    private static PromptSpec withReleaseTagAttached(PromptSpec spec) {
-        if (spec == null) {
-            return null;
-        }
+    private static String releaseTagOrNull(PromptSpec spec) {
         ReleaseMetadata release = spec.getReleaseMetadata();
         if (release == null) {
-            return spec;
+            return null;
         }
         String tag = release.tag();
         if (tag == null || tag.isBlank()) {
-            return spec;
+            return null;
         }
-        return spec.withReleaseTag(tag);
+        return tag;
     }
 
     private static Instant timestampOrEpoch(Execution execution) {

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
@@ -103,7 +103,7 @@ public class PromptSpecController {
         @ApiResponse(responseCode = "404", description = "Prompt specification not found")
     })
     @GetMapping(path = "/{promptSpecId}")
-    public ResponseEntity<PromptSpec> getById(
+    public ResponseEntity<PromptSpecResponseDto> getById(
             @Parameter(description = "Unique identifier of the prompt specification")
             @PathVariable(name = "promptSpecId") String promptSpecId) {
         Optional<PromptSpec> latestVersion = promptStore.getLatestVersion(promptSpecId);
@@ -120,7 +120,7 @@ public class PromptSpecController {
                 content = @Content(mediaType = "application/json",
                         array = @ArraySchema(schema = @Schema(implementation = PromptSpec.class))))
     @GetMapping
-    public ResponseEntity<List<PromptSpec>> listPromptSpecs() {
+    public ResponseEntity<List<PromptSpecResponseDto>> listPromptSpecs() {
         List<PromptSpec> prompts = promptStore.listAllPrompts();
         return ResponseEntity.ok(PromptSpecApiView.toApiView(prompts, lifecycleDeriver));
     }
@@ -137,7 +137,7 @@ public class PromptSpecController {
         @ApiResponse(responseCode = "404", description = "Failed to create prompt specification")
     })
     @PostMapping
-    public ResponseEntity<PromptSpec> createPromptSpec(
+    public ResponseEntity<PromptSpecResponseDto> createPromptSpec(
             @RequestBody(description = "Prompt specification creation request details", required = true,
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = PromptSpecCreationRequest.class)))
@@ -167,7 +167,7 @@ public class PromptSpecController {
         @ApiResponse(responseCode = "404", description = "Prompt specification not found")
     })
     @PutMapping("/{promptSpecId}")
-    public ResponseEntity<PromptSpec> updatePromptSpec(
+    public ResponseEntity<PromptSpecResponseDto> updatePromptSpec(
             @Parameter(description = "ID of the prompt specification to update")
             @PathVariable("promptSpecId") String promptSpecId,
             @RequestBody(description = "Updated prompt specification details", required = true,

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecResponseDto.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecResponseDto.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.web;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import dev.promptlm.domain.promptspec.PromptSpec;
+import dev.promptlm.domain.promptspec.PromptSpecLifecycleState;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * API-boundary response payload for a {@link PromptSpec}. Carries the spec
+ * itself (serialized inline via {@link JsonUnwrapped} so the existing JSON
+ * field names and shapes are preserved byte-for-byte) plus the three
+ * server-derived fields the editor UI reads from {@code GET /api/prompts/*}:
+ * lifecycle state, HEAD short SHA, and release tag.
+ *
+ * <p>This DTO exists so the domain {@link PromptSpec} stays free of API-only
+ * fields. The deriver populates the boundary fields in
+ * {@link PromptSpecApiView#toApiView(PromptSpec, PromptSpecLifecycleDeriver)};
+ * the wire format consumed by the frontend is unchanged.
+ *
+ * @see PromptSpecApiView
+ * @see PromptSpecLifecycleDeriver
+ */
+@Schema(description = "Prompt specification response payload (domain spec + server-derived UI hints)")
+final class PromptSpecResponseDto {
+
+    @JsonUnwrapped
+    private final PromptSpec spec;
+
+    @JsonProperty("lifecycleState")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "Server-derived lifecycle state of the spec. Omitted when the backend cannot derive it (e.g. no active project).",
+            implementation = PromptSpecLifecycleState.class,
+            nullable = true,
+            accessMode = Schema.AccessMode.READ_ONLY)
+    private final PromptSpecLifecycleState lifecycleState;
+
+    @JsonProperty("headShortSha")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "Server-derived Git short SHA (7 chars) of HEAD when the working tree matches a commit. Omitted otherwise.",
+            nullable = true,
+            accessMode = Schema.AccessMode.READ_ONLY,
+            example = "a1b2c3d")
+    private final String headShortSha;
+
+    @JsonProperty("releaseTag")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "Server-derived release tag for the current revision. Omitted when the spec has not been released.",
+            nullable = true,
+            accessMode = Schema.AccessMode.READ_ONLY,
+            example = "v1.4")
+    private final String releaseTag;
+
+    PromptSpecResponseDto(PromptSpec spec,
+                          PromptSpecLifecycleState lifecycleState,
+                          String headShortSha,
+                          String releaseTag) {
+        this.spec = spec;
+        this.lifecycleState = lifecycleState;
+        this.headShortSha = headShortSha;
+        this.releaseTag = releaseTag;
+    }
+
+    /** Returns the wrapped spec. Visible to tests and assemblers within the web module. */
+    PromptSpec getSpec() {
+        return spec;
+    }
+
+    PromptSpecLifecycleState getLifecycleState() {
+        return lifecycleState;
+    }
+
+    String getHeadShortSha() {
+        return headShortSha;
+    }
+
+    String getReleaseTag() {
+        return releaseTag;
+    }
+}


### PR DESCRIPTION
## Summary

Reform the API boundary so that `PromptSpecApiView.toApiView(...)` returns a dedicated `PromptSpecResponseDto` instead of a polluted `PromptSpec`. This eliminates the root cause of three rounds of domain pollution we've been routing around: `lifecycleState` (#189), `headShortSha` (#184), and `releaseTag` (#184) were all stamped onto the domain entity via withers because the API view returned the domain type.

- New `PromptSpecResponseDto` in `components/promptlm-web-api/.../web/` wraps a `PromptSpec` via `@JsonUnwrapped` and exposes the three server-derived UI hints as top-level fields.
- `PromptSpec` is back to a pure domain type: no `lifecycleState`, `headShortSha`, `releaseTag` fields/withers/getters; the 26-arg private constructor and the `@JsonProperty`-annotated 23-arg bridge constructor are gone.
- Wire format is byte-identical (`@JsonUnwrapped` inlines the spec's existing JSON shape). The frontend (`selectRevisionId.ts`, `PromptFormShell.tsx`) reads via structural typing, so no client changes are needed.

## Pollution removed from `PromptSpec`

| Field          | Type                        | Wither              | Getter                |
| -------------- | --------------------------- | ------------------- | --------------------- |
| `lifecycleState` | `PromptSpecLifecycleState`  | `withLifecycleState` | `getLifecycleState`   |
| `headShortSha`   | `String`                    | `withHeadShortSha`   | `getHeadShortSha`     |
| `releaseTag`     | `String`                    | `withReleaseTag`     | `getReleaseTag`       |

Also removed: the OpenAPI `@Schema` annotations for those fields, plus the private 26-arg constructor and the public 23-arg `@JsonProperty`-annotated overload introduced to thread them through.

`Execution` was not touched — `getCostUsd()` doesn't exist on `main` (#197 is still open and will need to be rebased).

## Heads-up: open PRs need to rebase

All four open PRs touch `PromptSpecApiView` or PromptSpec withers and will need a rebase after this merges:

- #194, #195, #196 — they call `PromptSpecApiView.toApiView(...)` expecting `PromptSpec` back.
- #197 — adds a `getCostUsd()` virtual getter on `Execution` for the same architectural reason. After this lands, #197 should introduce `ExecutionResponseDto` to surface `costUsd` instead.

## Test plan

- [x] `./mvnw -pl components/promptlm-domain,components/promptlm-web-api,components/promptlm-lifecycle,components/promptlm-execution-springai test` — **100 tests pass** (web-api: 100, domain: 51, lifecycle/execution-springai green via reactor)
- [x] `npm test -w @promptlm/web-ui` — **139 tests pass** across 26 files (incl. `selectRevisionId.test.ts`)
- [x] `npm test -w @promptlm/ui` smoke — **passed**
- [x] JSON wire-format identity verified via existing WebMvc `jsonPath` assertions (`$.lifecycleState`, `$.headShortSha`, `$.releaseTag`, `$.executions[*]`)