### PR TITLE
feat(store,webui): surface repoDir workspace rule as a form-field error

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,6 +8,12 @@
       "port": 5174
     },
     {
+      "name": "ui-storybook",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "storybook", "--workspace", "@promptlm/ui", "--", "--port", "6007", "--no-open"],
+      "port": 6007
+    },
+    {
       "name": "report-static",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev", "--workspace", "@promptlm/report-static"],

--- a/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/FieldValidationException.java
+++ b/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/FieldValidationException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.api;
+
+/**
+ * Signals that a request field violated a business rule and should be surfaced as a
+ * field-scoped validation error (HTTP 400), not as an opaque server error.
+ *
+ * <p>Extends {@link IllegalArgumentException} so existing call sites that map
+ * {@code IllegalArgumentException} to a {@code 400} keep working; handlers that want
+ * field attribution can match this subtype and read {@link #getField()}/{@link #getCode()}.
+ */
+public class FieldValidationException extends IllegalArgumentException {
+
+    private final String field;
+    private final String code;
+
+    public FieldValidationException(String field, String code, String message) {
+        super(message);
+        this.field = field;
+        this.code = code;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/components/promptlm-store/promptlm-store-api/src/test/java/dev/promptlm/store/api/FieldValidationExceptionTest.java
+++ b/components/promptlm-store/promptlm-store-api/src/test/java/dev/promptlm/store/api/FieldValidationExceptionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class FieldValidationExceptionTest {
+
+    @Test
+    void exposesFieldCodeAndMessageAndIsIllegalArgument() {
+        FieldValidationException exception =
+                new FieldValidationException("repoDir", "store.path.outsideWorkspace", "repoDir must be inside the workspace");
+
+        assertEquals("repoDir", exception.getField());
+        assertEquals("store.path.outsideWorkspace", exception.getCode());
+        assertEquals("repoDir must be inside the workspace", exception.getMessage());
+        assertInstanceOf(IllegalArgumentException.class, exception);
+    }
+}

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/LocalWorkspacePathPolicy.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/LocalWorkspacePathPolicy.java
@@ -16,6 +16,7 @@
 
 package dev.promptlm.store.github;
 
+import dev.promptlm.store.api.FieldValidationException;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Path;
@@ -31,13 +32,15 @@ class LocalWorkspacePathPolicy {
 
     public Path assertWithinWorkspace(Path candidatePath, String fieldName) {
         if (candidatePath == null) {
-            throw new IllegalArgumentException(fieldName + " must not be null");
+            throw new FieldValidationException(fieldName, "store.path.required", fieldName + " must not be null");
         }
 
         Path workspaceRoot = resolveWorkspaceRoot();
         Path normalizedCandidate = candidatePath.toAbsolutePath().normalize();
         if (!normalizedCandidate.startsWith(workspaceRoot)) {
-            throw new IllegalArgumentException(
+            throw new FieldValidationException(
+                    fieldName,
+                    "store.path.outsideWorkspace",
                     "%s must be located under workspace root %s, but was %s"
                             .formatted(fieldName, workspaceRoot, normalizedCandidate)
             );

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/LocalWorkspacePathPolicyTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/LocalWorkspacePathPolicyTest.java
@@ -16,6 +16,7 @@
 
 package dev.promptlm.store.github;
 
+import dev.promptlm.store.api.FieldValidationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -23,6 +24,7 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 class LocalWorkspacePathPolicyTest {
 
@@ -49,5 +51,11 @@ class LocalWorkspacePathPolicyTest {
         assertThatThrownBy(() -> policy.assertWithinWorkspace(Path.of("/tmp/outside"), "repoDir"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("repoDir must be located under workspace root");
+
+        FieldValidationException thrown = catchThrowableOfType(
+                FieldValidationException.class,
+                () -> policy.assertWithinWorkspace(Path.of("/tmp/outside"), "repoDir"));
+        assertThat(thrown.getField()).isEqualTo("repoDir");
+        assertThat(thrown.getCode()).isEqualTo("store.path.outsideWorkspace");
     }
 }

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/FieldValidationExceptionHandler.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/FieldValidationExceptionHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.web;
+
+import dev.promptlm.store.api.FieldValidationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Translates {@link FieldValidationException} into a field-scoped {@code 400} problem so the UI can
+ * render the violation against the offending form field instead of as an opaque banner.
+ *
+ * <p>The {@code fieldErrors} array shape ({@code [{field, message}]}) matches what the web client's
+ * {@code apiError} parser already reads.
+ */
+@RestControllerAdvice
+class FieldValidationExceptionHandler {
+
+    @ExceptionHandler(FieldValidationException.class)
+    ResponseEntity<ProblemDetail> handleFieldValidation(FieldValidationException exception) {
+        ProblemDetail detail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, exception.getMessage());
+        detail.setTitle("Validation failed");
+        if (exception.getCode() != null) {
+            detail.setProperty("code", exception.getCode());
+        }
+        detail.setProperty("fieldErrors", List.of(Map.of(
+                "field", exception.getField() == null ? "" : exception.getField(),
+                "message", exception.getMessage() == null ? "" : exception.getMessage()
+        )));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body(detail);
+    }
+}

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptStoreController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptStoreController.java
@@ -18,6 +18,7 @@ package dev.promptlm.web;
 
 import dev.promptlm.domain.AppContext;
 import dev.promptlm.domain.projectspec.ProjectSpec;
+import dev.promptlm.store.api.FieldValidationException;
 import dev.promptlm.store.api.ProjectService;
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
 import dev.promptlm.store.api.RemoteRepositoryAuthenticationException;
@@ -131,12 +132,14 @@ public class PromptStoreController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ex.getMessage(), ex);
         } catch (RemoteRepositoryProvisioningException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, ex.getMessage(), ex);
+        } catch (FieldValidationException ex) {
+            throw ex;
         } catch (IllegalArgumentException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
         }
     }
 
-    @Operation(summary = "Clone existing store", 
+    @Operation(summary = "Clone existing store",
                description = "Clones an existing prompt store repository from a remote URL")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Store cloned successfully, returns the result message",

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptStoreControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptStoreControllerWebMvcTest.java
@@ -18,6 +18,7 @@ package dev.promptlm.web;
 
 import dev.promptlm.domain.AppContext;
 import dev.promptlm.domain.projectspec.ProjectSpec;
+import dev.promptlm.store.api.FieldValidationException;
 import dev.promptlm.store.api.ProjectService;
 import dev.promptlm.store.api.RemoteRepositoryAlreadyExistsException;
 import dev.promptlm.store.api.RemoteRepositoryAuthenticationException;
@@ -243,6 +244,31 @@ class PromptStoreControllerWebMvcTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createStoreShouldReturnFieldScopedProblemWhenRepoDirOutsideWorkspace(@TempDir Path tempDir) throws Exception {
+        Path repoDir = tempDir.resolve("repo-parent");
+        Files.createDirectories(repoDir);
+
+        CreateStoreRequest request = new CreateStoreRequest();
+        request.setRepoDir(repoDir.toString());
+        request.setRepoName("repo-name");
+
+        when(projectService.newProject(eq(repoDir), eq(null), eq("repo-name")))
+                .thenThrow(new FieldValidationException(
+                        "repoDir",
+                        "store.path.outsideWorkspace",
+                        "repoDir must be located under workspace root /workspace, but was /tmp"));
+
+        mockMvc.perform(post("/api/store")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.code").value("store.path.outsideWorkspace"))
+                .andExpect(jsonPath("$.fieldErrors[0].field").value("repoDir"))
+                .andExpect(jsonPath("$.fieldErrors[0].message", containsString("workspace root")));
     }
 
     @Test

--- a/components/promptlm-web-ui/src/api-common/apiError.ts
+++ b/components/promptlm-web-ui/src/api-common/apiError.ts
@@ -14,12 +14,18 @@
 
 import { ApiError } from '@promptlm/api-client';
 
+export type ApiFieldError = {
+  field?: string;
+  message: string;
+};
+
 export type ApiErrorI18n = {
   code: string;
   messageKey: string;
   message?: string;
   params?: Record<string, string | number>;
   status?: number;
+  fieldErrors?: ApiFieldError[];
 };
 
 type ProblemDetail = {
@@ -65,10 +71,18 @@ const toProblemValidationEntry = (value: unknown): ProblemValidationEntry | null
   return value as ProblemValidationEntry;
 };
 
-const normalizeValidationMessage = (value: unknown): string | undefined => {
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : undefined;
+const normalizeText = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const toFieldError = (value: unknown): ApiFieldError | undefined => {
+  const messageOnly = normalizeText(value);
+  if (messageOnly) {
+    return { message: messageOnly };
   }
 
   const entry = toProblemValidationEntry(value);
@@ -76,18 +90,16 @@ const normalizeValidationMessage = (value: unknown): string | undefined => {
     return undefined;
   }
 
-  const field = entry.field ?? entry.path ?? entry.name;
-  const message = entry.message ?? entry.detail ?? entry.defaultMessage ?? entry.reason;
-  const normalizedMessage = normalizeValidationMessage(message);
-  if (!normalizedMessage) {
+  const message = normalizeText(entry.message ?? entry.detail ?? entry.defaultMessage ?? entry.reason);
+  if (!message) {
     return undefined;
   }
 
-  const normalizedField = normalizeValidationMessage(field);
-  return normalizedField ? `${normalizedField}: ${normalizedMessage}` : normalizedMessage;
+  const field = normalizeText(entry.field ?? entry.path ?? entry.name);
+  return field ? { field, message } : { message };
 };
 
-const readProblemValidationMessages = (problem: ProblemDetail | null): string[] => {
+const readProblemFieldErrors = (problem: ProblemDetail | null): ApiFieldError[] => {
   if (!problem) {
     return [];
   }
@@ -99,22 +111,32 @@ const readProblemValidationMessages = (problem: ProblemDetail | null): string[] 
     problem.properties?.messages,
   ];
 
-  const uniqueMessages = new Set<string>();
+  const seen = new Set<string>();
+  const result: ApiFieldError[] = [];
   for (const candidate of candidates) {
     if (!Array.isArray(candidate)) {
       continue;
     }
 
     for (const item of candidate) {
-      const message = normalizeValidationMessage(item);
-      if (message) {
-        uniqueMessages.add(message);
+      const fieldError = toFieldError(item);
+      if (!fieldError) {
+        continue;
       }
+      const key = `${fieldError.field ?? ''}::${fieldError.message}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      result.push(fieldError);
     }
   }
 
-  return Array.from(uniqueMessages);
+  return result;
 };
+
+const formatFieldError = (fieldError: ApiFieldError): string =>
+  fieldError.field ? `${fieldError.field}: ${fieldError.message}` : fieldError.message;
 
 export const apiErrorToI18n = (error: unknown): ApiErrorI18n => {
   const fallbackMessage = error instanceof Error ? error.message : undefined;
@@ -123,9 +145,9 @@ export const apiErrorToI18n = (error: unknown): ApiErrorI18n => {
     const problem = toProblemDetail(error.body);
     const code = readProblemCode(problem);
     const status = error.status;
-    const validationMessages = readProblemValidationMessages(problem);
+    const fieldErrors = readProblemFieldErrors(problem);
     const message =
-      (validationMessages.length > 0 ? validationMessages.join('; ') : undefined) ??
+      (fieldErrors.length > 0 ? fieldErrors.map(formatFieldError).join('; ') : undefined) ??
       problem?.detail ??
       problem?.title ??
       error.message;
@@ -136,6 +158,7 @@ export const apiErrorToI18n = (error: unknown): ApiErrorI18n => {
       messageKey,
       message,
       status,
+      fieldErrors: fieldErrors.length > 0 ? fieldErrors : undefined,
     };
   }
 
@@ -156,4 +179,21 @@ export const toDisplayError = (error: unknown): Error => {
   const normalized = new Error(message);
   (normalized as { i18n?: ApiErrorI18n }).i18n = i18n;
   return normalized;
+};
+
+/**
+ * Extract field-scoped validation messages as a {@code field -> message} map, suitable for
+ * binding to form inputs. Reads the {@code i18n} payload attached by {@link toDisplayError}
+ * when present, otherwise derives it from the raw error.
+ */
+export const getFieldErrors = (error: unknown): Record<string, string> => {
+  const attached = (error as { i18n?: ApiErrorI18n } | null)?.i18n;
+  const i18n = attached ?? apiErrorToI18n(error);
+  const result: Record<string, string> = {};
+  for (const fieldError of i18n.fieldErrors ?? []) {
+    if (fieldError.field && !(fieldError.field in result)) {
+      result[fieldError.field] = fieldError.message;
+    }
+  }
+  return result;
 };

--- a/components/promptlm-web-ui/src/api/__tests__/apiError.test.ts
+++ b/components/promptlm-web-ui/src/api/__tests__/apiError.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { ApiError } from '@promptlm/api-client';
-import { apiErrorToI18n, toDisplayError } from '@api-common/apiError';
+import { apiErrorToI18n, getFieldErrors, toDisplayError } from '@api-common/apiError';
 
 const createApiError = (body: unknown, status = 400) =>
   new ApiError(
@@ -64,6 +64,45 @@ describe('apiErrorToI18n', () => {
     );
 
     expect(result.message).toBe('name: must not be blank; messages[0].content: must not be blank');
+  });
+
+  it('exposes structured field errors from a fieldErrors array', () => {
+    const result = apiErrorToI18n(
+      createApiError({
+        detail: 'Validation failed',
+        properties: {
+          code: 'store.path.outsideWorkspace',
+          fieldErrors: [
+            { field: 'repoDir', message: 'repoDir must be located under workspace root /ws, but was /tmp' },
+          ],
+        },
+      }),
+    );
+
+    expect(result.code).toBe('store.path.outsideWorkspace');
+    expect(result.fieldErrors).toEqual([
+      { field: 'repoDir', message: 'repoDir must be located under workspace root /ws, but was /tmp' },
+    ]);
+  });
+});
+
+describe('getFieldErrors', () => {
+  it('maps field -> message for a field-scoped problem', () => {
+    const error = toDisplayError(
+      createApiError({
+        properties: {
+          code: 'store.path.outsideWorkspace',
+          fieldErrors: [{ field: 'repoDir', message: 'must be inside the workspace' }],
+        },
+      }),
+    );
+
+    expect(getFieldErrors(error)).toEqual({ repoDir: 'must be inside the workspace' });
+  });
+
+  it('returns an empty map when there are no field-scoped errors', () => {
+    const error = toDisplayError(createApiError({ detail: 'boom' }));
+    expect(getFieldErrors(error)).toEqual({});
   });
 });
 

--- a/components/promptlm-web-ui/src/components/projects/ProjectModal.tsx
+++ b/components/promptlm-web-ui/src/components/projects/ProjectModal.tsx
@@ -32,6 +32,7 @@ import {
 } from '@api-common/projectModel';
 import type { StoreStatusEvent } from '@promptlm/api-client';
 import { useToast } from '@/hooks/use-toast';
+import { getFieldErrors } from '@api-common/apiError';
 import { useProjectsContext } from '@api-common/projects/ProjectsContext';
 import { useGeneratedApiClient } from '@api-common/generatedClientProvider';
 import {
@@ -65,6 +66,9 @@ export function ProjectModal({ open, onOpenChange }: ProjectModalProps) {
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+  const [createFieldErrors, setCreateFieldErrors] = useState<
+    Partial<Record<'repoName' | 'parentDirectory', string>>
+  >({});
   const [importError, setImportError] = useState<string | null>(null);
   const [cloneError, setCloneError] = useState<string | null>(null);
   const [cloneStatusEvent, setCloneStatusEvent] = useState<StoreStatusEvent | null>(null);
@@ -109,6 +113,7 @@ export function ProjectModal({ open, onOpenChange }: ProjectModalProps) {
   useEffect(() => {
     if (!open) {
       setCreateError(null);
+      setCreateFieldErrors({});
       setImportError(null);
       setCloneError(null);
       setCloneStatusEvent(null);
@@ -152,6 +157,7 @@ export function ProjectModal({ open, onOpenChange }: ProjectModalProps) {
   const handleAddProject = async (values: { repoName: string; parentDirectory: string; description: string; owner?: string }) => {
     setIsSubmitting(true);
     setCreateError(null);
+    setCreateFieldErrors({});
     try {
       const created = await createProject({
         repoName: values.repoName.trim(),
@@ -168,7 +174,18 @@ export function ProjectModal({ open, onOpenChange }: ProjectModalProps) {
       onOpenChange(false);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to create project. Please try again.';
-      setCreateError(message);
+      const backendFieldErrors = getFieldErrors(err);
+      const formFieldErrors: Partial<Record<'repoName' | 'parentDirectory', string>> = {};
+      if (backendFieldErrors.repoDir) {
+        formFieldErrors.parentDirectory = backendFieldErrors.repoDir;
+      }
+      if (backendFieldErrors.repoName) {
+        formFieldErrors.repoName = backendFieldErrors.repoName;
+      }
+
+      const hasFieldErrors = Object.keys(formFieldErrors).length > 0;
+      setCreateFieldErrors(formFieldErrors);
+      setCreateError(hasFieldErrors ? null : message);
       toast({
         title: 'Error',
         description: message,
@@ -340,6 +357,7 @@ export function ProjectModal({ open, onOpenChange }: ProjectModalProps) {
           onSubmit={handleAddProject}
           isSubmitting={isSubmitting}
           error={createError}
+          fieldErrors={createFieldErrors}
           owners={ownerOptions}
           isOwnersLoading={isOwnersLoading}
           ownersError={ownersError}

--- a/components/ui/src/layout/forms/CreateProjectForm.stories.tsx
+++ b/components/ui/src/layout/forms/CreateProjectForm.stories.tsx
@@ -51,3 +51,16 @@ export const WithError: Story = {
     error: 'Failed to create the repository in the selected directory.',
   },
 };
+
+export const WithFieldError: Story = {
+  args: {
+    initialValues: {
+      repoName: 'promptlm-studio',
+      parentDirectory: '/tmp',
+      description: 'Workspace for prompt experimentation',
+    },
+    fieldErrors: {
+      parentDirectory: 'repoDir must be located under workspace root /Users/alex, but was /tmp',
+    },
+  },
+};

--- a/components/ui/src/layout/forms/CreateProjectForm.tsx
+++ b/components/ui/src/layout/forms/CreateProjectForm.tsx
@@ -28,6 +28,7 @@ export type CreateProjectFormProps = {
   submitLabel?: string;
   isSubmitting?: boolean;
   error?: string | null;
+  fieldErrors?: Partial<Record<keyof CreateProjectFormValues, string>>;
   owners?: RepositoryOwnerOption[];
   isOwnersLoading?: boolean;
   ownersError?: string | null;
@@ -52,6 +53,7 @@ export const CreateProjectForm: React.FC<CreateProjectFormProps> = ({
   submitLabel = 'Create project',
   isSubmitting = false,
   error,
+  fieldErrors,
   owners,
   isOwnersLoading = false,
   ownersError,
@@ -99,6 +101,8 @@ export const CreateProjectForm: React.FC<CreateProjectFormProps> = ({
           value={values.repoName}
           onChange={handleChange('repoName')}
           inputProps={{ 'data-testid': 'repositoryName' }}
+          error={Boolean(fieldErrors?.repoName)}
+          helperText={fieldErrors?.repoName ?? undefined}
           fullWidth
           required
         />
@@ -108,6 +112,8 @@ export const CreateProjectForm: React.FC<CreateProjectFormProps> = ({
           value={values.parentDirectory}
           onChange={handleChange('parentDirectory')}
           inputProps={{ 'data-testid': 'newRepoPath' }}
+          error={Boolean(fieldErrors?.parentDirectory)}
+          helperText={fieldErrors?.parentDirectory ?? undefined}
           fullWidth
           required
         />


### PR DESCRIPTION
Closes #307. (#306 has merged; this targets `main` directly.)

## Summary
The `repoDir must be located under workspace root` business rule threw a raw `IllegalArgumentException` → generic 400 with developer text, so the Create-project form could only show it as an opaque banner/toast. The web client already had unused machinery to parse field-scoped problem details; this wires it end-to-end so the rule renders against the offending input.

No code was removed previously — `apiError.ts`'s field-extraction was added speculatively and never finished; git history shows no prior backend validation handler or `fieldErrors` property.

## Backend (`promptlm-store-api`, `promptlm-store-github`, `promptlm-web-api`)
- `FieldValidationException(field, code, message)` — extends `IllegalArgumentException`, so existing clone/connect 400 mapping and tests are unchanged.
- `LocalWorkspacePathPolicy` throws it with the field (`repoDir`) + a stable `code` (`store.path.outsideWorkspace` / `store.path.required`).
- `FieldValidationExceptionHandler` (`@RestControllerAdvice`) → `400 application/problem+json` with `code` + `fieldErrors:[{field,message}]`. `createStore` rethrows it ahead of the generic `IllegalArgumentException` catch so it reaches the advice.

## Frontend (`promptlm-web-ui`, `ui`)
- `apiError.ts`: structured `fieldErrors` on `ApiErrorI18n` + `getFieldErrors()` helper; joined-message banner fallback preserved.
- `CreateProjectForm`: per-field `error`/`helperText`. `ProjectModal`: routes backend `repoDir → parentDirectory` (and `repoName`), suppressing the banner when the error is field-scoped. Added a `WithFieldError` story.

## Test plan
- [x] Java: `FieldValidationExceptionTest`, `LocalWorkspacePathPolicyTest`, `GitProjectServiceTest`, `PromptStoreControllerWebMvcTest` (new field-error case asserting `code` + `fieldErrors[0].field == repoDir`) — green.
- [x] JS: full web-ui vitest (215) + `apiError` tests (6, incl. structured + `getFieldErrors`) + `@promptlm/ui` smoke — green.
- [x] Visual: Storybook screenshot confirms a red field-scoped error under "Parent directory" (not a banner), no console errors.

## Out of scope (follow-ups)
- Generic `MethodArgumentNotValidException` handling for `@NotNull`/`@NotBlank` required fields.
- Same field-routing for the Clone/Connect forms (`targetDir`, `repoPath`).
- i18n catalog resolution for `error.<code>` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)