### PR TITLE
fix(acceptance): HappyPath shouldCreateNewPrompt races default-template hydration

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
@@ -149,15 +149,35 @@ public class HappyPathUserJourneyTest {
         // v2 UX: there is no global "Add" dropdown — the New prompt button lives in
         // the catalog top bar. Navigate to /prompts and click it directly.
         navigateToPath("/prompts");
-        page.getByTestId("create-prompt-button").click();
+        // The /prompts/new route fetches a server-side default template
+        // (GET /api/prompts/template) that asynchronously hydrates the form
+        // with sample values ("support-prompt", "customer_name" placeholder,
+        // etc.). If we start typing before that response lands, the template
+        // hydration overwrites our input AND flips the dirty-state guard,
+        // which then surfaces an "Unsaved changes" dialog that blocks every
+        // subsequent click (e.g. `placeholder-add-button`). Wait for the
+        // template request to finish *before* the click, then verify the
+        // hydration landed before we start filling.
+        page.waitForResponse(
+                response -> response.url().contains("/api/prompts/template")
+                        && response.status() == 200,
+                () -> page.getByTestId("create-prompt-button").click());
 
         // Verify we're in the prompt editor via unique heading test id
         Locator editorHeading = page.getByTestId("prompt-editor-heading");
         editorHeading.waitFor();
         assertThat(editorHeading.isVisible()).isTrue();
 
+        // Confirm the template has hydrated by waiting for the default
+        // "support-prompt" name to appear in the name input. After this we
+        // can safely fill — Playwright's .fill() clears then types so our
+        // values cleanly overwrite the template defaults.
+        Locator nameInput = page.getByTestId("prompt-name-input");
+        nameInput.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
+        waitForInputHydrated(nameInput, Duration.ofSeconds(30));
+
         // Fill the form
-        page.getByTestId("prompt-name-input").fill(PROMPT_NAME);
+        nameInput.fill(PROMPT_NAME);
         page.getByTestId("prompt-group-input").fill(GROUP);
         page.getByTestId("description-text").fill("Description of the prompt.");
         configureCustomPlaceholderDelimiters("[[", "]]");
@@ -453,6 +473,30 @@ public class HappyPathUserJourneyTest {
         valueEditor.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
         valueEditor.fill(value);
         valueEditor.press("Tab");
+    }
+
+    /**
+     * Wait until the given input has a non-empty value. The /prompts/new
+     * route loads a server-side default template asynchronously
+     * (GET /api/prompts/template) and hydrates the form. If the test types
+     * before that hydration lands, the template's `replaceState` clobbers
+     * the user input and the resulting dirty-state flip can surface an
+     * "Unsaved changes" dialog that blocks every subsequent click. Polling
+     * the visible input value is the most reliable proxy for "template
+     * applied" without coupling the test to internal React state.
+     */
+    private void waitForInputHydrated(Locator input, Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            String value = input.inputValue();
+            if (value != null && !value.isEmpty()) {
+                return;
+            }
+            page.waitForTimeout(100);
+        }
+        throw new IllegalStateException(
+                "Timed out waiting for prompt form template hydration (input still empty after "
+                        + timeout.toSeconds() + "s)");
     }
 
     private void insertPlaceholderToken(String placeholderName) {


### PR DESCRIPTION
## Root cause

The HappyPath acceptance test `shouldCreateNewPrompt` was timing out at `addPlaceholder("number_one")` (line 164 → line 436) because the form's default-template fetch was racing the test's typing:

1. The test navigates to `/prompts/new`, which mounts `PromptFormShell` and fires `GET /api/prompts/template` to load a sample prompt (`support-prompt` / `support` / `Assist support agents`, with a pre-populated `customer_name` placeholder).
2. The test fills the name/group/description inputs immediately. This makes the form dirty, so the #185 unsaved-changes guard pushes a sentinel history entry and installs a popstate handler.
3. The template fetch then resolves and `replaceState(template)` overwrites the user's input. `setBaseline(template)` flips `isDirty` back to `false`; the effect cleanup removes the listener AND calls `history.back()` on the still-current sentinel.
4. The next dirty fields (delimiter inputs `[[`, `]]`) trip the effect again, but on a now-fragile history; one race later the unsaved-changes dialog appears and covers the `placeholder-add-button`.
5. `addPlaceholder` calls `addButton.waitFor(VISIBLE)` — which passes since the button IS in the DOM behind the dialog — then `addButton.click()`, which hangs because the dialog blocks pointer events. After 5 minutes the JUnit method-level `@Timeout` fires.

The other three reported failures (`runPromptPersistsManualExecution`, `releasePrompt`, `releaseProject`) cascade from this: no prompt is ever saved, so the catalog row the next tests click doesn't exist, no release happens, no Gitea Actions workflow runs.

### Evidence

The CI failure screenshot from run [`26146307645`](https://github.com/promptLM/promptlm-app/actions/runs/26146307645) (nightly on `main`, 2026-05-20) shows the form filled with the template defaults (NAME=`support-prompt`, GROUP=`support`, DESCRIPTION=`Assist support agents`, placeholder `customer_na…`), and the **Unsaved changes** dialog covering the visible `+ Add` button. Trace shows the last action that completed was `Frame.fill placeholder-close-sequence-input` at 28815ms; the subsequent `Frame.click placeholder-add-button` never finished — screenshot taken 286 seconds later.

```
java.util.concurrent.TimeoutException: shouldCreateNewPrompt() timed out after 5 minutes
    at dev.promptlm.test.HappyPathUserJourneyTest.addPlaceholder(HappyPathUserJourneyTest.java:436)
    at dev.promptlm.test.HappyPathUserJourneyTest.shouldCreateNewPrompt(HappyPathUserJourneyTest.java:164)
```

## What changed

`acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java`:

- Wrap the `create-prompt-button` click in `page.waitForResponse(/api/prompts/template, …)` so the template request resolves **before** the click returns.
- After the editor heading appears, explicitly poll the name input's `inputValue()` until it's non-empty — a robust proxy for "React has applied the template via `replaceState`". Only then do we start filling.
- `.fill()` already clears-then-types, so the template defaults are cleanly overwritten by our test values. No race, no phantom dirty-flip, no dialog.

## What this does NOT touch

- `CiWorkflowHarnessTest` — that's Agent G's territory.
- The in-Gitea workflow (`components/repository-template/repo-resources/.github/workflows/deploy-artifactory.yml`) or the prompt-repo POM — the initial parent-POM hypothesis in the task brief turned out to be wrong for these failures. The prompt-repo POM has no `<parent>` at all, and the CI workflow that runs acceptance.yml already installs the platform parent via #237's composite action. The failures came from the late-template race on the create-prompt UI, not from a Maven resolution issue.

## Does this fix `CiWorkflowHarnessTest` too?

**No.** Different root cause. `CiWorkflowHarnessTest` exercises the in-Gitea Maven build directly (no prompt-creation UI involved). Whatever's wrong there is independent of the template-hydration race fixed here. Agent G's work covers it.

## Verification

- `mvn -B -f acceptance-tests/pom.xml -DskipTests test-compile` ✅ (BUILD SUCCESS)
- Full local run not attempted: the acceptance tests need a 30-min framework build + Gitea/Artifactory containers + `OPENAI_API_KEY` to drive real LLM calls, and the local Docker socket is in a flaky state per the user's known-issues memo. **Shipping as draft so CI's acceptance run can verify against the same conditions as the nightly that surfaced the regression.**

## Test plan

- [ ] CI's `Acceptance Tests` workflow runs against this branch and `shouldCreateNewPrompt` completes (no 5-minute timeout at line 164/436).
- [ ] The cascading failures (`runPromptPersistsManualExecution`, `releasePrompt`, `releaseProject`) clear as a side effect.
- [ ] No regression in `shouldValidateRequiredFields` (uses the same form route, but doesn't depend on hydration since validation fires regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)