### PR TITLE
site: add Windows install option to hero install line

### DIFF
--- a/docs/pages/get-started/install-cli.adoc
+++ b/docs/pages/get-started/install-cli.adoc
@@ -33,9 +33,26 @@ curl -fsSL https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/
 
 == Windows (PowerShell)
 
-A PowerShell installer is available at
-`scripts/install.ps1` in the same repository.
-// source: scripts (sibling file referenced from README.adoc)
+[source,powershell]
+----
+irm https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.ps1 | iex
+----
+// source: scripts/install.ps1
+
+The installer fetches the latest release for your architecture, verifies
+the SHA-256 checksum, and places `promptlm-cli.exe` in `$env:PROMPTLM_INSTALL_DIR`
+(default `$HOME\.local\bin`).
+// source: scripts/install.ps1:20,40-46
+
+To pin a specific version or override the destination, download the
+script first and pass parameters:
+
+[source,powershell]
+----
+iwr https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.ps1 -OutFile install.ps1
+.\install.ps1 -Version v0.2.0 -InstallDir "$HOME\bin"
+----
+// source: scripts/install.ps1:17-22
 
 == Verify
 

--- a/site/index.html
+++ b/site/index.html
@@ -121,10 +121,33 @@
             </div>
 
             <!-- install line -->
-            <div class="install-line">
+            <div class="install-line" data-install-os-group>
+              <span class="install-os-tabs" role="tablist" aria-label="Operating system">
+                <button
+                  type="button"
+                  role="tab"
+                  class="install-os-tab is-active"
+                  data-install-os="unix"
+                  aria-selected="true"
+                >macOS · Linux</button>
+                <button
+                  type="button"
+                  role="tab"
+                  class="install-os-tab"
+                  data-install-os="windows"
+                  aria-selected="false"
+                >Windows</button>
+              </span>
+              <span class="install-line-divider" aria-hidden="true"></span>
               <span class="install-line-text">
-                <span class="install-line-prompt">$</span>
-                <span data-install-cmd>curl -fsSL https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.sh | bash</span>
+                <span class="install-line-prompt" data-install-prompt>$</span>
+                <span
+                  data-install-cmd
+                  data-cmd-unix="curl -fsSL https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.sh | bash"
+                  data-cmd-windows="irm https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.ps1 | iex"
+                  data-prompt-unix="$"
+                  data-prompt-windows="PS&gt;"
+                >curl -fsSL https://raw.githubusercontent.com/promptLM/promptlm-app/main/scripts/install.sh | bash</span>
               </span>
               <span class="install-line-divider" aria-hidden="true"></span>
               <button

--- a/site/script.js
+++ b/site/script.js
@@ -10,9 +10,33 @@
 (function () {
   'use strict';
 
+  // ── install-line OS toggle (macOS·Linux / Windows) ────────────────
+  const osGroup = document.querySelector('[data-install-os-group]');
+  const cmdNode = document.querySelector('[data-install-cmd]');
+  const promptNode = document.querySelector('[data-install-prompt]');
+
+  if (osGroup && cmdNode) {
+    const osTabs = Array.from(osGroup.querySelectorAll('[data-install-os]'));
+    const activateOs = (key) => {
+      osTabs.forEach((tab) => {
+        const isActive = tab.dataset.installOs === key;
+        tab.classList.toggle('is-active', isActive);
+        tab.setAttribute('aria-selected', String(isActive));
+      });
+      const nextCmd = cmdNode.dataset['cmd' + key.charAt(0).toUpperCase() + key.slice(1)];
+      if (nextCmd) cmdNode.textContent = nextCmd;
+      if (promptNode) {
+        const nextPrompt = cmdNode.dataset['prompt' + key.charAt(0).toUpperCase() + key.slice(1)];
+        if (nextPrompt) promptNode.textContent = nextPrompt;
+      }
+    };
+    osTabs.forEach((tab) => {
+      tab.addEventListener('click', () => activateOs(tab.dataset.installOs));
+    });
+  }
+
   // ── install-line copy-to-clipboard ────────────────────────────────
   const copyButton = document.querySelector('[data-install-copy]');
-  const cmdNode = document.querySelector('[data-install-cmd]');
 
   if (copyButton && cmdNode && navigator.clipboard) {
     copyButton.addEventListener('click', async () => {

--- a/site/styles.css
+++ b/site/styles.css
@@ -301,6 +301,32 @@ img, svg { display: block; }
 .install-copy:hover { color: var(--pl-ink-800); }
 .install-copy.is-copied { color: var(--pl-ok); }
 
+.install-os-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex: 0 0 auto;
+}
+.install-os-tab {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-family: var(--pl-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pl-ink-500);
+  padding: 3px 7px;
+  border-radius: 4px;
+  transition: color .15s, background .15s;
+}
+.install-os-tab:hover { color: var(--pl-ink-800); }
+.install-os-tab.is-active {
+  color: var(--pl-ink-900);
+  background: var(--pl-ink-100, rgba(0, 0, 0, 0.05));
+}
+
 .hero-mock { margin-top: 80px; }
 
 /* ─── DiffMock — static replica of site.jsx DiffMock ─── */


### PR DESCRIPTION
## Summary
- Adds a small **macOS · Linux / Windows** toggle inside the hero install pill on the landing page. Swaps the command and prompt (`$` ↔ `PS>`) on click.
- Replaces the docs page "PowerShell installer exists, go find it" stub with the actual `irm … | iex` one-liner plus a pinned-version variant.
- No script changes — `scripts/install.ps1` already shipped working in v0.2.0; this just surfaces it.

## Verification
- Verified `install.ps1` end-to-end against the live v0.2.0 release: asset name (`promptlm-cli-windows-x64.zip`), archive layout (`promptlm-cli.exe` at root), and SHA256 entry all match what the script expects.
- Loaded `site/` in the local preview, clicked the Windows tab — command swaps to PowerShell, prompt becomes `PS>`, active state moves to the Windows tab, no console errors.
- Rebuilt the docs (`npm run docs:build`); the install-cli page renders the new Windows section.

## Test plan
- [ ] Pages deploy succeeds after merge.
- [ ] On the live site, hero install pill shows both tabs; Windows tab swaps command + prompt.
- [ ] `docs/install-cli.html` "Windows (PowerShell)" section shows the one-liner and the pinned-version variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)