### PR TITLE
site: align SDK example with the customer_support thread

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -249,11 +249,9 @@
               <img src="media/studio-detail.png" alt="promptLM studio — prompt detail showing version 1.8.0, model, parameters, and dev execution metrics" width="1500" height="937" loading="lazy" />
             </figure>
 
-            <pre class="code-snippet" aria-label="promptLM SDK usage example"><span class="code-snippet-comment">// SupportBot.java</span>
-Prompt prompt = PromptLoader.load(<span class="code-str">"doc-rag-answer"</span>);   <span class="code-snippet-comment">// pinned v1.8.0 in pom.xml</span>
-String filled = prompt.fill(Map.of(
-  <span class="code-str">"question"</span>, question,
-  <span class="code-str">"chunks"</span>,   retrievedChunks));
+            <pre class="code-snippet" aria-label="promptLM SDK usage example"><span class="code-snippet-comment">// SupportService.java</span>
+Prompt prompt = PromptLoader.load(<span class="code-str">"customer_support"</span>);  <span class="code-snippet-comment">// pinned v1.0.0 in pom.xml</span>
+String filled = prompt.fill(Map.of(<span class="code-str">"ticket"</span>, ticket));
 
 <span class="code-snippet-comment">// vendor, model, parameters come from the spec — not your code</span>
 String reply = llm.send(filled, prompt.model(), prompt.parameters());</pre>


### PR DESCRIPTION
## Summary
One-line edit to the "In your app" pillar's SDK snippet so the whole landing page walks through a single example.

The page previously showed three different prompt ids:
- `customer_support` in the YAML diff at the top (canonical)
- `doc-rag-answer` in this SDK snippet (out of band)
- `translate-hello` in the test snippet — will become `customer_support` once [#212](https://github.com/promptLM/promptLM-app/pull/212) lands

This PR consolidates the SDK snippet onto the same example:

| Before | After |
|---|---|
| `// SupportBot.java` | `// SupportService.java` |
| `PromptLoader.load("doc-rag-answer")` | `PromptLoader.load("customer_support")` |
| `prompt.fill(Map.of("question", question, "chunks", retrievedChunks))` | `prompt.fill(Map.of("ticket", ticket))` |
| `// pinned v1.8.0 in pom.xml` | `// pinned v1.0.0 in pom.xml` (matches YAML's `version: 1.0.0`) |

Pure copy — no structural or CSS changes. Independent of #212; either order of merge works.

## Test plan
- [ ] Render [site/index.html](site/index.html) — "In your app" pillar shows the new `SupportService.java` snippet
- [ ] Compare against the YAML diff above and (post-#212) the test snippet below — same prompt id throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)