### PR TITLE
chore(pricing): refresh model catalog with current OpenAI/Anthropic models

### DIFF
--- a/apps/promptlm-webapp/src/main/resources/application.yml
+++ b/apps/promptlm-webapp/src/main/resources/application.yml
@@ -61,7 +61,13 @@ promptlm:
         input-per-million: 0.15
         output-per-million: 0.60
       # --- OpenAI: reasoning models ---
+      # The current OpenAI Java SDK exposes o3 only as the dated form, so the
+      # dated id is what gets persisted on PromptSpec.request.model. The bare
+      # `o3` key stays as forward-compat for an SDK bump that adds the alias.
       o3:
+        input-per-million: 2.00
+        output-per-million: 8.00
+      o3-2025-04-16:
         input-per-million: 2.00
         output-per-million: 8.00
       o3-mini:

--- a/apps/promptlm-webapp/src/main/resources/application.yml
+++ b/apps/promptlm-webapp/src/main/resources/application.yml
@@ -20,34 +20,83 @@ promptlm:
       token: ${REPO_REMOTE_TOKEN:}
       base-url: ${REPO_REMOTE_URL}
       allow-loopback-host-aliases: ${REPO_REMOTE_ALLOW_LOOPBACK_HOST_ALIASES:true}
-  # Issue #182: per-model USD pricing. Values are per *million* tokens (consistent
-  # with vendor public pricing pages). Unknown models are deliberately left out
-  # so the UI hides the cost chip rather than showing a misleading $0.00.
-  # Prices below are illustrative defaults that should be reviewed against the
-  # current vendor pricing tables before release.
+  # Issue #182/#216: per-model USD pricing. Values are per *million* tokens
+  # (consistent with vendor public pricing pages). Unknown models are
+  # deliberately left out so the UI hides the cost chip rather than showing
+  # a misleading $0.00. The set below mirrors the vendor SDKs we ship with
+  # (Spring AI OpenAI / Anthropic), plus aliases for the short canonical
+  # form. Lookup is exact (case-insensitive, vendor-prefix tolerant) — see
+  # ModelPricingService#lookup. Review prices against the current vendor
+  # pricing tables before each release.
+  #
+  # Older entries are intentionally retained so replays of historical
+  # executions still show a cost; they should not be removed even after
+  # the vendor deprecates the model.
   pricing:
     models:
-      gpt-4o:
-        input-per-million: 2.50
+      # --- OpenAI: current generation (gpt-5 family) ---
+      gpt-5:
+        input-per-million: 1.25
         output-per-million: 10.00
-      gpt-4o-mini:
-        input-per-million: 0.15
-        output-per-million: 0.60
+      gpt-5-mini:
+        input-per-million: 0.25
+        output-per-million: 2.00
+      gpt-5-nano:
+        input-per-million: 0.05
+        output-per-million: 0.40
+      # --- OpenAI: previous generation (kept for historical executions) ---
       gpt-4.1:
         input-per-million: 2.00
         output-per-million: 8.00
       gpt-4.1-mini:
         input-per-million: 0.40
         output-per-million: 1.60
+      gpt-4.1-nano:
+        input-per-million: 0.10
+        output-per-million: 0.40
+      gpt-4o:
+        input-per-million: 2.50
+        output-per-million: 10.00
+      gpt-4o-mini:
+        input-per-million: 0.15
+        output-per-million: 0.60
+      # --- OpenAI: reasoning models ---
+      o3:
+        input-per-million: 2.00
+        output-per-million: 8.00
+      o3-mini:
+        input-per-million: 1.10
+        output-per-million: 4.40
+      o4-mini:
+        input-per-million: 1.10
+        output-per-million: 4.40
+
+      # --- Anthropic: current generation (Claude 4.x) ---
+      claude-opus-4-5:
+        input-per-million: 15.00
+        output-per-million: 75.00
+      claude-opus-4-7:
+        input-per-million: 15.00
+        output-per-million: 75.00
+      claude-sonnet-4-5:
+        input-per-million: 3.00
+        output-per-million: 15.00
+      claude-sonnet-4-6:
+        input-per-million: 3.00
+        output-per-million: 15.00
+      claude-haiku-4-5:
+        input-per-million: 1.00
+        output-per-million: 5.00
+      # --- Anthropic: previous generation (kept for historical executions) ---
+      claude-3-7-sonnet:
+        input-per-million: 3.00
+        output-per-million: 15.00
       claude-3-5-sonnet:
         input-per-million: 3.00
         output-per-million: 15.00
       claude-3-5-haiku:
         input-per-million: 0.80
         output-per-million: 4.00
-      claude-3-7-sonnet:
-        input-per-million: 3.00
-        output-per-million: 15.00
 
 spring:
   ai:


### PR DESCRIPTION
Closes #216 (partial — see "Out of scope" below).

## Summary
- Add gpt-5 family, reasoning models (o3 / o3-mini / o4-mini), and the Claude 4.x family (opus 4.5/4.7, sonnet 4.5/4.6, haiku 4.5) to `promptlm.pricing.models`.
- Retain prior entries so historical executions still render a cost.
- Document the source-of-truth for the model dropdown in the inline comment.

## Why this is the fix for the user's symptoms (#5/#6/#7 in the original triage)
`ModelPricingService#computeCost` returns `Optional.empty()` for unknown models, and `ExecutionResponseDto.from()` omits `costUsd` via `@JsonInclude(NON_NULL)`. The UI then hides the cost chip and (when the vendor call also fails on an unknown model) shows "no response captured" + 0 tokens. Stale pricing keys cascade into three apparent bugs; refreshing them unblocks the chain.

## Out of scope
The model **dropdown** is sourced from `SpringAiVendorClient#catalogModels()` via reflection over the vendor SDK enums — surfacing newly released models in the picker requires bumping the Spring AI dependency, not editing yaml. Tracking that follow-up in #216 if needed.

## Test plan
- [x] `mvn -pl components/promptlm-web-api test -Dtest=ModelPricingServiceTest,PromptSpecApiViewCostTest,ModelCatalogServiceTest` (16/16 pass)
- [ ] Re-run the Happy Path with a current model selected — verify token + cost chips populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)