### PR TITLE
ci: SHA-pin all github-actions in workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,15 +36,15 @@ jobs:
           echo "REPO_REMOTE_USERNAME=${REPO_REMOTE_USERNAME:+set}"
           echo "REPO_REMOTE_TOKEN=${REPO_REMOTE_TOKEN:+set}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Check license headers
-        uses: apache/skywalking-eyes/header@v0.6.0
+        uses: apache/skywalking-eyes/header@cd7b195c51fd3d6ad52afceb760719ddc6b3ee91  # v0.6.0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload Framework Artifacts
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         continue-on-error: true
         with:
           name: promptlm-framework-${{ github.sha }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload Repository Template
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         continue-on-error: true
         with:
           name: repository-template-${{ github.sha }}

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -35,12 +35,12 @@ jobs:
       run: ${{ steps.decide.outputs.run }}
       reason: ${{ steps.decide.outputs.reason }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Detect changed paths
         id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
         with:
           filters: |
             critical:
@@ -116,12 +116,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload Acceptance Test Artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: acceptance-tests-${{ github.sha }}
           if-no-files-found: warn

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -39,9 +39,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -52,7 +52,7 @@ jobs:
       - name: Build docs (AsciiDoc → site/docs/)
         run: npm run docs:build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: site
           path: ./site
@@ -65,16 +65,16 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: site
           path: ./site
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5
         with:
           path: ./site
 
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/e2e-mock.yml
+++ b/.github/workflows/e2e-mock.yml
@@ -40,16 +40,16 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: playwright-report
           path: acceptance-tests/playwright-report/
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: playwright-test-results
           path: acceptance-tests/test-results/

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -24,9 +24,9 @@ jobs:
   build-native:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Set up GraalVM
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f  # v1
         with:
           java-version: '25.0.2'
           distribution: 'graalvm-community'
@@ -37,9 +37,9 @@ jobs:
   native-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Set up GraalVM
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f  # v1
         with:
           java-version: '25.0.2'
           distribution: 'graalvm-community'
@@ -58,7 +58,7 @@ jobs:
             test
       - name: Upload Native Smoke Artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: native-smoke-${{ github.sha }}
           if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       version: ${{ steps.set-version.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Set Next Version
         id: set-version
@@ -83,9 +83,9 @@ jobs:
     needs: calculate_version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -97,9 +97,9 @@ jobs:
     needs: jvm-verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -110,7 +110,7 @@ jobs:
         run: mvn -B -f acceptance-tests/pom.xml -Dpromptlm.bootstrap.skip=true test
       - name: Upload Acceptance Test Artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: release-acceptance-tests-${{ github.sha }}
           if-no-files-found: warn
@@ -132,12 +132,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -202,7 +202,7 @@ jobs:
           mvn -B -pl apps/promptlm-cli,apps/promptlm-webapp -am -DskipTests package
 
       - name: Upload JAR Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: app-jars
           path: |
@@ -226,9 +226,9 @@ jobs:
             platform: windows
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Set up GraalVM
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f  # v1
         with:
           java-version: '25.0.2'
           distribution: 'graalvm-community'
@@ -267,7 +267,7 @@ jobs:
 
           Compress-Archive -Path "$workDir/promptlm-cli/*" -DestinationPath "target/native/promptlm-cli-windows-$arch.zip" -Force
       - name: Upload Native Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: native-${{ matrix.platform }}
           path: |
@@ -280,9 +280,9 @@ jobs:
     needs: jvm-acceptance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Set up GraalVM
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f  # v1
         with:
           java-version: '25.0.2'
           distribution: 'graalvm-community'
@@ -301,7 +301,7 @@ jobs:
             test
       - name: Upload Native Smoke Artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: release-native-smoke-${{ github.sha }}
           if-no-files-found: warn
@@ -320,7 +320,7 @@ jobs:
     needs: [calculate_version, release, build-native-matrix, native-smoke]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Prep dir
         run: |
@@ -328,14 +328,14 @@ jobs:
           mkdir -p target/native
 
       - name: Download JAR Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: app-jars
           merge-multiple: true
           path: target/jars
 
       - name: Download Native Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: native-*
           merge-multiple: true
@@ -392,7 +392,7 @@ jobs:
       - name: Generate Changelog
         if: steps.tag-check.outputs.has_tags == 'true'
         id: changelog
-        uses: mikepenz/release-changelog-builder-action@v5
+        uses: mikepenz/release-changelog-builder-action@c9dc8369bccbc41e0ac887f8fd674f5925d315f7  # v5
         with:
           configurationJson: |
             {
@@ -418,7 +418,7 @@ jobs:
 
       - name: Create Release (With Changelog)
         if: steps.tag-check.outputs.has_tags == 'true'
-        uses: mikepenz/action-gh-release@v1
+        uses: mikepenz/action-gh-release@9a604afa5167a745eab07256a54e2f578a1a0c5e  # v1
         with:
           tag_name: v${{ needs.calculate_version.outputs.version }}
           allowUpdates: true
@@ -432,7 +432,7 @@ jobs:
 
       - name: Create Release (Initial Notes Fallback)
         if: steps.tag-check.outputs.has_tags != 'true'
-        uses: mikepenz/action-gh-release@v1
+        uses: mikepenz/action-gh-release@9a604afa5167a745eab07256a54e2f578a1a0c5e  # v1
         with:
           tag_name: v${{ needs.calculate_version.outputs.version }}
           allowUpdates: true


### PR DESCRIPTION
## Summary

- Sweep every third-party `uses:` line across `.github/workflows/*.yml` to `@<sha>  # vX`, matching the format the org's own reusable [`oss-checks.yml`](https://github.com/promptLM/.github/blob/main/.github/workflows/oss-checks.yml) already uses.
- **Versions are not bumped.** Each action stays on the same version that's currently on `main` — only the pin format changes. This keeps the diff narrowly scoped to the policy fix.
- Local actions (`./.github/actions/*`) and the org reusable workflow (`promptLM/.github/.github/workflows/oss-checks.yml@main`) are intentionally left unpinned — these live in repos we control.

## Why

Org policy now requires actions to be pinned by commit SHA. Tag pins like `@v4` would be rejected, which is why the four currently open Dependabot bump PRs ([#318](https://github.com/promptLM/promptlm-app/pull/318), [#320](https://github.com/promptLM/promptlm-app/pull/320), [#321](https://github.com/promptLM/promptlm-app/pull/321), [#322](https://github.com/promptLM/promptlm-app/pull/322)) would fail in their current form — they each bump to a new major using a bare tag (`@v6`, `@v8`, …).

## Follow-up

After this merges I'll close those four PRs. Dependabot recognises the `@<sha>  # vX` shape and will reopen the bumps against the new SHA-pinned baseline, updating both the SHA and the trailing `# vX` comment in lockstep.

## Test plan

- [ ] `oss-checks`, CI, `e2e-mock`, `Deploy site to Pages` all green on this PR — proves the resolved SHAs actually exist and behave identically to the tags they replace.
- [ ] After merge: verify Dependabot reopens the four bumps with the SHA + comment format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)