### PR TITLE
D3: Move Gitea runner cleanup to @BeforeEach

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
@@ -116,6 +116,26 @@ public class HappyPathUserJourneyTest {
         page = playwrightSession.getPage();
     }
 
+    /**
+     * Reap stale Gitea Actions runner task containers from prior runs before every test.
+     * Otherwise stale containers from a failed prior test class can leak into earlier-ordered
+     * tests of the next run, where the mid-test cleanup never executes.
+     */
+    @BeforeEach
+    void cleanupStaleActionsRunnerContainers() {
+        if (gitea == null) {
+            // @BeforeAll has not run yet (or failed); nothing to clean.
+            return;
+        }
+        try {
+            int removed = gitea.cleanupActionsTaskContainers("workflow-prompt-repository-ci");
+            log.info("Removed {} stale CI Actions task container(s) before test.", removed);
+        } catch (RuntimeException exception) {
+            // Cleanup is best-effort; never fail a test because diagnostics housekeeping failed.
+            log.warn("Failed to clean stale CI Actions task containers before test: {}", exception.getMessage());
+        }
+    }
+
 
     @AfterAll
     void afterAll() {
@@ -493,10 +513,7 @@ public class HappyPathUserJourneyTest {
     private void waitUntilBuildSucceeded() {
         String workflowFile = System.getProperty("promptlm.gitea.actions.workflow.file", "deploy-artifactory.yml");
         try {
-            int removedCiTasks = gitea.cleanupActionsTaskContainers("workflow-prompt-repository-ci");
-            if (removedCiTasks > 0) {
-                log.info("Removed {} stale CI Actions task container(s) before deploy wait.", removedCiTasks);
-            }
+            // Stale runner-task container cleanup runs in @BeforeEach now (see cleanupStaleActionsRunnerContainers).
             gitea.logRepositoryActionsDiagnostics(repositoryOwner, REPO_NAME);
 
             Duration timeout = Duration.ofMinutes(12);


### PR DESCRIPTION
## Summary

- Refs #263 (Phase D3 of epic #248)
- Move `gitea.cleanupActionsTaskContainers("workflow-prompt-repository-ci")` out of `waitUntilBuildSucceeded()` and into a new `@BeforeEach` on `HappyPathUserJourneyTest`, so stale runner-task containers from a previously failed test class are reaped before *every* test — not only before `@Order(40) releaseProject`.

## Why

Before this PR the cleanup only ran inside the mid-test path of `@Order(40)`. If a prior run of the class died before that order, leaked Gitea Actions runner-task containers were not cleaned, and earlier-ordered tests of the *next* run inherited them. Moving the cleanup to `@BeforeEach` guarantees a clean slate per test method.

## Change shape

- New `@BeforeEach cleanupStaleActionsRunnerContainers()`:
  - No-op if `gitea` is null (i.e. `@BeforeAll` has not yet wired it, or failed).
  - Logs the removed count using the existing log pattern from `waitUntilBuildSucceeded`.
  - Wraps the call in try/catch so cleanup failures cannot fail a test.
- `waitUntilBuildSucceeded()` no longer calls the cleanup itself — left a one-line comment pointing at `@BeforeEach`. The surrounding try/catch with `logRepositoryActionsDiagnostics` + `logActionsRunnerDiagnostics` on failure is preserved.
- No other Java files modified.

`cleanupActionsTaskContainers` in `junit-gitea-artifactory` 1.2.0 does not actually require `actionsEnabled = true` to run — it just lists Docker containers and removes matches — so no `actionsEnabled` guard is needed. The class is annotated `@WithGitea(actionsEnabled = true)` anyway.

## Test plan

- [x] `mvn -f acceptance-tests/pom.xml test-compile` — BUILD SUCCESS, no warnings beyond the pre-existing `PlaywrightSession` deprecated-API warning.
- [ ] Did **not** run the HappyPath acceptance suite locally: Testcontainers/Docker spin-up of Gitea + Artifactory plus Playwright is expensive and the prior commit history flags this suite as flaky in local Docker environments. The change is a pure refactor of when an already-existing best-effort call fires, so the risk is contained. Recommend the standard nightly HappyPath run as the gating signal.
- [ ] Verify in the next nightly that the new log line `Removed N stale CI Actions task container(s) before test.` appears in `@Order(1..40)` logs (N=0 on fresh boxes, possibly >0 on re-runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)