### PR TITLE
fix(prompt-editor): preserve caret when inserting placeholder from rail

### DIFF
--- a/components/ui/src/prompts-v2/form/atoms.tsx
+++ b/components/ui/src/prompts-v2/form/atoms.tsx
@@ -379,6 +379,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
 export interface GhostButtonProps {
   children: React.ReactNode;
   onClick?: () => void;
+  onMouseDown?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   danger?: boolean;
   mini?: boolean;
   disabled?: boolean;
@@ -389,6 +390,7 @@ export interface GhostButtonProps {
 export const GhostButton: React.FC<GhostButtonProps> = ({
   children,
   onClick,
+  onMouseDown,
   danger,
   mini,
   disabled,
@@ -397,6 +399,7 @@ export const GhostButton: React.FC<GhostButtonProps> = ({
 }) => (
   <button
     onClick={onClick}
+    onMouseDown={onMouseDown}
     type={type}
     disabled={disabled}
     data-testid={testId}

--- a/components/ui/src/prompts-v2/form/sections.tsx
+++ b/components/ui/src/prompts-v2/form/sections.tsx
@@ -694,6 +694,11 @@ export const RailPlaceholders: React.FC<RailPlaceholdersProps> = ({
                   {onInsertPlaceholder ? (
                     <GhostButton
                       mini
+                      // Preserve the focused message textarea's caret across
+                      // the click — without preventDefault on mousedown the
+                      // textarea blurs first, which clears the selection ref
+                      // that the insert handler relies on. See #217.
+                      onMouseDown={(event) => event.preventDefault()}
                       onClick={() => onInsertPlaceholder(ph.name)}
                       disabled={!ph.name}
                       testId={


### PR DESCRIPTION
Closes #217.

## Summary
- Rail "Insert" button gained focus on mousedown, blurring the active message textarea **before** the click handler ran. The textarea's `onBlur` cleared the caret selection ref that `PromptFormShell` reads, so the insert handler always saw `null` and reported "place the cursor in the editor".
- Fix: `onMouseDown={(e) => e.preventDefault()}` on the rail Insert button keeps focus on the textarea through the click; the caret selection ref stays populated.
- Add an optional `onMouseDown` prop to `GhostButton` so the rail can wire this without forking the component.

This is a regression introduced by #187 (PR #196).

## Test plan
- [x] `npm --workspace @promptlm/web-ui run test` (206/206 pass)
- [ ] Manual: focus user-prompt textarea → click rail "Insert" → placeholder appears at the caret position. Verify via the Playwright case the issue calls for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)