### PR TITLE
fix(prompt-editor): don't inject empty system message into draft payload

### DIFF
--- a/components/promptlm-web-ui/src/api/__tests__/promptPayloads.test.ts
+++ b/components/promptlm-web-ui/src/api/__tests__/promptPayloads.test.ts
@@ -305,4 +305,70 @@ describe('buildPromptDraftInputFromPrompt', () => {
     expect(draft.placeholders.defaults).toEqual({ customer: 'Alice' });
     expect(draft.extensions).toEqual({ 'x-custom': { foo: 'bar' } });
   });
+
+  it('does not inject a system message when the source prompt has none', () => {
+    const prompt: PromptSpec = {
+      id: 'prompt-2',
+      name: 'No-System Prompt',
+      group: 'support',
+      request: {
+        type: 'chat/completion',
+        vendor: 'openai',
+        model: 'gpt-4o',
+        messages: [{ role: 'USER', content: 'hello' }],
+      },
+    };
+
+    const draft = buildPromptDraftInputFromPrompt(prompt);
+
+    expect(draft.request.messages).toEqual([{ role: 'user', content: 'hello' }]);
+  });
+
+  it('preserves an existing system message from the source prompt', () => {
+    const prompt: PromptSpec = {
+      id: 'prompt-3',
+      name: 'With System',
+      group: 'support',
+      request: {
+        type: 'chat/completion',
+        vendor: 'openai',
+        model: 'gpt-4o',
+        messages: [
+          { role: 'SYSTEM', content: 'you are helpful' },
+          { role: 'USER', content: 'hi' },
+        ],
+      },
+    };
+
+    const draft = buildPromptDraftInputFromPrompt(prompt);
+
+    expect(draft.request.messages).toEqual([
+      { role: 'system', content: 'you are helpful' },
+      { role: 'user', content: 'hi' },
+    ]);
+  });
+
+  it('preserves a user-authored empty system message', () => {
+    const prompt: PromptSpec = {
+      id: 'prompt-4',
+      name: 'Empty System Authored',
+      group: 'support',
+      request: {
+        type: 'chat/completion',
+        vendor: 'openai',
+        model: 'gpt-4o',
+        messages: [
+          { role: 'SYSTEM', content: '' },
+          { role: 'USER', content: 'hi' },
+        ],
+      },
+    };
+
+    const draft = buildPromptDraftInputFromPrompt(prompt);
+
+    expect(draft.request.messages).toEqual([
+      { role: 'system', content: '' },
+      { role: 'user', content: 'hi' },
+    ]);
+  });
 });

--- a/components/promptlm-web-ui/src/api/promptPayloads.ts
+++ b/components/promptlm-web-ui/src/api/promptPayloads.ts
@@ -262,14 +262,23 @@ export const buildPromptDraftInputFromPrompt = (
   const request = prompt.request as PromptSpecRequest | undefined;
   const existingMessages = readPromptMessages(prompt);
   const preservedMessages = existingMessages.filter((message) => message.role !== 'system' && message.role !== 'user');
-  const systemMessage =
-    overrides?.systemMessage ??
-    existingMessages.find((message) => message.role === 'system')?.content ??
-    '';
+  const existingSystem = existingMessages.find((message) => message.role === 'system');
+  // Only synthesise a system message when the caller supplied one or the stored
+  // prompt already had one. Injecting an empty system message into prompts that
+  // never declared one makes the editor's draft diverge from the stored spec,
+  // which causes executeStoredPrompt to misclassify the run as a draft (#248).
+  const systemMessage = overrides?.systemMessage ?? existingSystem?.content;
   const userMessage =
     overrides?.userMessage ??
     existingMessages.find((message) => message.role === 'user')?.content ??
     '';
+
+  const messages: EditablePromptMessage[] = [];
+  if (systemMessage !== undefined) {
+    messages.push({ role: 'system', content: systemMessage });
+  }
+  messages.push({ role: 'user', content: userMessage });
+  messages.push(...preservedMessages);
 
   return {
     id: prompt.id,
@@ -297,11 +306,7 @@ export const buildPromptDraftInputFromPrompt = (
       url: request?.url,
       modelSnapshot: request?.model_snapshot,
       parameters: request?.parameters,
-      messages: [
-        { role: 'system', content: systemMessage },
-        { role: 'user', content: userMessage },
-        ...preservedMessages,
-      ],
+      messages,
     },
     extensions: prompt.extensions as Record<string, unknown> | undefined,
   };


### PR DESCRIPTION
## Summary

Unblocks `HappyPathUserJourneyTest#runPromptPersistsManualExecution` on main.

The editor was unconditionally prepending `{role: 'system', content: ''}` when loading a stored prompt into the draft. Stored specs that have no system message ended up with `[empty-system, user]` in the editor, while the backend still had `[user]`. Their semantic hashes diverged, so `PromptSpecController#executeStoredPrompt` misclassified the dev-run as a draft and skipped recording the MANUAL `Execution`. The test then NPE'd asserting on `getExecutions().get(0)`.

Fix: only emit the system message in `buildPromptDraftInputFromPrompt` when the source prompt already had one, or when the caller supplies an override. User-authored empty system content (`{role:'system', content:''}`) is still preserved.

## Files

- `components/promptlm-web-ui/src/api/promptPayloads.ts` — 23-line change to `buildPromptDraftInputFromPrompt`
- `components/promptlm-web-ui/src/api/__tests__/promptPayloads.test.ts` — 3 new vitest cases (no-system / with-system / empty-system)

## UX impact

Prompts loaded from a stored spec with no system message will no longer show a default empty system-message row in the editor. The "+ insert system" button in `components/ui/src/prompts-v2/form/sections.tsx` remains the way to add one back. Brand-new prompts created from scratch are unaffected — `createEmptyPromptDraft` in `draftState.ts` still seeds a system row directly.

## Test plan

- [x] `pnpm -F web-ui test src/api/__tests__/promptPayloads.test.ts` — 8/8 pass
- [ ] Full `HappyPathUserJourneyTest#runPromptPersistsManualExecution` against this branch (skipped locally; CI / reviewer to confirm)
- [ ] `releaseProject` is still broken on main; tracked separately by #276 (default-flip stopgap) and #275 (durable design)

Refs #248