### PR TITLE
feat(projects): show local path with mid-ellipsis + copy button on card

### DIFF
--- a/components/promptlm-web-ui/src/pages/Projects.tsx
+++ b/components/promptlm-web-ui/src/pages/Projects.tsx
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Fragment, useMemo, useState } from 'react';
+import { Fragment, useMemo, useState, type MouseEvent } from 'react';
 import { Button } from '@promptlm/ui';
 import { Badge } from '@promptlm/ui';
-import { Plus, FolderOpen, FileText, Clock, Loader2, RefreshCw } from 'lucide-react';
+import { Plus, FolderOpen, FileText, Clock, Loader2, RefreshCw, Copy, Check } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { AlertTriangle } from 'lucide-react';
+import { truncateMiddlePath } from '@/utils/path';
 import {
   compareProjectsByUpdatedAt,
   getProjectSelectionBlockedReason,
@@ -32,6 +33,52 @@ import { ProjectModal } from '@/components/projects/ProjectModal';
 import { useProjects } from '@/api/hooks';
 import { useProjectsContext } from '@api-common/projects/ProjectsContext';
 import { useToast } from '@/hooks/use-toast';
+
+function LocalPathChip({ path }: { path: string }) {
+  const [copied, setCopied] = useState(false);
+  const display = truncateMiddlePath(path, 36);
+
+  const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+    // The chip sits inside the clickable card; don't trigger project
+    // selection when the user just wants to copy the path.
+    event.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(path);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard may be denied (e.g. insecure context). Swallow silently
+      // — the path is still visible and selectable via the tooltip.
+    }
+  };
+
+  return (
+    <div className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span
+        className="truncate font-mono"
+        title={path}
+        data-testid="project-card-local-path"
+      >
+        {display}
+      </span>
+      <button
+        type="button"
+        onClick={handleCopy}
+        onMouseDown={(event) => event.stopPropagation()}
+        aria-label={copied ? 'Path copied' : 'Copy local path'}
+        title={copied ? 'Copied' : 'Copy path'}
+        data-testid="project-card-copy-path"
+        className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+      >
+        {copied ? (
+          <Check className="h-3 w-3 text-emerald-500" />
+        ) : (
+          <Copy className="h-3 w-3" />
+        )}
+      </button>
+    </div>
+  );
+}
 
 export default function Projects() {
   const [modalOpen, setModalOpen] = useState(false);
@@ -148,8 +195,12 @@ export default function Projects() {
                           {project.description}
                         </p>
                       )}
+                      {project.localPath && <LocalPathChip path={project.localPath} />}
                       {project.repositoryUrl && (
-                        <p className="mt-2 text-xs text-muted-foreground truncate">
+                        <p
+                          className="mt-1 text-xs text-muted-foreground/80 truncate"
+                          title={project.repositoryUrl}
+                        >
                           {project.repositoryUrl}
                         </p>
                       )}

--- a/components/promptlm-web-ui/src/utils/__tests__/path.test.ts
+++ b/components/promptlm-web-ui/src/utils/__tests__/path.test.ts
@@ -1,0 +1,62 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+
+import { truncateMiddlePath } from '../path';
+
+describe('truncateMiddlePath', () => {
+  it('returns short paths unchanged', () => {
+    expect(truncateMiddlePath('~/dev/foo', 40)).toBe('~/dev/foo');
+    expect(truncateMiddlePath('/short/path', 40)).toBe('/short/path');
+  });
+
+  it('preserves the leading tilde and the last two segments', () => {
+    expect(
+      truncateMiddlePath('~/work/clients/acme/repo/main', 25),
+    ).toBe('~/…/repo/main');
+  });
+
+  it('preserves the root segment for absolute paths', () => {
+    expect(
+      truncateMiddlePath('/Users/fk/dev/promptLM/promptlm-app', 25),
+    ).toBe('/Users/…/promptLM/promptlm-app');
+  });
+
+  it('returns the original when there is nothing meaningful to elide', () => {
+    // Only two segments — no middle to collapse.
+    expect(truncateMiddlePath('/Users/fk', 5)).toBe('/Users/fk');
+  });
+
+  it('handles Windows-style separators', () => {
+    expect(
+      truncateMiddlePath('C:\\Users\\fk\\dev\\promptLM\\promptlm-app', 25),
+    ).toBe('C:\\…\\promptLM\\promptlm-app');
+  });
+
+  it('returns opaque strings unchanged (let CSS handle them)', () => {
+    const long = 'a'.repeat(60);
+    expect(truncateMiddlePath(long, 20)).toBe(long);
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(truncateMiddlePath('', 40)).toBe('');
+  });
+
+  it('respects a custom tailSegments count', () => {
+    expect(
+      truncateMiddlePath('/a/b/c/d/e/f/g/h', 10, 3),
+    ).toBe('/a/…/f/g/h');
+  });
+});

--- a/components/promptlm-web-ui/src/utils/path.ts
+++ b/components/promptlm-web-ui/src/utils/path.ts
@@ -1,0 +1,69 @@
+// Copyright 2025 promptLM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const ELLIPSIS = '…';
+
+/**
+ * Shorten a filesystem path for display by collapsing intermediate segments
+ * into a single ellipsis, preserving the leading `~` or root segment and the
+ * trailing `tailSegments` (default 2) segments. When the input is already
+ * shorter than `maxLength`, it's returned unchanged. When there is not
+ * enough path structure to elide meaningfully, the original is returned —
+ * callers can layer CSS truncation on top for those edge cases.
+ *
+ * Examples (with default maxLength=40, tailSegments=2):
+ *   "~/dev/promptLM/promptlm-app"             → "~/dev/promptLM/promptlm-app"
+ *   "/Users/fk/dev/promptLM/promptlm-app"     → "/Users/…/promptLM/promptlm-app"
+ *   "~/work/clients/acme/repo/main"           → "~/…/repo/main"
+ */
+export function truncateMiddlePath(
+  path: string,
+  maxLength: number = 40,
+  tailSegments: number = 2,
+): string {
+  if (!path) {
+    return '';
+  }
+  if (path.length <= maxLength) {
+    return path;
+  }
+
+  const hasBackslash = path.includes('\\');
+  const hasForward = path.includes('/');
+  const separator = hasBackslash && !hasForward ? '\\' : '/';
+
+  const segments = path.split(separator).filter((segment) => segment.length > 0);
+  const isAbsolute = path.startsWith(separator);
+  const isTilde = path.startsWith('~');
+
+  let head: string;
+  let bodySegments: string[];
+  if (isTilde) {
+    head = '~';
+    bodySegments = segments[0] === '~' ? segments.slice(1) : segments;
+  } else if (segments.length === 0) {
+    return path;
+  } else {
+    head = segments[0];
+    bodySegments = segments.slice(1);
+  }
+
+  if (bodySegments.length <= tailSegments) {
+    return path;
+  }
+
+  const tail = bodySegments.slice(-tailSegments);
+  const leadingSep = isAbsolute ? separator : '';
+  return `${leadingSep}${head}${separator}${ELLIPSIS}${separator}${tail.join(separator)}`;
+}


### PR DESCRIPTION
Closes #219.

## Summary
- Projects view rendered only `repositoryUrl`. Add the local path as a chip on each card with a Copy icon that writes the full path to the clipboard and flips to a tick for 1.5s. Hover reveals the untruncated path via `title`.
- `truncateMiddlePath` keeps the leading `~` or root segment and the last 2 components, collapsing everything in between to a single `…`. Handles Windows separators, returns the original when there isn't enough structure to elide, and short paths pass through unchanged.
- The copy button stops propagation on mousedown + click so the parent card's project-selection handler doesn't fire when you just want the path.

## Test plan
- [x] `npm --workspace @promptlm/web-ui run test` (206/206 pass, including 8 new tests for `truncateMiddlePath`)
- [ ] Manual: visual check in projects view; verify copy → paste round-trip and the "Copied" indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)