### PR TITLE
site: clarify what test-support example mocks (and why it saves money)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -285,14 +285,15 @@
             </div>
 
             <pre class="code-snippet" aria-label="JUnit test-support example"><span class="code-snippet-comment">// TranslationServiceTest.java</span>
-<span class="code-key">@EnablePromptWireMock</span>
-<span class="code-fn">class</span> TranslationServiceTest {
+<span class="code-key">@EnablePromptWireMock</span> <span class="code-snippet-comment">// boots WireMock on a local port,</span>
+<span class="code-fn">class</span> TranslationServiceTest {              <span class="code-snippet-comment">// pre-stubbed from your prompt repo</span>
 
   <span class="code-key">@Test</span>
-  <span class="code-fn">void</span> translates(
-    <span class="code-key">@InjectPrompt</span>(id = <span class="code-str">"translate-hello"</span>) String prompt,
-    <span class="code-key">@InjectResponse</span>(id = <span class="code-str">"translate-hello"</span>) String response) {
-    <span class="code-snippet-comment">// WireMock stubs auto-generated from your prompt repo</span>
+  <span class="code-fn">void</span> translates(<span class="code-key">@InjectResponse</span>(id = <span class="code-str">"translate-hello"</span>) String recorded) {
+    String result = callLLM(<span class="code-str">"translate-hello"</span>, Map.of(<span class="code-str">"text"</span>, <span class="code-str">"Hello"</span>)); <span class="code-snippet-comment">// pseudocode: your prod code that POSTs to the LLM</span>
+    <span class="code-snippet-comment">// The LLM URL points at WireMock, so the recorded reply is returned.</span>
+    <span class="code-snippet-comment">// No real model call, no tokens billed, deterministic across runs.</span>
+    assertThat(result).isEqualTo(recorded);
   }
 }</pre>
           </div>


### PR DESCRIPTION
## Summary
Updates the JUnit snippet on the landing page ([site/index.html:287-300](site/index.html:287)) so the substitution that `@EnablePromptWireMock` performs is legible at a glance:

- Adds a `callLLM("translate-hello", Map.of(...))` line (marked `// pseudocode: your prod code that POSTs to the LLM`) so readers see *what* gets intercepted
- Adds an `assertThat(result).isEqualTo(recorded)` line so the test-shape is complete
- Replaces the vague *"WireMock stubs auto-generated from your prompt repo"* trailing comment with two lines that name the value: *"The LLM URL points at WireMock, so the recorded reply is returned. No real model call, no tokens billed, deterministic across runs."*
- Drops the unused `@InjectPrompt` parameter (the previous snippet declared it but never used it)

## Why
Before this change, the body of the test was a single comment — readers couldn't see what `@EnablePromptWireMock` actually substitutes for, so the cost/determinism payoff was invisible. The new snippet makes the substitution visible (the `callLLM(...)` line) and the payoff explicit (the trailing two-line comment).

## Verification
Mechanics confirmed against [promptLM/promptlm-test-support · client-example/LlmServiceTest.java](https://github.com/promptLM/promptlm-test-support/blob/main/client-example/src/test/java/dev/promptlm/example/service/LlmServiceTest.java):
- `@EnablePromptWireMock` boots a WireMock server, stubs pre-loaded from `prompts.json` / `responses.json` shipped in the prompt JAR's `test-support` classifier
- The prod service is constructed pointing at `http://localhost:<wiremockPort>` instead of the real LLM URL
- `@InjectResponse(id = "...")` injects the same recorded reply for equality assertions

## Tradeoff
`callLLM(...)` is illustrative — it's not a real method on the test-support API. Anyone copy-pasting would hit a compile error. Hence the inline `// pseudocode: ...` marker. The alternative (showing a real `HttpClient` POST against `api.openai.com`) is more authentic but pushes line width and obscures the concept.

## Test plan
- [x] `npm run docs:build` succeeds (snippet lives outside the footer markers — no interaction with #208's footer-sync logic)
- [ ] Eyeball the rendered snippet on the deployed landing page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)