### PR TITLE
ci: expand dependabot to all ecosystems + migrate oss-checks to org reusable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,34 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot version updates — promptlm-app
+# Org template: https://github.com/promptLM/.github/blob/main/dependabot.template.yml
+#
+# npm entries cover the React webapp (apps/promptlm-webapp/), the shared UI
+# component library (components/ui/), the API-client package, and the
+# acceptance-tests harness. Dependabot does NOT auto-discover npm workspaces;
+# each workspace with its own package-lock.json needs its own entry.
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/acceptance-tests"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/components/promptlm-api-client"
     schedule:
       interval: "weekly"

--- a/.github/workflows/oss-checks.yml
+++ b/.github/workflows/oss-checks.yml
@@ -1,8 +1,14 @@
-name: OSS Hygiene Checks
+name: oss-checks
 
-# Read-only OSS hygiene gates: secret scanning. License header presence
-# is already enforced by .github/workflows/CI.yml via skywalking-eyes —
-# do not duplicate that check here.
+# Thin caller of the org-wide reusable workflow. The gitleaks install + run
+# logic and the license-header check both live in
+# promptLM/.github/.github/workflows/oss-checks.yml — keeping them there means
+# bumping the gitleaks CLI version (or its install method) is a one-PR change
+# org-wide, not a per-repo sweep.
+#
+# License-header check is OFF here because CI.yml already runs skywalking-eyes
+# on every PR — switching it on in both places would double-spend CI minutes
+# and surface duplicate failures.
 
 on:
   push:
@@ -14,35 +20,7 @@ permissions:
   contents: read
 
 jobs:
-  gitleaks:
-    name: Secret scan (gitleaks)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    # We install the gitleaks CLI directly instead of using
-    # gitleaks/gitleaks-action@v2 — that wrapper requires a commercial
-    # GITLEAKS_LICENSE secret for org repos. The underlying CLI remains
-    # MIT-licensed and free.
-    env:
-      GITLEAKS_VERSION: "8.21.2"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install gitleaks
-        run: |
-          curl -sSfL \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz gitleaks
-          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
-          gitleaks version
-
-      - name: Run gitleaks
-        run: |
-          gitleaks detect \
-            --config .gitleaks.toml \
-            --no-banner \
-            --redact \
-            --verbose \
-            --exit-code 1
+  run:
+    uses: promptLM/.github/.github/workflows/oss-checks.yml@main
+    with:
+      check-license-headers: false


### PR DESCRIPTION
## Summary

- **\`.github/dependabot.yml\`** — add \`github-actions\` ecosystem (pins were silently drifting) and three \`npm\` entries for the workspaces with their own \`package-lock.json\` (root, \`acceptance-tests/\`, \`components/promptlm-api-client/\`). Dependabot does not auto-discover npm workspaces.
- **\`.github/workflows/oss-checks.yml\`** — replace inline gitleaks install + run with a thin caller of \`promptLM/.github/.github/workflows/oss-checks.yml@main\`.
- \`check-license-headers: false\` here because \`CI.yml\` already enforces license headers via skywalking-eyes — switching it on in both places would double-spend CI minutes and surface duplicate failures.

Depends on the org-github reusable workflow PR; merge that one first.

Context: the runbook tracked 25 open Dependabot security alerts as of 2026-05-24, mostly npm (lodash, handlebars, picomatch, fast-uri, playwright, storybook). Those come from always-on Security alerts. This PR turns on the version-update PRs that auto-bump them.

## Test plan

- [ ] After this merges, next PR triggers oss-checks workflow which now \`uses:\` the org reusable. Expect green gitleaks run.
- [ ] Expect Dependabot to open several npm version-update PRs within 24h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)