### PR TITLE
site: extract footer into single source-of-truth partial

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,6 +1,12 @@
 name: Deploy site to Pages
 
-# Triggers on any change that affects what the static site serves:
+# Runs only on pushes to main (i.e. after a PR is merged) and manual
+# dispatch. Pull requests do NOT trigger this workflow — broken builds
+# surface here when main rebuilds, so run `npm run docs:build` locally
+# before opening a PR to catch them sooner.
+#
+# Path filter keeps unrelated main pushes (backend code, tests, …) from
+# spinning up a Pages deploy:
 #   - site/**                 the website itself
 #   - docs/**                 AsciiDoc source for the user docs
 #   - scripts/build-docs.mjs  the docs renderer
@@ -11,16 +17,6 @@ name: Deploy site to Pages
 on:
   push:
     branches: [main]
-    paths:
-      - 'site/**'
-      - 'docs/**'
-      - 'scripts/build-docs.mjs'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/deploy-site.yml'
-  # Build (but do not deploy) on PRs that touch the same paths, so
-  # broken AsciiDoc fails a PR check rather than the deploy.
-  pull_request:
     paths:
       - 'site/**'
       - 'docs/**'
@@ -64,8 +60,6 @@ jobs:
 
   deploy:
     needs: build
-    # Deploy only on pushes to main / manual dispatch. PR runs stop at `build`.
-    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -110,46 +110,12 @@
         </aside>
       </div>
 
-      <!-- ─── footer (mirrors site/index.html, paths adjusted for site/docs/) ─── -->
-      <footer class="site-footer" role="contentinfo">
-        <div class="footer-grid">
-          <div>
-            <a class="nav-wordmark" href="../index.html" aria-label="promptLM home">
-              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <line x1="7" y1="7" x2="17" y2="12" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
-                <line x1="7" y1="7" x2="7" y2="17" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
-                <line x1="7" y1="17" x2="17" y2="12" stroke="var(--pl-signal-deep)" stroke-width="1.75" stroke-linecap="round" />
-                <circle cx="7" cy="7" r="2.6" fill="var(--pl-ink-900)" />
-                <circle cx="7" cy="17" r="2.6" fill="var(--pl-ink-900)" />
-                <circle cx="17" cy="12" r="2.8" fill="var(--pl-signal-deep)" />
-              </svg>
-              <span class="nav-wordmark-text" style="font-size: 17.6px;">prompt<strong>LM</strong></span>
-            </a>
-            <p class="footer-tagline">
-              prompt lifecycle management<br />
-              © 2026 · promptlm.dev<br />
-              Made with ❤️ in Frankfurt 🇩🇪
-            </p>
-          </div>
-
-          <div class="footer-cols">
-            <div class="footer-col">
-              <p class="footer-col-heading">Product</p>
-              <a href="../docs.html#get-started">CLI</a>
-              <a href="../docs.html#studio">Studio</a>
-              <a href="https://github.com/promptLM/promptlm-client-sdk">Java SDK</a>
-              <a href="https://github.com/promptLM/promptlm-macos">macOS app</a>
-              <a href="https://github.com/promptLM/promptlm-junit-gitea-artifactory">Test support</a>
-            </div>
-            <div class="footer-col">
-              <p class="footer-col-heading">Resources</p>
-              <a href="index.html">Docs</a>
-              <a href="https://github.com/promptLM/promptlm-app/releases">Changelog</a>
-              <a href="https://github.com/promptLM/promptlm-app">GitHub</a>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <!-- ─── footer ───
+           Generated from docs/templates/partials/footer.html by
+           scripts/build-docs.mjs (paths rewritten for site/docs/*).
+           Do not hand-edit; edit the partial and re-run the build. -->
+      <!-- footer:start -->
+      <!-- footer:end -->
     </div>
   </body>
 </html>

--- a/docs/templates/partials/footer.html
+++ b/docs/templates/partials/footer.html
@@ -1,39 +1,39 @@
 <footer class="site-footer" role="contentinfo">
-        <div class="footer-grid">
-          <div>
-            <a class="nav-wordmark" href="{{homeHref}}" aria-label="promptLM home">
-              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <line x1="7" y1="7" x2="17" y2="12" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
-                <line x1="7" y1="7" x2="7" y2="17" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
-                <line x1="7" y1="17" x2="17" y2="12" stroke="var(--pl-signal-deep)" stroke-width="1.75" stroke-linecap="round" />
-                <circle cx="7" cy="7" r="2.6" fill="var(--pl-ink-900)" />
-                <circle cx="7" cy="17" r="2.6" fill="var(--pl-ink-900)" />
-                <circle cx="17" cy="12" r="2.8" fill="var(--pl-signal-deep)" />
-              </svg>
-              <span class="nav-wordmark-text" style="font-size: 17.6px;">prompt<strong>LM</strong></span>
-            </a>
-            <p class="footer-tagline">
-              prompt lifecycle management<br />
-              © 2026 · promptlm.dev<br />
-              Made with ❤️ in Frankfurt 🇩🇪
-            </p>
-          </div>
+  <div class="footer-grid">
+    <div>
+      <a class="nav-wordmark" href="{{homeHref}}" aria-label="promptLM home">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <line x1="7" y1="7" x2="17" y2="12" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
+          <line x1="7" y1="7" x2="7" y2="17" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
+          <line x1="7" y1="17" x2="17" y2="12" stroke="var(--pl-signal-deep)" stroke-width="1.75" stroke-linecap="round" />
+          <circle cx="7" cy="7" r="2.6" fill="var(--pl-ink-900)" />
+          <circle cx="7" cy="17" r="2.6" fill="var(--pl-ink-900)" />
+          <circle cx="17" cy="12" r="2.8" fill="var(--pl-signal-deep)" />
+        </svg>
+        <span class="nav-wordmark-text" style="font-size: 17.6px;">prompt<strong>LM</strong></span>
+      </a>
+      <p class="footer-tagline">
+        prompt lifecycle management<br />
+        © 2026 · promptlm.dev<br />
+        Made with ❤️ in Frankfurt 🇩🇪
+      </p>
+    </div>
 
-          <div class="footer-cols">
-            <div class="footer-col">
-              <p class="footer-col-heading">Product</p>
-              <a href="{{root}}docs.html#get-started">CLI</a>
-              <a href="{{root}}docs.html#studio">Studio</a>
-              <a href="https://github.com/promptLM/promptlm-client-sdk">Java SDK</a>
-              <a href="https://github.com/promptLM/promptlm-macos">macOS app</a>
-              <a href="https://github.com/promptLM/promptlm-junit-gitea-artifactory">Test support</a>
-            </div>
-            <div class="footer-col">
-              <p class="footer-col-heading">Resources</p>
-              <a href="{{root}}docs.html">Docs</a>
-              <a href="https://github.com/promptLM/promptlm-app/releases">Changelog</a>
-              <a href="https://github.com/promptLM/promptlm-app">GitHub</a>
-            </div>
-          </div>
-        </div>
-      </footer>
+    <div class="footer-cols">
+      <div class="footer-col">
+        <p class="footer-col-heading">Product</p>
+        <a href="{{root}}docs.html#get-started">CLI</a>
+        <a href="{{root}}docs.html#studio">Studio</a>
+        <a href="https://github.com/promptLM/promptlm-client-sdk">Java SDK</a>
+        <a href="https://github.com/promptLM/promptlm-macos">macOS app</a>
+        <a href="https://github.com/promptLM/promptlm-junit-gitea-artifactory">Test support</a>
+      </div>
+      <div class="footer-col">
+        <p class="footer-col-heading">Resources</p>
+        <a href="{{root}}docs.html">Docs</a>
+        <a href="https://github.com/promptLM/promptlm-app/releases">Changelog</a>
+        <a href="https://github.com/promptLM/promptlm-app">GitHub</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/docs/templates/partials/footer.html
+++ b/docs/templates/partials/footer.html
@@ -1,0 +1,39 @@
+<footer class="site-footer" role="contentinfo">
+        <div class="footer-grid">
+          <div>
+            <a class="nav-wordmark" href="{{homeHref}}" aria-label="promptLM home">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <line x1="7" y1="7" x2="17" y2="12" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
+                <line x1="7" y1="7" x2="7" y2="17" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
+                <line x1="7" y1="17" x2="17" y2="12" stroke="var(--pl-signal-deep)" stroke-width="1.75" stroke-linecap="round" />
+                <circle cx="7" cy="7" r="2.6" fill="var(--pl-ink-900)" />
+                <circle cx="7" cy="17" r="2.6" fill="var(--pl-ink-900)" />
+                <circle cx="17" cy="12" r="2.8" fill="var(--pl-signal-deep)" />
+              </svg>
+              <span class="nav-wordmark-text" style="font-size: 17.6px;">prompt<strong>LM</strong></span>
+            </a>
+            <p class="footer-tagline">
+              prompt lifecycle management<br />
+              © 2026 · promptlm.dev<br />
+              Made with ❤️ in Frankfurt 🇩🇪
+            </p>
+          </div>
+
+          <div class="footer-cols">
+            <div class="footer-col">
+              <p class="footer-col-heading">Product</p>
+              <a href="{{root}}docs.html#get-started">CLI</a>
+              <a href="{{root}}docs.html#studio">Studio</a>
+              <a href="https://github.com/promptLM/promptlm-client-sdk">Java SDK</a>
+              <a href="https://github.com/promptLM/promptlm-macos">macOS app</a>
+              <a href="https://github.com/promptLM/promptlm-junit-gitea-artifactory">Test support</a>
+            </div>
+            <div class="footer-col">
+              <p class="footer-col-heading">Resources</p>
+              <a href="{{root}}docs.html">Docs</a>
+              <a href="https://github.com/promptLM/promptlm-app/releases">Changelog</a>
+              <a href="https://github.com/promptLM/promptlm-app">GitHub</a>
+            </div>
+          </div>
+        </div>
+      </footer>

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -38,9 +38,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const PAGES_DIR = path.join(ROOT, 'docs/pages');
 const TEMPLATE_DIR = path.join(ROOT, 'docs/templates');
+const PARTIALS_DIR = path.join(TEMPLATE_DIR, 'partials');
 const STYLES_DIR = path.join(ROOT, 'docs/styles');
 const NAV_PATH = path.join(ROOT, 'docs/nav.yml');
 const OUT_DIR = path.join(ROOT, 'site/docs');
+const SITE_INDEX = path.join(ROOT, 'site/index.html');
+
+// Markers wrapping the footer block in the marketing landing page and in
+// docs/templates/page.html. The build replaces everything between them
+// with the rendered partial from docs/templates/partials/footer.html.
+const FOOTER_START = '<!-- footer:start -->';
+const FOOTER_END = '<!-- footer:end -->';
 
 const adoc = asciidoctor();
 
@@ -221,14 +229,77 @@ async function buildPage(adocPath, nav, template) {
   return slug;
 }
 
+/** Render the footer partial for a given consumer context. Substitutes
+ *  `{{root}}` (path prefix to site root) and `{{homeHref}}` (wordmark
+ *  destination). The returned string has no surrounding markers. */
+function renderFooter(rawPartial, { root, homeHref }) {
+  return rawPartial
+    .replaceAll('{{root}}', root)
+    .replaceAll('{{homeHref}}', homeHref);
+}
+
+/** Replace the block between FOOTER_START and FOOTER_END in `host` with
+ *  `body`. Indents every line of `body` to match the column at which the
+ *  start marker sits in `host`. Throws if the markers are missing —
+ *  that means the consumer file was tampered with and we'd silently
+ *  no-op without this check. */
+function spliceBetweenMarkers(host, body, label) {
+  const startIdx = host.indexOf(FOOTER_START);
+  const endIdx = host.indexOf(FOOTER_END, startIdx + 1);
+  if (startIdx === -1 || endIdx === -1) {
+    throw new Error(`${label}: footer markers not found (expected ${FOOTER_START} … ${FOOTER_END})`);
+  }
+  // Column at which the start marker line begins — same indent used for
+  // the body lines and the trailing end marker.
+  const lineStart = host.lastIndexOf('\n', startIdx) + 1;
+  const indent = host.slice(lineStart, startIdx).match(/^[ \t]*/)[0];
+  const indented = body
+    .replace(/\n+$/, '')
+    .split('\n')
+    .map(line => (line.length === 0 ? line : indent + line))
+    .join('\n');
+  const head = host.slice(0, startIdx + FOOTER_START.length);
+  const tail = host.slice(endIdx);
+  return `${head}\n${indented}\n${indent}${tail}`;
+}
+
+/** Write `content` to `outPath` only if it differs from what's on disk.
+ *  Keeps `git status` clean when nothing changed. */
+async function writeIfChanged(outPath, content, label) {
+  let existing = null;
+  try { existing = await fs.readFile(outPath, 'utf8'); } catch {}
+  if (existing === content) {
+    console.log(`  · ${label} unchanged`);
+    return false;
+  }
+  await fs.writeFile(outPath, content);
+  console.log(`  ✓ ${label} updated`);
+  return true;
+}
+
 async function main() {
   console.log('promptLM docs · build');
 
-  const [nav, template, pages] = await Promise.all([
+  const [nav, rawTemplate, footerPartial, pages] = await Promise.all([
     fs.readFile(NAV_PATH, 'utf8').then(s => YAML.parse(s)),
     fs.readFile(path.join(TEMPLATE_DIR, 'page.html'), 'utf8'),
+    fs.readFile(path.join(PARTIALS_DIR, 'footer.html'), 'utf8'),
     walk(PAGES_DIR),
   ]);
+
+  // Inject the footer into the marketing landing page (in-place between
+  // markers). Paths are site-root-relative; the wordmark "home" is `#`
+  // so clicking it scrolls to top instead of reloading.
+  const siteIndex = await fs.readFile(SITE_INDEX, 'utf8');
+  const footerForIndex = renderFooter(footerPartial, { root: '', homeHref: '#' });
+  const newSiteIndex = spliceBetweenMarkers(siteIndex, footerForIndex, 'site/index.html');
+  await writeIfChanged(SITE_INDEX, newSiteIndex, 'site/index.html');
+
+  // Bake the footer into the docs page template (in memory only; the
+  // committed template keeps the marker block empty). Paths get a `../`
+  // prefix because rendered docs sit at site/docs/*.html.
+  const footerForDocs = renderFooter(footerPartial, { root: '../', homeHref: '../index.html' });
+  const template = spliceBetweenMarkers(rawTemplate, footerForDocs, 'docs/templates/page.html');
 
   if (pages.length === 0) {
     console.error('  ! no .adoc files found under docs/pages/');

--- a/site/index.html
+++ b/site/index.html
@@ -313,46 +313,51 @@
         </section>
       </main>
 
-      <!-- ─── footer ─── -->
+      <!-- ─── footer ───
+           Generated from docs/templates/partials/footer.html by
+           scripts/build-docs.mjs. Do not hand-edit the block below;
+           edit the partial and run `npm run docs:build`. -->
+      <!-- footer:start -->
       <footer class="site-footer" role="contentinfo">
-        <div class="footer-grid">
-          <div>
-            <a class="nav-wordmark" href="#" aria-label="promptLM home">
-              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <line x1="7" y1="7" x2="17" y2="12" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
-                <line x1="7" y1="7" x2="7" y2="17" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
-                <line x1="7" y1="17" x2="17" y2="12" stroke="var(--pl-signal-deep)" stroke-width="1.75" stroke-linecap="round" />
-                <circle cx="7" cy="7" r="2.6" fill="var(--pl-ink-900)" />
-                <circle cx="7" cy="17" r="2.6" fill="var(--pl-ink-900)" />
-                <circle cx="17" cy="12" r="2.8" fill="var(--pl-signal-deep)" />
-              </svg>
-              <span class="nav-wordmark-text" style="font-size: 17.6px;">prompt<strong>LM</strong></span>
-            </a>
-            <p class="footer-tagline">
-              prompt lifecycle management<br />
-              © 2026 · promptlm.dev<br />
-              Made with ❤️ in Frankfurt 🇩🇪
-            </p>
-          </div>
+              <div class="footer-grid">
+                <div>
+                  <a class="nav-wordmark" href="#" aria-label="promptLM home">
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                      <line x1="7" y1="7" x2="17" y2="12" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
+                      <line x1="7" y1="7" x2="7" y2="17" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
+                      <line x1="7" y1="17" x2="17" y2="12" stroke="var(--pl-signal-deep)" stroke-width="1.75" stroke-linecap="round" />
+                      <circle cx="7" cy="7" r="2.6" fill="var(--pl-ink-900)" />
+                      <circle cx="7" cy="17" r="2.6" fill="var(--pl-ink-900)" />
+                      <circle cx="17" cy="12" r="2.8" fill="var(--pl-signal-deep)" />
+                    </svg>
+                    <span class="nav-wordmark-text" style="font-size: 17.6px;">prompt<strong>LM</strong></span>
+                  </a>
+                  <p class="footer-tagline">
+                    prompt lifecycle management<br />
+                    © 2026 · promptlm.dev<br />
+                    Made with ❤️ in Frankfurt 🇩🇪
+                  </p>
+                </div>
 
-          <div class="footer-cols">
-            <div class="footer-col">
-              <p class="footer-col-heading">Product</p>
-              <a href="docs.html#get-started">CLI</a>
-              <a href="docs.html#studio">Studio</a>
-              <a href="https://github.com/promptLM/promptlm-client-sdk">Java SDK</a>
-              <a href="https://github.com/promptLM/promptlm-macos">macOS app</a>
-              <a href="https://github.com/promptLM/promptlm-junit-gitea-artifactory">Test support</a>
-            </div>
-            <div class="footer-col">
-              <p class="footer-col-heading">Resources</p>
-              <a href="docs.html">Docs</a>
-              <a href="https://github.com/promptLM/promptlm-app/releases">Changelog</a>
-              <a href="https://github.com/promptLM/promptlm-app">GitHub</a>
-            </div>
-          </div>
-        </div>
-      </footer>
+                <div class="footer-cols">
+                  <div class="footer-col">
+                    <p class="footer-col-heading">Product</p>
+                    <a href="docs.html#get-started">CLI</a>
+                    <a href="docs.html#studio">Studio</a>
+                    <a href="https://github.com/promptLM/promptlm-client-sdk">Java SDK</a>
+                    <a href="https://github.com/promptLM/promptlm-macos">macOS app</a>
+                    <a href="https://github.com/promptLM/promptlm-junit-gitea-artifactory">Test support</a>
+                  </div>
+                  <div class="footer-col">
+                    <p class="footer-col-heading">Resources</p>
+                    <a href="docs.html">Docs</a>
+                    <a href="https://github.com/promptLM/promptlm-app/releases">Changelog</a>
+                    <a href="https://github.com/promptLM/promptlm-app">GitHub</a>
+                  </div>
+                </div>
+              </div>
+            </footer>
+      <!-- footer:end -->
     </div>
 
     <script src="script.js" defer></script>

--- a/site/index.html
+++ b/site/index.html
@@ -319,44 +319,44 @@
            edit the partial and run `npm run docs:build`. -->
       <!-- footer:start -->
       <footer class="site-footer" role="contentinfo">
-              <div class="footer-grid">
-                <div>
-                  <a class="nav-wordmark" href="#" aria-label="promptLM home">
-                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                      <line x1="7" y1="7" x2="17" y2="12" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
-                      <line x1="7" y1="7" x2="7" y2="17" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
-                      <line x1="7" y1="17" x2="17" y2="12" stroke="var(--pl-signal-deep)" stroke-width="1.75" stroke-linecap="round" />
-                      <circle cx="7" cy="7" r="2.6" fill="var(--pl-ink-900)" />
-                      <circle cx="7" cy="17" r="2.6" fill="var(--pl-ink-900)" />
-                      <circle cx="17" cy="12" r="2.8" fill="var(--pl-signal-deep)" />
-                    </svg>
-                    <span class="nav-wordmark-text" style="font-size: 17.6px;">prompt<strong>LM</strong></span>
-                  </a>
-                  <p class="footer-tagline">
-                    prompt lifecycle management<br />
-                    © 2026 · promptlm.dev<br />
-                    Made with ❤️ in Frankfurt 🇩🇪
-                  </p>
-                </div>
+        <div class="footer-grid">
+          <div>
+            <a class="nav-wordmark" href="#" aria-label="promptLM home">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <line x1="7" y1="7" x2="17" y2="12" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
+                <line x1="7" y1="7" x2="7" y2="17" stroke="var(--pl-ink-900)" stroke-width="1.5" stroke-linecap="round" />
+                <line x1="7" y1="17" x2="17" y2="12" stroke="var(--pl-signal-deep)" stroke-width="1.75" stroke-linecap="round" />
+                <circle cx="7" cy="7" r="2.6" fill="var(--pl-ink-900)" />
+                <circle cx="7" cy="17" r="2.6" fill="var(--pl-ink-900)" />
+                <circle cx="17" cy="12" r="2.8" fill="var(--pl-signal-deep)" />
+              </svg>
+              <span class="nav-wordmark-text" style="font-size: 17.6px;">prompt<strong>LM</strong></span>
+            </a>
+            <p class="footer-tagline">
+              prompt lifecycle management<br />
+              © 2026 · promptlm.dev<br />
+              Made with ❤️ in Frankfurt 🇩🇪
+            </p>
+          </div>
 
-                <div class="footer-cols">
-                  <div class="footer-col">
-                    <p class="footer-col-heading">Product</p>
-                    <a href="docs.html#get-started">CLI</a>
-                    <a href="docs.html#studio">Studio</a>
-                    <a href="https://github.com/promptLM/promptlm-client-sdk">Java SDK</a>
-                    <a href="https://github.com/promptLM/promptlm-macos">macOS app</a>
-                    <a href="https://github.com/promptLM/promptlm-junit-gitea-artifactory">Test support</a>
-                  </div>
-                  <div class="footer-col">
-                    <p class="footer-col-heading">Resources</p>
-                    <a href="docs.html">Docs</a>
-                    <a href="https://github.com/promptLM/promptlm-app/releases">Changelog</a>
-                    <a href="https://github.com/promptLM/promptlm-app">GitHub</a>
-                  </div>
-                </div>
-              </div>
-            </footer>
+          <div class="footer-cols">
+            <div class="footer-col">
+              <p class="footer-col-heading">Product</p>
+              <a href="docs.html#get-started">CLI</a>
+              <a href="docs.html#studio">Studio</a>
+              <a href="https://github.com/promptLM/promptlm-client-sdk">Java SDK</a>
+              <a href="https://github.com/promptLM/promptlm-macos">macOS app</a>
+              <a href="https://github.com/promptLM/promptlm-junit-gitea-artifactory">Test support</a>
+            </div>
+            <div class="footer-col">
+              <p class="footer-col-heading">Resources</p>
+              <a href="docs.html">Docs</a>
+              <a href="https://github.com/promptLM/promptlm-app/releases">Changelog</a>
+              <a href="https://github.com/promptLM/promptlm-app">GitHub</a>
+            </div>
+          </div>
+        </div>
+      </footer>
       <!-- footer:end -->
     </div>
 


### PR DESCRIPTION
## Summary
- Canonical footer lives at [docs/templates/partials/footer.html](docs/templates/partials/footer.html) with `{{root}}` / `{{homeHref}}` placeholders for the site-root vs docs-subdir contexts
- [scripts/build-docs.mjs](scripts/build-docs.mjs) renders the partial twice and splices it between `<!-- footer:start -->` … `<!-- footer:end -->` markers in `site/index.html` (in place) and the docs page template (in memory before per-page rendering)
- Drop `pull_request` trigger from [deploy-site.yml](.github/workflows/deploy-site.yml) — Pages deploy now runs only on pushes to main and manual dispatch

## Why
Both consumer files had a near-identical footer with only path prefixes differing. The Frankfurt line in #207 had to be applied twice in parallel — the next change would have the same risk.

## Tradeoff
Removing the PR build means broken AsciiDoc or partial-template errors surface only when main rebuilds. Mitigation: run `npm run docs:build` locally before opening a PR. The build is fast (~1s after `npm ci`) and produces a clean `git status` when nothing changed.

## Test plan
- [x] `npm run docs:build` succeeds locally and regenerates `site/index.html` + `site/docs/*.html`
- [x] `site/index.html` footer contains "Made with ❤️ in Frankfurt 🇩🇪" with root-relative links (`docs.html`, `#`)
- [x] `site/docs/index.html` footer contains the same line with `../`-prefixed links and `../index.html` as the wordmark home
- [ ] After merge: `Deploy site to Pages` runs on the main commit (and not on the PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)