### PR TITLE
fix(acceptance): CiWorkflowHarnessTest — workflow conclusion failure

### DIFF
--- a/components/repository-template/repo-resources/scripts/validate-prompts.sh
+++ b/components/repository-template/repo-resources/scripts/validate-prompts.sh
@@ -19,8 +19,12 @@
 # Exits non-zero with a clear message if:
 #   - prompts/ is missing or contains no files
 #   - any file under prompts/ is empty (zero-byte or whitespace-only)
-#   - any promptlm.yml / promptlm.yaml file is missing one of the required fields:
-#       id, name, group, version, request
+#   - any per-prompt promptlm.yml / promptlm.yaml manifest under prompts/ is
+#     missing one of the required fields: id, name, group, version, request
+#
+# The repository-level configuration file at <repo>/promptlm.yml (release
+# toggle, provider, …) is intentionally NOT validated by this script — it has
+# a different schema and lives outside `prompts/`.
 #
 # Exits 0 on success with a summary of what was validated.
 #
@@ -74,7 +78,11 @@ if [[ -n "${empty_files}" ]]; then
     exit 1
 fi
 
-# 3. Every promptlm.yml / promptlm.yaml file must declare the required fields.
+# 3. Every per-prompt promptlm.yml / promptlm.yaml manifest must declare the
+#    required fields. The repository-level `<repo>/promptlm.yml` is a
+#    configuration file (release toggle, provider, …) and is intentionally
+#    excluded — it has a different schema and lives at the repo root, not
+#    under `prompts/`.
 promptlm_count=0
 missing_fields_report=""
 while IFS= read -r -d '' f; do
@@ -93,7 +101,7 @@ while IFS= read -r -d '' f; do
     if [[ -n "${missing}" ]]; then
         missing_fields_report+="${f}: missing ${missing}"$'\n'
     fi
-done < <(find "${REPO_ROOT}" -type f \( -name 'promptlm.yml' -o -name 'promptlm.yaml' \) -print0)
+done < <(find "${PROMPTS_DIR}" -type f \( -name 'promptlm.yml' -o -name 'promptlm.yaml' \) -print0)
 
 if [[ -n "${missing_fields_report}" ]]; then
     {


### PR DESCRIPTION
## Summary

`CiWorkflowHarnessTest.shouldExecuteCiWorkflowAndPublishArtifacts` has been failing on every PR that touches `components/repository-template/**` (or otherwise opts into Acceptance Tests) since #161 + #163 merged on May 17. The workflow run that the test orchestrates inside the in-process Gitea container reaches `conclusion=failure` ~10s after the seed commit — well before any Maven build could even start — and the test asserts `expected: "success" but was: "failure"` at `CiWorkflowHarnessTest.java:202`.

## Which Gitea workflow step was failing

Two workflows shipped in `repo-template.zip` trigger on `push`:

- `.github/workflows/validate.yml` → runs `scripts/validate-prompts.sh`
- `.github/workflows/deploy-artifactory.yml` → runs `mvn clean verify` inside `maven:3.9.9-eclipse-temurin-21`

`validate.yml` terminates in seconds. `deploy-artifactory.yml` takes minutes. `GiteaActions#waitForWorkflowRunBySha` returns the first SHA-matching **terminal** run — so the test asserts on `validate.yml`.

`scripts/validate-prompts.sh` does, among other things, this:

```bash
while IFS= read -r -d '' f; do
    …
done < <(find "${REPO_ROOT}" -type f \( -name 'promptlm.yml' -o -name 'promptlm.yaml' \) -print0)
```

It walks the **whole repo root** for any file named `promptlm.yml` and requires each to declare the per-prompt manifest schema: `id`, `name`, `group`, `version`, `request`.

PR #161 then introduced a repository-level configuration file at `<repo>/promptlm.yml` that has a completely different schema (release toggle, provider, trigger, artifact, versioning, validation):

```yaml
release:
  enabled: false
  provider: github-actions
  …
```

This file is shipped inside `repo-template.zip` and so lands at the repo root of the seeded Gitea repository. As soon as the seed commit is pushed, `validate.yml` runs, `validate-prompts.sh` finds the repo-level `promptlm.yml`, none of the five required fields are present, and the workflow exits 1.

Pre-fix log excerpt, reproduced locally against the fixture:

```
validate-prompts: ERROR: promptlm.y(a)ml files missing required fields:
  - /tmp/validate-test/promptlm.yml: missing id group version request
EXIT CODE: 1
```

Matching CI evidence from the most recent failing acceptance run (`26173650772`):

```
ERROR d.p.test.CiWorkflowHarnessTest - Workflow run terminated with conclusion=failure; dumping diagnostics before assertion
…
INFO  d.p.testutils.gitea.GiteaContainer - Actions diagnostics for testuser/template-repo:
  .gitea/workflows files=0, .github/workflows files=5
  names=build-artifacts.yml,deploy-artifactory.yml,deploy-artifacts.yml,release.yml,validate.yml,
  action runs=2
…
[ERROR] CiWorkflowHarnessTest.shouldExecuteCiWorkflowAndPublishArtifacts:154->assertSuccessfulWorkflowExecution:202
  [workflow run conclusion should be success]
  expected: "success" but was: "failure"
```

Total elapsed time between "Template repository seeded" and the failure assertion is ~30 s — far too short for `mvn -B clean verify` to even start downloading dependencies, consistent with `validate.yml` being the culprit, not `deploy-artifactory.yml`.

## Fix

Narrow `validate-prompts.sh` to only scan `${PROMPTS_DIR}` (i.e. `prompts/**`) when looking for prompt manifests. The repo-level `<repo>/promptlm.yml` lives at the repo root, outside `prompts/`, so it is no longer picked up. Per-prompt manifests under `prompts/**` continue to be validated as before. Header docstring updated to document the new scope.

## How verified

- Reproduced the pre-fix failure with a minimal sandbox (`/tmp/validate-test`) using the original `find ${REPO_ROOT}` semantics — exits 1 with the exact error.
- Ran the post-fix script against the actual template fixture (`components/repository-template/repo-resources`) — exits 0 with summary:
  ```
  validate-prompts: validated 1 prompt file(s) under prompts/
  validate-prompts: no promptlm.y(a)ml files found (skipping field check)
  validate-prompts: OK
  ```
- `mvn -B -pl components/repository-template test` — 18 tests, all pass.
- The full Gitea-backed `CiWorkflowHarnessTest` was **not** re-run locally (Docker / Gitea container time exceeds the budget for this fix). I'm opening this as a regular PR since the CI Acceptance Tests job will exercise it end-to-end — please flip to draft if you'd prefer me to verify locally first.

## Test plan

- [ ] CI `Acceptance Tests` workflow runs (touches `components/repository-template/**` → matches the `critical` paths filter) and `CiWorkflowHarnessTest.shouldExecuteCiWorkflowAndPublishArtifacts` passes.
- [ ] No other tests regress.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>