### PR TITLE
D1: Adopt Awaitility for waitForArtifactoryDeployments

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/HappyPathUserJourneyTest.java
@@ -353,47 +353,55 @@ public class HappyPathUserJourneyTest {
     private JsonNode waitForArtifactoryDeployments() {
         Duration timeout = Duration.ofMinutes(12);
         Duration pollInterval = Duration.ofSeconds(5);
-        long deadline = System.nanoTime() + timeout.toNanos();
-        JsonNode lastDeployments = null;
-        JsonNode lastArchiveMetadata = null;
-        RuntimeException lastFetchError = null;
+        AtomicReference<JsonNode> lastDeployments = new AtomicReference<>();
+        AtomicReference<JsonNode> lastArchiveMetadata = new AtomicReference<>();
+        AtomicReference<RuntimeException> lastFetchError = new AtomicReference<>();
 
-        while (System.nanoTime() < deadline) {
-            try {
-                lastDeployments = ArtifactoryStorageHelper.fetchArtifactoryDeployments(HTTP_CLIENT, artifactoryContainer);
-                lastFetchError = null;
-                JsonNode children = lastDeployments.path("children");
-                if (children.isArray() && children.size() > 0) {
-                    lastArchiveMetadata = ArtifactoryStorageHelper.findFirstArtifactArchiveMetadata(HTTP_CLIENT, artifactoryContainer);
-                    if (lastArchiveMetadata != null) {
-                        String archivePath = lastArchiveMetadata.path("path").asText();
-                        log.info("Artifactory archive ready: {}", archivePath);
-                        return lastDeployments;
-                    }
-                    log.info("Artifactory has entries but no archive artifact yet; retrying in {}s",
-                            pollInterval.toSeconds());
-                } else {
-                    log.info("Artifactory has no artifacts yet; retrying in {}s", pollInterval.toSeconds());
+        try {
+            await()
+                    .pollInterval(pollInterval)
+                    .atMost(timeout)
+                    .until(() -> {
+                        try {
+                            JsonNode deployments = ArtifactoryStorageHelper.fetchArtifactoryDeployments(HTTP_CLIENT, artifactoryContainer);
+                            lastDeployments.set(deployments);
+                            lastFetchError.set(null);
+                            JsonNode children = deployments.path("children");
+                            if (children.isArray() && children.size() > 0) {
+                                JsonNode archiveMetadata = ArtifactoryStorageHelper.findFirstArtifactArchiveMetadata(HTTP_CLIENT, artifactoryContainer);
+                                lastArchiveMetadata.set(archiveMetadata);
+                                if (archiveMetadata != null) {
+                                    String archivePath = archiveMetadata.path("path").asText();
+                                    log.info("Artifactory archive ready: {}", archivePath);
+                                    return true;
+                                }
+                                log.info("Artifactory has entries but no archive artifact yet; retrying in {}s",
+                                        pollInterval.toSeconds());
+                            } else {
+                                log.info("Artifactory has no artifacts yet; retrying in {}s", pollInterval.toSeconds());
+                            }
+                            return false;
+                        } catch (RuntimeException fetchError) {
+                            lastFetchError.set(fetchError);
+                            log.warn("Failed to fetch Artifactory deployments (will retry in {}s): {}",
+                                    pollInterval.toSeconds(),
+                                    fetchError.getMessage());
+                            return false;
+                        }
+                    });
+            return lastDeployments.get();
+        } catch (ConditionTimeoutException conditionTimeout) {
+            if (lastDeployments.get() != null) {
+                if (lastArchiveMetadata.get() == null) {
+                    throw new IllegalStateException("Timed out waiting for an archive artifact (.jar/.zip) in Artifactory");
                 }
-            } catch (RuntimeException fetchError) {
-                lastFetchError = fetchError;
-                log.warn("Failed to fetch Artifactory deployments (will retry in {}s): {}",
-                        pollInterval.toSeconds(),
-                        fetchError.getMessage());
+                return lastDeployments.get();
             }
-            page.waitForTimeout(pollInterval.toMillis());
-        }
-
-        if (lastDeployments != null) {
-            if (lastArchiveMetadata == null) {
-                throw new IllegalStateException("Timed out waiting for an archive artifact (.jar/.zip) in Artifactory");
+            if (lastFetchError.get() != null) {
+                throw lastFetchError.get();
             }
-            return lastDeployments;
+            throw new IllegalStateException("Timed out waiting for Artifactory deployments to become available");
         }
-        if (lastFetchError != null) {
-            throw lastFetchError;
-        }
-        throw new IllegalStateException("Timed out waiting for Artifactory deployments to become available");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #261. Part of epic #248 (Phase D — hardening).

- Replaces the hand-rolled `while (System.nanoTime() < deadline) { ... page.waitForTimeout(...) }` loop in `HappyPathUserJourneyTest.waitForArtifactoryDeployments` with an Awaitility block that mirrors the canonical pattern of `waitForPromptSpec` in the same file.
- `page.waitForTimeout` (a Playwright primitive) was driving the polling cadence by burning Playwright's idle loop. That ties this background poll into the same event loop as concurrent navigation on the `Page`, which is a documented contributor to HappyPath flakiness.
- Diagnostic state (last deployments JSON, last archive metadata, last fetch error) is now captured via `AtomicReference` inside the Awaitility condition, the same way `waitForPromptSpec` does.

## Behaviour preserved

- 12-minute timeout, 5-second poll interval.
- Same three log lines: archive-ready (info), entries-but-no-archive (info), nothing-yet (info), fetch-error (warn).
- Same `IllegalStateException` shapes on timeout (`Timed out waiting for an archive artifact (.jar/.zip) in Artifactory` vs `Timed out waiting for Artifactory deployments to become available`).
- `RuntimeException` from `ArtifactoryStorageHelper.fetchArtifactoryDeployments` is retained and rethrown only if the loop never saw a successful response.

## Scope discipline

- Only `waitForArtifactoryDeployments` modified. Other `page.waitForTimeout` calls in the file are intentionally untouched (D2/D3 scope).
- No imports added — `await`, `Duration`, `AtomicReference`, `ConditionTimeoutException` were already present.

## Test plan

- [ ] `mvn test-compile` from the `acceptance-tests` module compiles cleanly (verified locally).
- [ ] Reviewer: confirm the three diagnostic log lines and the `IllegalStateException` messages are byte-for-byte preserved.
- [ ] HappyPath integration run (nightly or pre-merge) stays green for the artifactory-deploy phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)