### PR TITLE
site: add "Made with ❤️ in Frankfurt 🇩🇪" to footer

### DIFF
--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -127,7 +127,8 @@
             </a>
             <p class="footer-tagline">
               prompt lifecycle management<br />
-              © 2026 · promptlm.dev
+              © 2026 · promptlm.dev<br />
+              Made with ❤️ in Frankfurt 🇩🇪
             </p>
           </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -330,7 +330,8 @@
             </a>
             <p class="footer-tagline">
               prompt lifecycle management<br />
-              © 2026 · promptlm.dev
+              © 2026 · promptlm.dev<br />
+              Made with ❤️ in Frankfurt 🇩🇪
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- Adds "Made with ❤️ in Frankfurt 🇩🇪" below the logo/copyright line in the landing page footer ([site/index.html](site/index.html))
- Mirrors the same line into the AsciiDoc docs page template so generated docs pages get it too ([docs/templates/page.html](docs/templates/page.html))

## Test plan
- [ ] Open landing page locally — verify the new line appears below "© 2026 · promptlm.dev" in the left footer column
- [ ] Rebuild docs (`npm run docs:build`) and verify the line appears in the docs footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)