### PR TITLE
fix(store): surface remote-repo auth failures instead of opaque RuntimeExceptions

### DIFF
--- a/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/RemoteRepositoryAuthenticationException.java
+++ b/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/RemoteRepositoryAuthenticationException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.api;
+
+/**
+ * Raised when the store backend rejects the configured credentials (e.g. an
+ * invalid or insufficiently scoped token). Distinct from a generic
+ * {@link RemoteRepositoryProvisioningException} so callers can prompt the user
+ * to fix their credentials rather than treating it as an upstream outage.
+ */
+public class RemoteRepositoryAuthenticationException extends RemoteRepositoryProvisioningException {
+
+    public RemoteRepositoryAuthenticationException(String baseUrl, int httpStatus, Throwable cause) {
+        super("Remote repository credentials for '%s' were rejected (HTTP %d). Check the configured access token and its scopes."
+                .formatted(baseUrl, httpStatus), httpStatus, cause);
+    }
+}

--- a/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/RemoteRepositoryProvisioningException.java
+++ b/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/RemoteRepositoryProvisioningException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.api;
+
+/**
+ * Raised when a remote repository operation against the store backend fails for
+ * reasons other than the target already existing. Carries the upstream HTTP
+ * status (when known) so callers can map the failure to a meaningful response
+ * instead of surfacing an opaque {@link RuntimeException}.
+ */
+public class RemoteRepositoryProvisioningException extends RuntimeException {
+
+    private final Integer httpStatus;
+
+    public RemoteRepositoryProvisioningException(String message, Throwable cause) {
+        this(message, null, cause);
+    }
+
+    public RemoteRepositoryProvisioningException(String message, Integer httpStatus, Throwable cause) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    /**
+     * @return the upstream HTTP status code that triggered this failure, or
+     *         {@code null} if the failure was not HTTP-related.
+     */
+    public Integer getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/RemoteGitRepositoryProvisioner.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/RemoteGitRepositoryProvisioner.java
@@ -17,6 +17,8 @@
 package dev.promptlm.store.github;
 
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
+import dev.promptlm.store.api.RemoteRepositoryAuthenticationException;
+import dev.promptlm.store.api.RemoteRepositoryProvisioningException;
 import dev.promptlm.store.api.RepositoryGenerationConfig;
 import dev.promptlm.store.api.RepositoryOwner;
 import org.kohsuke.github.*;
@@ -69,7 +71,7 @@ public class RemoteGitRepositoryProvisioner {
 
             return List.copyOf(owners);
         } catch (IOException ex) {
-            throw new RuntimeException(ex);
+            throw translateProvisioningFailure("Listing repository owners", ex);
         }
     }
 
@@ -141,12 +143,11 @@ public class RemoteGitRepositoryProvisioner {
             log.debug("Repository {} exists: {}", repoFullName, exists);
             return exists;
         } catch (GHFileNotFoundException notFound) {
-            log.debug("Repository {}/{} does not exist", owner, repoName);
+            log.debug("Repository {}/{} does not exist", effectiveOwner, repoName);
             return false;
         } catch (IOException e) {
-
-//            throw new RuntimeException("Could not check if repository exists: " + owner + "/" + repoName + ": " + e.getMessage(), e);
-            return false;
+            throw translateProvisioningFailure(
+                    "Checking whether repository %s/%s exists".formatted(effectiveOwner, repoName), e);
         }
     }
 
@@ -180,8 +181,28 @@ public class RemoteGitRepositoryProvisioner {
             }
             return GitHubRepository.create(r.getOwnerName(), r.getName(), r.getHtmlUrl());
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw translateProvisioningFailure("Creating repository %s/%s".formatted(owner, repoName), e);
         }
+    }
+
+    /**
+     * Translates a low-level {@link IOException} from the GitHub client into a
+     * typed provisioning exception. Rejected credentials (HTTP 401/403/406)
+     * become a {@link RemoteRepositoryAuthenticationException}; everything else
+     * becomes a {@link RemoteRepositoryProvisioningException} carrying the
+     * upstream status when available.
+     */
+    private RemoteRepositoryProvisioningException translateProvisioningFailure(String action, IOException ex) {
+        if (ex instanceof HttpException httpException) {
+            int status = httpException.getResponseCode();
+            if (status == 401 || status == 403 || status == 406) {
+                return new RemoteRepositoryAuthenticationException(gitHubProperties.getBaseUrl(), status, ex);
+            }
+            return new RemoteRepositoryProvisioningException(
+                    "%s failed against '%s' (HTTP %d)".formatted(action, gitHubProperties.getBaseUrl(), status), status, ex);
+        }
+        return new RemoteRepositoryProvisioningException(
+                "%s failed against '%s'".formatted(action, gitHubProperties.getBaseUrl()), ex);
     }
 
     private String resolveOwner(String requestedOwner) {

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/RemoteGitRepositoryProvisionerRepositoryExistsTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/RemoteGitRepositoryProvisionerRepositoryExistsTest.java
@@ -18,6 +18,7 @@ package dev.promptlm.store.github;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
+import dev.promptlm.store.api.RemoteRepositoryAuthenticationException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RemoteGitRepositoryProvisionerRepositoryExistsTest {
 
@@ -53,18 +55,45 @@ class RemoteGitRepositoryProvisionerRepositoryExistsTest {
         }
     }
 
+    /**
+     * Rejected credentials on the target lookup must surface as an authentication
+     * failure rather than being masked as "repository does not exist", which would
+     * otherwise let `repo create` proceed and fail later with an opaque error.
+     */
+    @Test
+    void repositoryExistsRaisesAuthenticationFailureWhenCredentialsRejected() {
+        try (FakeGitHubApi api = FakeGitHubApi.start(401)) {
+            GitHubProperties properties = new GitHubProperties();
+            properties.setBaseUrl(api.baseApiUrl());
+            properties.setEndpoint(api.baseApiUrl());
+            properties.setUsername("alice");
+            properties.setToken("token");
+
+            RemoteGitRepositoryProvisioner provisioner = new RemoteGitRepositoryProvisioner(properties);
+
+            assertThatThrownBy(() -> provisioner.repositoryExists(api.baseApiUrl(), "owner", "repo"))
+                    .isInstanceOf(RemoteRepositoryAuthenticationException.class);
+        }
+    }
+
     private static final class FakeGitHubApi implements AutoCloseable {
         private final HttpServer server;
+        private final int repoStatus;
         private final List<String> requestPaths = new CopyOnWriteArrayList<>();
 
-        private FakeGitHubApi(HttpServer server) {
+        private FakeGitHubApi(HttpServer server, int repoStatus) {
             this.server = server;
+            this.repoStatus = repoStatus;
         }
 
         static FakeGitHubApi start() {
+            return start(404);
+        }
+
+        static FakeGitHubApi start(int repoStatus) {
             try {
                 HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-                FakeGitHubApi fakeGitHubApi = new FakeGitHubApi(server);
+                FakeGitHubApi fakeGitHubApi = new FakeGitHubApi(server, repoStatus);
                 server.createContext("/", fakeGitHubApi::handle);
                 server.start();
                 return fakeGitHubApi;
@@ -93,7 +122,7 @@ class RemoteGitRepositoryProvisionerRepositoryExistsTest {
             }
 
             if (path.endsWith("/repos/owner/repo")) {
-                writeJson(exchange, 404, """
+                writeJson(exchange, repoStatus, """
                         {"message":"Not Found"}
                         """);
                 return;

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptStoreController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptStoreController.java
@@ -20,6 +20,8 @@ import dev.promptlm.domain.AppContext;
 import dev.promptlm.domain.projectspec.ProjectSpec;
 import dev.promptlm.store.api.ProjectService;
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
+import dev.promptlm.store.api.RemoteRepositoryAuthenticationException;
+import dev.promptlm.store.api.RemoteRepositoryProvisioningException;
 import dev.promptlm.store.api.RepositoryOwner;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
@@ -94,7 +96,13 @@ public class PromptStoreController {
                     array = @ArraySchema(schema = @Schema(implementation = RepositoryOwner.class))))
     @GetMapping("/owners")
     public ResponseEntity<List<RepositoryOwner>> listOwners() {
-        return ResponseEntity.ok(projectService.listAvailableOwners());
+        try {
+            return ResponseEntity.ok(projectService.listAvailableOwners());
+        } catch (RemoteRepositoryAuthenticationException ex) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ex.getMessage(), ex);
+        } catch (RemoteRepositoryProvisioningException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, ex.getMessage(), ex);
+        }
     }
 
     @Operation(summary = "Create new store", 
@@ -119,6 +127,10 @@ public class PromptStoreController {
             return ResponseEntity.ok(ensureProjectIdentity(projectSpec));
         } catch (RemoteRepositoryAlreadyExistsException ex) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage(), ex);
+        } catch (RemoteRepositoryAuthenticationException ex) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ex.getMessage(), ex);
+        } catch (RemoteRepositoryProvisioningException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, ex.getMessage(), ex);
         } catch (IllegalArgumentException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
         }

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptStoreControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptStoreControllerWebMvcTest.java
@@ -20,6 +20,8 @@ import dev.promptlm.domain.AppContext;
 import dev.promptlm.domain.projectspec.ProjectSpec;
 import dev.promptlm.store.api.ProjectService;
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
+import dev.promptlm.store.api.RemoteRepositoryAuthenticationException;
+import dev.promptlm.store.api.RemoteRepositoryProvisioningException;
 import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -187,6 +189,42 @@ class PromptStoreControllerWebMvcTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict());
+    }
+
+    @Test
+    void createStoreShouldReturnUnauthorizedWhenCredentialsRejected(@TempDir Path tempDir) throws Exception {
+        Path repoDir = tempDir.resolve("repo-parent");
+        Files.createDirectories(repoDir);
+
+        CreateStoreRequest request = new CreateStoreRequest();
+        request.setRepoDir(repoDir.toString());
+        request.setRepoName("repo-name");
+
+        when(projectService.newProject(eq(repoDir), eq(null), eq("repo-name")))
+                .thenThrow(new RemoteRepositoryAuthenticationException("https://github.com", 406, new RuntimeException("boom")));
+
+        mockMvc.perform(post("/api/store")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void createStoreShouldReturnBadGatewayWhenProvisioningFails(@TempDir Path tempDir) throws Exception {
+        Path repoDir = tempDir.resolve("repo-parent");
+        Files.createDirectories(repoDir);
+
+        CreateStoreRequest request = new CreateStoreRequest();
+        request.setRepoDir(repoDir.toString());
+        request.setRepoName("repo-name");
+
+        when(projectService.newProject(eq(repoDir), eq(null), eq("repo-name")))
+                .thenThrow(new RemoteRepositoryProvisioningException("Creating repository failed", 500, new RuntimeException("boom")));
+
+        mockMvc.perform(post("/api/store")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadGateway());
     }
 
     @Test


### PR DESCRIPTION
## Summary
Rejected GitHub credentials (HTTP 401/403/406) were masked twice in the remote-repo provisioning flow: `repositoryExists` swallowed the error and returned `false`, then `_createRemoteRepository` re-hit it and wrapped it in a bare `RuntimeException` that surfaced to the API as a generic 500 with a leaked stack trace. (Observed in the debugger as a `406` on `GET /user`.)

- Add typed `RemoteRepositoryProvisioningException` (base, carries upstream HTTP status) and `RemoteRepositoryAuthenticationException` to `promptlm-store-api`, siblings of the existing `RemoteRepositoryAlreadyExistsException`.
- In `RemoteGitRepositoryProvisioner`, translate `IOException`/`HttpException` by status at the three swallow/opaque-wrap sites (`listAvailableOwners`, `repositoryExists`, `_createRemoteRepository`). `repositoryExists` now only returns `false` on a genuine 404 — a rejected-credentials error surfaces instead of being mistaken for "doesn't exist".
- Map both in `PromptStoreController` (`createStore` + `listOwners`): auth → **401 Unauthorized**, other provisioning failures → **502 Bad Gateway**.

Scoped to the remote-provisioning flow; the same `RuntimeException(e)` pattern elsewhere (`GitHubPromptStore`, `Git`, etc.) is left untouched.

## Test plan
- [x] `RemoteGitRepositoryProvisionerRepositoryExistsTest` — added 401 target-lookup case asserting `RemoteRepositoryAuthenticationException`; existing issue-#11 "no global credential probe" test still passes (404 path unchanged).
- [x] `PromptStoreControllerWebMvcTest` — added 401 and 502 mapping cases.
- [x] Full module test runs green: `promptlm-store-api`, `promptlm-store-github`, `promptlm-web-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)