### PR TITLE
feat(project-create): default new projects to release-enabled mode

### DIFF
--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitProjectService.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitProjectService.java
@@ -23,6 +23,7 @@ import dev.promptlm.repository.template.RepositoryTemplateExtractor;
 import dev.promptlm.repository.template.TemplateContext;
 import dev.promptlm.repository.template.TemplateSubstitutionEngine;
 import dev.promptlm.store.api.ProjectService;
+import dev.promptlm.store.api.ReleaseProvider;
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
 import dev.promptlm.store.api.RepositoryGenerationConfig;
 import dev.promptlm.store.api.RepositoryOwner;
@@ -225,10 +226,19 @@ public class GitProjectService implements ProjectService {
                     ownerAndRepo.repo()
             );
         }
-        // TODO(#161): drive description / defaultBranch / release config from promptlm.yml.
-        RepositoryGenerationConfig config = RepositoryGenerationConfig.defaults(
+        // TODO(#275): drive description / defaultBranch / release config from
+        // promptlm.yml once the progressive-disclosure (Mode 1 default + opt-in
+        // promotion) UX ships. Until then, #276 has us default new repositories
+        // to release-enabled (Mode 2) so the full release pipeline is reachable
+        // without a user-facing "Enable releases" toggle. Revert this branch
+        // back to RepositoryGenerationConfig.defaults(...) when #275 lands.
+        RepositoryGenerationConfig config = new RepositoryGenerationConfig(
+                ownerAndRepo.repo(),
                 ownerAndRepo.owner(),
-                ownerAndRepo.repo()
+                RepositoryGenerationConfig.DEFAULT_DESCRIPTION,
+                RepositoryGenerationConfig.DEFAULT_BRANCH,
+                true,
+                ReleaseProvider.GITHUB_ACTIONS
         );
         return remoteGitRepositoryProvisioner.createRemoteRepository(config);
     }

--- a/components/repository-template/repo-resources/promptlm.yml
+++ b/components/repository-template/repo-resources/promptlm.yml
@@ -3,19 +3,23 @@
 # This file is the canonical entry point for promptLM behaviour in this
 # repository. The most important setting is `release.enabled`:
 #
-#   release.enabled: false  (default) — Mode 1, "Prompt management"
+#   release.enabled: true   (current default) — Mode 2, "Prompt releases"
+#     The repository ships GitHub Actions workflows, build scripts under
+#     `tools/`, `.promptlm/artifacts.toml`, and a `pom.xml` for building,
+#     validating, and publishing versioned prompt artifacts.
+#
+#   release.enabled: false                    — Mode 1, "Prompt management"
 #     The repository is a plain git store for prompts under `prompts/`.
 #     No CI/CD workflows, no Maven/Artifactory tooling, no `artifacts.toml`,
 #     and no `pom.xml` are generated.
 #
-#   release.enabled: true                — Mode 2, "Prompt releases"
-#     The repository additionally ships GitHub Actions workflows, build
-#     scripts under `tools/`, `.promptlm/artifacts.toml`, and a `pom.xml`
-#     for building, validating, and publishing versioned prompt artifacts.
+# Note: the Mode-2 default is a stopgap (see issue #276) until the
+# progressive-disclosure UX in #275 ships, at which point the default
+# reverts to Mode 1 with an opt-in "Enable releases" action.
 #
 # Flip `release.enabled` and regenerate the repository to switch modes.
 release:
-  enabled: false
+  enabled: true
   provider: github-actions
   trigger:
     type: tag

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplatePromptlmYmlTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplatePromptlmYmlTest.java
@@ -28,8 +28,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * Verifies the bundled {@code promptlm.yml} template defaults to Mode 1
- * (release disabled) and ships the full schema required by issue #161.
+ * Verifies the bundled {@code promptlm.yml} template defaults to Mode 2
+ * (release enabled) per issue #276 and ships the full schema required by
+ * issue #161. The Mode-2 default is a stopgap until the progressive-disclosure
+ * UX in #275 ships — revert to Mode 1 when that work lands.
  */
 class RepositoryTemplatePromptlmYmlTest {
 
@@ -42,13 +44,15 @@ class RepositoryTemplatePromptlmYmlTest {
     }
 
     @Test
-    void promptlmYmlDefaultsReleaseEnabledToFalse() throws Exception {
+    void promptlmYmlDefaultsReleaseEnabledToTrue() throws Exception {
         String content = readPromptlmYmlFromTemplateZip();
-        // The default must be Mode 1 (prompt management) so private users do
-        // not unexpectedly receive a full CI/CD pipeline.
+        // Stopgap per #276: the template defaults to Mode 2 (release enabled)
+        // so newly created repositories ship with the full release pipeline.
+        // The durable Mode-1-default + opt-in promotion UX is tracked in #275;
+        // when that ships, revert this expectation back to `enabled: false`.
         assertThat(content)
-                .as("Default promptlm.yml must set release.enabled to false (issue #161, F-007/F-010)")
-                .containsPattern("(?m)^\\s+enabled:\\s*false\\b");
+                .as("Default promptlm.yml must set release.enabled to true (issue #276 stopgap; reverts when #275 ships)")
+                .containsPattern("(?m)^\\s+enabled:\\s*true\\b");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #276 (stopgap). Flips the create-project default so new repositories ship with the Mode-2 release infrastructure (`.github/workflows/`, `tools/`, `scripts/`, `pom.xml`, `.promptlm/artifacts.toml`) included from the first commit.

Until now, `GitProjectService#createRemoteRepository` hard-coded `RepositoryGenerationConfig.defaults(...)` (which produces `releaseEnabled=false`) with a `TODO(#161)`. There is no user-facing "Enable releases" toggle, so Mode 2 was unreachable from the product. This change makes the release pipeline reachable via the normal create-project flow, unblocking the product video and `HappyPathUserJourneyTest#releaseProject`.

This is a **stopgap, not the long-term direction.** The durable progressive-disclosure UX is tracked in #275; when that ships, revert this PR.

## Approach

Flipped at the **call site** (`GitProjectService`), not in `RepositoryGenerationConfig.defaults()`. Three other callers exist:

- `RemoteGitRepositoryProvisioner.createRemoteRepository(String, String)` — `@Deprecated` backward-compat overload
- `RepositoryGenerationConfigTest.defaultsShouldDisableReleaseAndUseDefaults` — explicitly asserts `releaseEnabled=false`
- `ReleaseTemplateProviderTest` — uses `defaults()` as a value carrier

Confining the change to one production call site:
- Keeps the eventual #275 revert a one-line change
- Leaves `defaults()` as a clean Mode-1 factory
- Avoids quietly changing semantics for the deprecated overload

## Files

- `components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitProjectService.java` (+13/-3) — call-site flip + `TODO(#161)` → `TODO(#275)`
- `components/repository-template/repo-resources/promptlm.yml` (+10/-6) — `enabled: false` → `true` + header comment rewritten
- `components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplatePromptlmYmlTest.java` (+11/-7) — assertion flipped to match new default

## Test plan

- [ ] CI: `RepositoryTemplatePromptlmYmlTest` (assertion flipped) — must pass
- [ ] CI: `RepositoryGenerationConfigTest.defaultsShouldDisableReleaseAndUseDefaults` — must still pass (`defaults()` untouched)
- [ ] CI: `ReleaseTemplateProviderTest` — must still pass
- [ ] `HappyPathUserJourneyTest#releaseProject` — should now pass without the test-only `ReleaseModeActivator` workaround from the parked #248-Hotfix-B branch
- [ ] Local unit tests skipped — could not run due to the documented `build-full.sh` BOM-resolution quirk; CI is the verification site

## Follow-ups

- After this merges, delete the parked `ReleaseModeActivator` helper + its branch `worktree-agent-aae97e92e4c9799e0` — it was a test-only stand-in for exactly this behavior.
- When #275's progressive-disclosure UX ships, revert the call site to `RepositoryGenerationConfig.defaults(...)` and the YAML default to `enabled: false`.

Refs #248, #275