### PR TITLE
fix(acceptance): BackendFacadeInfraE2eTest MissingNode.asText on missing JSON path

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/BackendFacadeInfraE2eTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/BackendFacadeInfraE2eTest.java
@@ -105,9 +105,12 @@ class BackendFacadeInfraE2eTest {
                     assertThat(contextFile).isRegularFile();
                     JsonNode context = JSON_MAPPER.readTree(Files.readString(contextFile));
                     assertThat(context.path("projects").isArray()).isTrue();
+                    // context.json stores activeProject as an id-only reference; full metadata lives in projects[].
                     assertThat(context.path("activeProject").path("id").asText()).isEqualTo(projectId);
-                    assertThat(context.path("activeProject").path("localPath").asText()).isEqualTo(localPath.toString());
-                    assertThat(context.path("activeProject").path("repositoryUrl").asText()).isEqualTo(repositoryUrl);
+                    JsonNode activeProjectEntry = findProjectById(context.path("projects"), projectId);
+                    assertThat(activeProjectEntry).as("activeProject entry in projects[]").isNotNull();
+                    assertThat(activeProjectEntry.path("localPath").asText()).isEqualTo(localPath.toString());
+                    assertThat(activeProjectEntry.path("repositoryUrl").asText()).isEqualTo(repositoryUrl);
                 });
 
         Path metadataFile = localPath.resolve(".promptlm/metadata.json");
@@ -388,6 +391,18 @@ class BackendFacadeInfraE2eTest {
                                 gitea.getAdminToken()
                         ),
                         Optional::isPresent);
+    }
+
+    private static JsonNode findProjectById(JsonNode projectsArray, String projectId) {
+        if (projectsArray == null || !projectsArray.isArray()) {
+            return null;
+        }
+        for (JsonNode entry : projectsArray) {
+            if (projectId.equals(entry.path("id").asText())) {
+                return entry;
+            }
+        }
+        return null;
     }
 
     private String uniqueRepoName(String prefix) {


### PR DESCRIPTION
## Root cause

`BackendFacadeInfraE2eTest#shouldPersistActiveProjectContextAndRepositoryMetadataWhenStoreIsCreatedViaApi` was reading `activeProject.localPath` and `activeProject.repositoryUrl` from `~/.promptlm/context.json`. The context.json wire format was intentionally narrowed in #138/#181 (`refactor(context): reference activeProject by id in context.json`) so that `activeProject` is now serialized as an id-only reference object (`{"id": "<uuid>"}`), with full project metadata living in `projects[]`.

In Jackson 3.x the missing-node access surfaces as the new error message in the CI failure:

```
tools.jackson.databind.exc.JsonNodeException: 'MissingNode' method `asString()` cannot convert value <missing> to `java.lang.String`
```

(Jackson 2.x silently returned an empty string from `asText()` on a missing node, masking the same bug.)

## Diff explanation

- `BackendFacadeInfraE2eTest.java`: still asserts `activeProject.id` matches the created project, then looks up the same id inside `context.projects[]` and asserts `localPath` and `repositoryUrl` against that entry. This matches the documented wire format in `SerializingAppContext#toWireFormat`. Added a small `findProjectById` helper. No production code changed; backend contract preserved.

## Test verification

Ran locally against a Gitea testcontainer:

```
mvn -B -f acceptance-tests/pom.xml \
  -Dtest='BackendFacadeInfraE2eTest#shouldPersistActiveProjectContextAndRepositoryMetadataWhenStoreIsCreatedViaApi' \
  -Dpromptlm.bootstrap.skip=true test
...
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 40.49 s -- in dev.promptlm.test.BackendFacadeInfraE2eTest
[INFO] BUILD SUCCESS
```

## Test plan

- [ ] CI green on `acceptance-tests` job for the targeted test (and no regression on the other tests in that class).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>