### PR TITLE
build: split parent POM into dedicated promptlm-platform repo

### DIFF
--- a/apps/promptlm-cli/pom.xml
+++ b/apps/promptlm-cli/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/apps/promptlm-webapp/pom.xml
+++ b/apps/promptlm-webapp/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
 
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-core/pom.xml
+++ b/components/promptlm-core/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-domain/pom.xml
+++ b/components/promptlm-domain/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-evaluation/pom.xml
+++ b/components/promptlm-evaluation/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-execution-litellm/pom.xml
+++ b/components/promptlm-execution-litellm/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-execution-springai/pom.xml
+++ b/components/promptlm-execution-springai/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-execution/pom.xml
+++ b/components/promptlm-execution/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-lifecycle/pom.xml
+++ b/components/promptlm-lifecycle/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-openapi-examples/pom.xml
+++ b/components/promptlm-openapi-examples/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-rest-docs/pom.xml
+++ b/components/promptlm-rest-docs/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-store/pom.xml
+++ b/components/promptlm-store/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-template/pom.xml
+++ b/components/promptlm-template/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/promptlm-web-api/pom.xml
+++ b/components/promptlm-web-api/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/components/repository-template/pom.xml
+++ b/components/repository-template/pom.xml
@@ -5,7 +5,7 @@
 
     <parent>
         <groupId>dev.promptlm</groupId>
-        <artifactId>promptlm-parent</artifactId>
+        <artifactId>promptlm-app</artifactId>
         <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/docs/proposals/shared-build-governance.md
+++ b/docs/proposals/shared-build-governance.md
@@ -1,0 +1,98 @@
+# Shared build governance across promptLM repositories
+
+**Status:** Proposal — for team discussion
+**Author:** Fabian
+**Date:** 2026-05-20
+
+## Why now
+
+Spring Boot versions drifted between `promptlm-app` and one of the sibling
+repos last week, and the mismatch only surfaced at integration time. The
+current `promptlm-parent` POM is local to `promptlm-app` and is not
+inherited by the other repos (`promptlm-client-sdk`,
+`promptlm-integrations`, `promptlm-test-support`,
+`promptlm-gitea-artifactory`, `promptlm-evals`, …), so there is no
+structural mechanism preventing the next drift.
+
+This proposal asks the team to make three independent decisions.
+
+---
+
+## Decision 1 — What artifacts to ship
+
+| Option | Summary |
+|---|---|
+| A. Parent POM only | One inheritable POM owns build policy *and* dependency versions. |
+| **B. Parent POM + BOM (recommended)** | `promptlm-parent` owns build policy; `promptlm-bom` owns dependency versions. Internal libs inherit the parent; everyone imports the BOM. |
+| C. Combined "platform" POM | One artifact does both jobs; conflates concerns. |
+| D. Status quo + discipline | What we have today; the drift we just hit. |
+
+**Recommendation: B.** Industry standard (Spring Boot, Spring Cloud,
+Quarkus, AWS SDK). Build policy and dependency versions evolve at
+different cadences, and external consumers can import the BOM without
+being forced to inherit our compiler/plugin policy.
+
+**Trade-off:** one extra artifact to release. Cheap once automated.
+
+---
+
+## Decision 2 — Release-train cadence
+
+| Option | Summary |
+|---|---|
+| **Calver train (recommended)** | `2026.05.0`, `2026.05.1`, … on a predictable schedule. Spring Cloud / Jakarta EE model. |
+| Semver-on-the-BOM | BOM has its own semver; majors mark breaking changes anywhere in the platform. Quarkus / Micronaut model. |
+| Independent semver, no train | What we have. Combinatorial "which versions go together?" problem. |
+
+**Recommendation: Calver, quarterly, starting once we have the parent +
+BOM in place.** We don't need a train yet for two repos, but committing
+to one now means the BOM has a clear cadence story before we add the
+fifth library.
+
+Soft decision — we can defer until we have >3 active downstream
+consumers, but "no train at all" is the wrong answer long-term.
+
+---
+
+## Decision 3 — Repo layout
+
+| Option | Summary |
+|---|---|
+| Monorepo for parent + BOM + all libraries | Atomic cross-repo bumps; larger repo, harder external access. |
+| **Dedicated `promptlm-platform` repo (recommended)** | Parent + BOM live in their own small repo. Libraries stay independent. |
+| Parent + BOM inside one library (e.g. `promptlm-core`) | One fewer repo, but couples platform release to that library. |
+| Hybrid (BOM auto-derived in CI) | Most moving parts. Overkill at current scale. |
+
+**Recommendation: dedicated `promptlm-platform` repo.** Clear ownership,
+small surface, can have its own reviewers and cadence. We are not at
+monorepo scale and probably won't be for a while.
+
+---
+
+## Migration path
+
+**Incremental, not big-bang:**
+
+1. Cut `promptlm-platform` repo with `promptlm-parent` (extracted from
+   `promptlm-app`) and an initial `promptlm-bom`.
+2. Tag `1.0.0` of both, publish to the Gitea artifactory.
+3. `promptlm-app` migrates first (proves the loop).
+4. Each sibling repo migrates the next time it ships a release. No
+   forced cutover.
+5. Once all internal repos are on the BOM, publish externally for SDK
+   consumers.
+
+---
+
+## Open questions for the team call
+
+1. **Diagnosis confirmation** — does everyone agree the Spring Boot
+   drift was structural, not a one-off?
+2. **Decision 1** — adopt parent + BOM (B)?
+3. **Decision 2** — commit to a Calver train now, or defer?
+4. **Decision 3** — dedicated platform repo?
+5. **Ownership** — who is empowered to say "no" to dependency bumps
+   that aren't part of a planned train? (Suggest: Fabian + Vitor as
+   joint platform owners; one approval required.)
+6. **Public vs private** — `promptlm-platform` public from day one, or
+   private until the external SDK lands?

--- a/pom.xml
+++ b/pom.xml
@@ -3,29 +3,19 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>dev.promptlm</groupId>
-    <artifactId>promptlm-parent</artifactId>
+    <parent>
+        <groupId>dev.promptlm</groupId>
+        <artifactId>promptlm-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../promptlm-platform/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>promptlm-app</artifactId>
     <version>0.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <properties>
-        <java.version>21</java.version>
-        <maven.compiler.release>21</maven.compiler.release>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.scm.id>github</project.scm.id>
-        <api.key>${env.OPENAI_API_KEY}</api.key>
-        <argLine></argLine>
-        <surefire.extraArgs></surefire.extraArgs>
-        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
-        <spring-boot.version>4.0.6</spring-boot.version>
-        <spring-ai.version>2.0.0-M5</spring-ai.version>
-        <native.maven.plugin.version>0.11.5</native.maven.plugin.version>
-        <spring-modulith.version>2.0.6</spring-modulith.version>
-        <spring-boot-maven-plugin.version>4.0.6</spring-boot-maven-plugin.version>
-        <promptlm-gitea-artifactory.version>1.2.0</promptlm-gitea-artifactory.version>
-        <swagger-annotations.version>2.2.50</swagger-annotations.version>
-    </properties>
+    <name>promptLM App</name>
+    <description>Aggregator for promptLM application components and apps.</description>
 
     <modules>
         <module>components/promptlm-domain</module>
@@ -66,120 +56,4 @@
             <url>https://maven.pkg.github.com/promptlm/promptlm-app</url>
         </snapshotRepository>
     </distributionManagement>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.ai</groupId>
-                <artifactId>spring-ai-bom</artifactId>
-                <version>${spring-ai.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-annotations</artifactId>
-                <version>${swagger-annotations.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.modulith</groupId>
-                <artifactId>spring-modulith-starter-core</artifactId>
-                <version>${spring-modulith.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.modulith</groupId>
-                <artifactId>spring-modulith-runtime</artifactId>
-                <version>${spring-modulith.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.modulith</groupId>
-                <artifactId>spring-modulith-events-api</artifactId>
-                <version>${spring-modulith.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit-pioneer</groupId>
-            <artifactId>junit-pioneer</artifactId>
-            <version>2.3.0</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>${spring-boot-maven-plugin.version}</version>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>${maven-jar-plugin.version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>3.3.1</version>
-                <configuration>
-                    <tagNameFormat>v@{project.version}</tagNameFormat>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <argLine>${argLine} ${surefire.extraArgs}</argLine>
-                    <systemPropertyVariables>
-                        <apiKey>${api.key}</apiKey>
-                        <junit.jupiter.tags.exclude>manual</junit.jupiter.tags.exclude>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <profiles>
-        <profile>
-            <id>github</id>
-        </profile>
-        <profile>
-            <id>enable-dynamic-agent-loading</id>
-            <activation>
-                <jdk>[21,)</jdk>
-            </activation>
-            <properties>
-                <surefire.extraArgs>-XX:+EnableDynamicAgentLoading</surefire.extraArgs>
-            </properties>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
## Summary

- Extracts `dev.promptlm:promptlm-parent` out of this repo and into the new [promptlm-platform](https://github.com/promptLM/promptlm-platform) repo.
- Root `pom.xml` becomes a thin aggregator (`dev.promptlm:promptlm-app:0.2.0-SNAPSHOT`) that inherits build policy, plugin management, shared test deps, and `<dependencyManagement>` from the new parent.
- 15 child poms repointed: `<parent><artifactId>promptlm-parent</artifactId></parent>` → `<parent><artifactId>promptlm-app</artifactId></parent>`. `<relativePath>` unchanged.
- Adds `docs/proposals/shared-build-governance.md` capturing the three decisions (artifact shape, release cadence, repo layout) discussed with the team.

## Why

Spring Boot versions drifted between this repo and a sibling library last week, only surfacing at integration time. The current parent POM is local to `promptlm-app` and is not shared with sibling repos, so there is no structural mechanism preventing the next drift. Extracting the parent into its own repo is the smallest reversible step that fixes the root cause and unblocks the BOM follow-up.

## Dry-run resolution

During this dry-run the new parent is resolved via a sibling-directory `<relativePath>../promptlm-platform/pom.xml</relativePath>`. Once `promptlm-parent:1.0.0` is published to GitHub Packages (`https://maven.pkg.github.com/promptlm/promptlm-platform`) the `<relativePath>` line can be dropped or set to `<relativePath/>` to force a remote lookup.

**This PR should not merge until `promptlm-parent:1.0.0` is published**, otherwise CI without the sibling checkout will fail.

## Verification done locally

- `./mvnw -N validate` — clean.
- `./mvnw validate` — full 18-module reactor SUCCESS.
- `./mvnw dependency:resolve -pl components/promptlm-domain -am` — clean. Confirms `<dependencyManagement>` from the new parent is inherited through the aggregator down to leaf modules (Spring Boot / Spring AI / Modulith BOMs flow correctly).

## Test plan

- [ ] Publish `promptlm-parent:1.0.0` from [promptlm-platform](https://github.com/promptLM/promptlm-platform) to GitHub Packages.
- [ ] Bump the `<parent><version>` in this PR from `1.0.0-SNAPSHOT` to `1.0.0` and drop `<relativePath>`.
- [ ] Trigger this repo's CI to confirm it can resolve the parent from GitHub Packages.
- [ ] Smoke: build a leaf module (e.g. `promptlm-domain`) and verify Spring Boot version still resolves to 4.0.6.

## Follow-ups

- #222 — `acceptance-tests/pom.xml` opt-in to the new parent.
- Add `promptlm-bom` (dependency-version BOM) as a second module in the platform repo (Decision 1B from the proposal doc).
- Onboard sibling repos (`promptlm-client-sdk`, `promptlm-integrations`, `promptlm-test-support`, `promptlm-evals`) one at a time on their next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)