### PR TITLE
site: hero copy — 'under version control'

### DIFF
--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -27,7 +27,7 @@
     <meta property="og:image" content="https://promptlm.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="promptLM — your prompt lifecycle, under control." />
+    <meta property="og:image:alt" content="promptLM — your prompt lifecycle, under version control." />
 
     <!-- Twitter / X (mirror of site/index.html) -->
     <meta name="twitter:card" content="summary_large_image" />
@@ -35,7 +35,7 @@
     <meta name="twitter:title" content="{{title}} · promptLM docs" />
     <meta name="twitter:description" content="{{description}}" />
     <meta name="twitter:image" content="https://promptlm.dev/og-image.png" />
-    <meta name="twitter:image:alt" content="promptLM — your prompt lifecycle, under control." />
+    <meta name="twitter:image:alt" content="promptLM — your prompt lifecycle, under version control." />
 
     <!-- Self-hosted Geist + JetBrains Mono (no external font CDN; see ../fonts.css) -->
     <link rel="stylesheet" href="../fonts.css" />

--- a/site/index.html
+++ b/site/index.html
@@ -36,7 +36,7 @@
     <meta property="og:image" content="https://promptlm.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="promptLM — your prompt lifecycle, under control." />
+    <meta property="og:image:alt" content="promptLM — your prompt lifecycle, under version control." />
 
     <!-- Twitter / X -->
     <meta name="twitter:card" content="summary_large_image" />
@@ -46,7 +46,7 @@
       content="Open-source, Git-native prompt lifecycle management for engineering teams. Version LLM prompts in Git, ship signed releases, replay them in JUnit, pytest, or Vitest. No new SaaS, no new auth — lives in the Git you already trust."
     />
     <meta name="twitter:image" content="https://promptlm.dev/og-image.png" />
-    <meta name="twitter:image:alt" content="promptLM — your prompt lifecycle, under control." />
+    <meta name="twitter:image:alt" content="promptLM — your prompt lifecycle, under version control." />
 
     <!-- Self-hosted Geist + JetBrains Mono (no external font CDN; see fonts.css) -->
     <link rel="stylesheet" href="fonts.css" />
@@ -97,7 +97,7 @@
             </p>
             <h1 id="hero-title" class="hero-title">
               Your prompt lifecycle,<br />
-              under control.
+              under version control.
             </h1>
             <p class="hero-sub">
               Specs in Git. Signed releases. Test harnesses for JUnit, pytest,


### PR DESCRIPTION
## Summary
Tightens the hero headline by making the closing pun explicit:

> Before:  **Your prompt lifecycle, under control.**
> After:   **Your prompt lifecycle, under version control.**

\"Version control\" carries double duty — it completes the \"under [X] control\" cadence and names the mechanism (Git) that the rest of the page is built around.

Also updates the `og:image:alt` / `twitter:image:alt` mirrors in `site/index.html` and `docs/templates/page.html` so social previews match.

## Test plan
- [ ] Pages deploy succeeds after merge.
- [ ] Hero on the live site reads \"…under version control.\"
- [ ] Social preview (Twitter / OG image-alt) reflects the new line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)