### PR TITLE
fix(#323): substitute REPLACE_ME_* in rollout templates and preserve exec bit

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/CiWorkflowHarnessTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/CiWorkflowHarnessTest.java
@@ -17,6 +17,9 @@
 package dev.promptlm.test;
 
 import com.microsoft.playwright.Page;
+import dev.promptlm.repository.template.ArtifactCoordinateSanitizer;
+import dev.promptlm.repository.template.TemplateContext;
+import dev.promptlm.repository.template.TemplateSubstitutionEngine;
 import dev.promptlm.test.support.ReleaseArtifactContractDelegate;
 import dev.promptlm.testutils.artifactory.Artifactory;
 import dev.promptlm.testutils.artifactory.ArtifactoryContainer;
@@ -45,12 +48,18 @@ import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -304,10 +313,89 @@ class CiWorkflowHarnessTest implements WithAssertions {
             }
         }
 
+        /**
+         * Path patterns that must land in the seeded repo with the executable bit set —
+         * mirrors {@code ZipFileRepositoryTemplateExtractor.EXECUTABLE_PATH_PATTERNS} in the
+         * production extractor. The two lists must stay in sync (see issue #331 finding #5
+         * for the planned shared helper). If a new shell script is added to the template,
+         * register it both here and in the production extractor.
+         */
+        private static final List<Pattern> EXECUTABLE_PATH_PATTERNS = List.of(
+                Pattern.compile("^tools/release/[^/]+$"),
+                Pattern.compile("^scripts/[^/]+\\.sh$"));
+
         private void extractTemplate(Path repoDir) throws IOException {
+            // The shipped template contains tokens like {{MAVEN_GROUP_ID}} that are
+            // invalid Maven coordinates until substituted; a raw unzip leaves the seeded
+            // repo with an unparseable pom.xml, the workflow dies in versions:set, and the
+            // outer test waits 12 minutes for an artifact that never gets published.
+            // Mirror the production extractor: substitute text entries and mark release
+            // scripts executable so JGit's add+commit preserves the +x bit downstream.
             try (InputStream inputStream = resourceStream()) {
                 ZipTestUtils.unzip(inputStream, repoDir);
             }
+            applyTemplateSubstitutionAndPermissions(repoDir);
+        }
+
+        private void applyTemplateSubstitutionAndPermissions(Path repoDir) throws IOException {
+            TemplateSubstitutionEngine engine = new TemplateSubstitutionEngine();
+            TemplateContext context = buildTemplateContext();
+            boolean posixSupported = FileSystems.getDefault()
+                    .supportedFileAttributeViews().contains("posix");
+            Set<java.nio.file.attribute.PosixFilePermission> executablePerms = posixSupported
+                    ? PosixFilePermissions.fromString("rwxr-xr-x")
+                    : Set.of();
+
+            try (Stream<Path> walk = Files.walk(repoDir)) {
+                List<Path> files = walk.filter(Files::isRegularFile).collect(Collectors.toList());
+                for (Path file : files) {
+                    String relativeEntry = repoDir.relativize(file).toString().replace('\\', '/');
+                    if (engine.isTextEntry(relativeEntry)) {
+                        byte[] original = Files.readAllBytes(file);
+                        byte[] substituted = engine.substitute(relativeEntry, original, context);
+                        Files.write(file, substituted);
+                    }
+                    if (posixSupported && isExecutableEntry(relativeEntry)) {
+                        try {
+                            Files.setPosixFilePermissions(file, executablePerms);
+                        } catch (UnsupportedOperationException ignored) {
+                            // Non-POSIX filesystem — best effort only.
+                        }
+                    }
+                }
+            }
+        }
+
+        private TemplateContext buildTemplateContext() {
+            String owner = gitea.getAdminUsername();
+            // Use the canonical 11-arg constructor and call ArtifactCoordinateSanitizer
+            // explicitly so the seeded pom.xml ends up with valid coordinates like
+            // <groupId>io.github.testuser</groupId> / <artifactId>template-repo</artifactId>.
+            return new TemplateContext(
+                    REPO_NAME,
+                    owner,
+                    "Acceptance-test seeded template repository",
+                    Instant.parse("2026-05-17T01:23:45Z"),
+                    "acceptance-test",
+                    ArtifactCoordinateSanitizer.projectName(REPO_NAME),
+                    ArtifactCoordinateSanitizer.mavenGroupId(owner),
+                    ArtifactCoordinateSanitizer.mavenArtifactId(REPO_NAME),
+                    ArtifactCoordinateSanitizer.pythonDistributionName(REPO_NAME),
+                    ArtifactCoordinateSanitizer.pythonImportName(REPO_NAME),
+                    ArtifactCoordinateSanitizer.npmPackageName(REPO_NAME));
+        }
+
+        private static boolean isExecutableEntry(String entryName) {
+            if (entryName == null) {
+                return false;
+            }
+            String normalized = entryName.replace('\\', '/').toLowerCase(Locale.ROOT);
+            for (Pattern p : EXECUTABLE_PATH_PATTERNS) {
+                if (p.matcher(normalized).matches()) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private String commitAndPush(Path repoDir, boolean force) throws IOException, GitAPIException {

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitProjectService.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitProjectService.java
@@ -19,6 +19,7 @@ package dev.promptlm.store.github;
 import dev.promptlm.domain.AppContext;
 import dev.promptlm.domain.events.ProjectCreatedEvent;
 import dev.promptlm.domain.projectspec.ProjectSpec;
+import dev.promptlm.repository.template.ArtifactCoordinateSanitizer;
 import dev.promptlm.repository.template.RepositoryTemplateExtractor;
 import dev.promptlm.repository.template.TemplateContext;
 import dev.promptlm.repository.template.TemplateSubstitutionEngine;
@@ -99,12 +100,23 @@ public class GitProjectService implements ProjectService {
 
         git.createRepository(repoPath, gitCloneUrl);
 
+        // Derive artifact-coordinate defaults from owner/repo so the rolled-out repository
+        // never ships literal REPLACE_ME_* sentinels in pom.xml / .promptlm/artifacts.toml.
+        // Users can still override these by editing the generated files. See issue #323.
+        String repo = ownerAndRepo.repo();
+        String owner = ownerAndRepo.owner();
         TemplateContext templateContext = new TemplateContext(
-                ownerAndRepo.repo(),
-                ownerAndRepo.owner(),
+                repo,
+                owner,
                 DEFAULT_PROJECT_DESCRIPTION,
                 Instant.now(),
-                TemplateSubstitutionEngine.BUILD_GENERATOR_VERSION
+                TemplateSubstitutionEngine.BUILD_GENERATOR_VERSION,
+                ArtifactCoordinateSanitizer.projectName(repo),
+                ArtifactCoordinateSanitizer.mavenGroupId(owner),
+                ArtifactCoordinateSanitizer.mavenArtifactId(repo),
+                ArtifactCoordinateSanitizer.pythonDistributionName(repo),
+                ArtifactCoordinateSanitizer.pythonImportName(repo),
+                ArtifactCoordinateSanitizer.npmPackageName(repo)
         );
         repositoryTemplateExtractor.extractTo(repoPath, templateContext);
 

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractor.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractor.java
@@ -29,13 +29,18 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -81,6 +86,21 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
         this.substitutionEngine = substitutionEngine;
     }
 
+    /**
+     * Path prefixes/suffixes whose entries must be made executable in the extracted
+     * working tree. These are the only files in the shipped template that the generated
+     * CI workflows invoke as scripts (e.g. {@code ./tools/release/build-artifacts}); if
+     * any of them lands without the executable bit the workflow fails with a confusing
+     * "Permission denied" error.
+     *
+     * <p>This list is the source of truth for the regression guard added in issue #323 —
+     * if a new shell script is added to the template, register it here too.
+     */
+    private static final List<Pattern> EXECUTABLE_PATH_PATTERNS = List.of(
+            Pattern.compile("^tools/release/[^/]+$"),
+            Pattern.compile("^scripts/[^/]+\\.sh$")
+    );
+
     @Override
     public void extractTo(Path repoPath, TemplateContext context) {
         Objects.requireNonNull(context, "context");
@@ -88,6 +108,9 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
         Map<String, byte[]> entries = readAllEntries();
         boolean releaseEnabled = isReleaseEnabled(entries.get(CONFIG_FILE_NAME));
         log.debug("Repository template release.enabled resolved to {}", releaseEnabled);
+
+        boolean posixSupported = FileSystems.getDefault()
+                .supportedFileAttributeViews().contains("posix");
 
         try {
             for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
@@ -103,6 +126,9 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
                     payload = substitutionEngine.substitute(name, payload, context);
                 }
                 Files.write(targetPath, payload);
+                if (posixSupported) {
+                    applyPosixMode(targetPath, name);
+                }
             }
             log.debug("Successfully extracted repository template to: {}", repoPath);
         } catch (IOException e) {
@@ -129,6 +155,56 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
             throw new RuntimeException("Failed to read repository template archive", e);
         }
         return entries;
+    }
+
+    /**
+     * Apply a sensible POSIX mode to the extracted file. We cannot reliably read the
+     * mode from the {@code java.util.zip.ZipInputStream} API in JDK 21 (the external
+     * attributes field of {@link ZipEntry} is package-private and only populated when
+     * reading via {@code ZipFile} random-access), so we use a deterministic
+     * path-pattern heuristic instead: entries under {@code tools/release/} and
+     * {@code scripts/*.sh} get {@code 0755}; everything else gets {@code 0644}. This
+     * mirrors the {@code fileMode} pinning in {@code src/assembly/repo-template.xml}
+     * which is the source of truth for the shipped archive.
+     *
+     * <p>Failures to apply the mode are logged at debug and never propagated — losing
+     * the executable bit is a workflow regression, not a reason to abort the rollout.
+     */
+    static void applyPosixMode(Path targetPath, String entryName) {
+        int mode = isExecutableEntry(entryName) ? 0755 : 0644;
+        try {
+            Files.setPosixFilePermissions(targetPath, fromMode(mode));
+        } catch (IOException | UnsupportedOperationException e) {
+            log.debug("Failed to apply POSIX mode {} to {}: {}",
+                    Integer.toOctalString(mode), targetPath, e.getMessage());
+        }
+    }
+
+    static boolean isExecutableEntry(String entryName) {
+        if (entryName == null) {
+            return false;
+        }
+        String normalized = entryName.replace('\\', '/').toLowerCase(Locale.ROOT);
+        for (Pattern p : EXECUTABLE_PATH_PATTERNS) {
+            if (p.matcher(normalized).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static Set<PosixFilePermission> fromMode(int mode) {
+        EnumSet<PosixFilePermission> perms = EnumSet.noneOf(PosixFilePermission.class);
+        if ((mode & 0400) != 0) perms.add(PosixFilePermission.OWNER_READ);
+        if ((mode & 0200) != 0) perms.add(PosixFilePermission.OWNER_WRITE);
+        if ((mode & 0100) != 0) perms.add(PosixFilePermission.OWNER_EXECUTE);
+        if ((mode & 0040) != 0) perms.add(PosixFilePermission.GROUP_READ);
+        if ((mode & 0020) != 0) perms.add(PosixFilePermission.GROUP_WRITE);
+        if ((mode & 0010) != 0) perms.add(PosixFilePermission.GROUP_EXECUTE);
+        if ((mode & 0004) != 0) perms.add(PosixFilePermission.OTHERS_READ);
+        if ((mode & 0002) != 0) perms.add(PosixFilePermission.OTHERS_WRITE);
+        if ((mode & 0001) != 0) perms.add(PosixFilePermission.OTHERS_EXECUTE);
+        return perms;
     }
 
     private static boolean isReleaseOnly(String entryName) {

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorSubstitutionTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorSubstitutionTest.java
@@ -17,17 +17,20 @@
 package dev.promptlm.store.github;
 
 import dev.promptlm.repository.template.TemplateContext;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -121,6 +124,100 @@ class ZipFileRepositoryTemplateExtractorSubstitutionTest {
         assertThat(metadata).doesNotContain("2025-01-19T22:42:35Z");
         assertThat(metadata).doesNotContain("0.1.0-SNAPSHOT");
         assertThat(metadata).doesNotContain("{{");
+    }
+
+    /**
+     * Regression guard for issue #323: the rolled-out repository must contain no literal
+     * {@code REPLACE_ME_} sentinels and must substitute the artifact-coordinate tokens
+     * derived from owner/repo into {@code pom.xml} and {@code .promptlm/artifacts.toml}.
+     */
+    @Test
+    void noFileContainsReplaceMeSentinelAndPomHasSubstitutedCoordinates(@TempDir Path tempDir) throws IOException {
+        ZipFileRepositoryTemplateExtractor extractor = new ZipFileRepositoryTemplateExtractor();
+        // Mirror what GitProjectService passes: derived coordinates from owner+repo.
+        TemplateContext context = new TemplateContext(
+                "my-prompts",
+                "ACME-Corp",
+                "issue-323 regression guard",
+                Instant.parse("2026-05-17T01:23:45Z"),
+                "9.9.9");
+
+        extractor.extractTo(tempDir, context);
+
+        String pom = Files.readString(tempDir.resolve("pom.xml"), StandardCharsets.UTF_8);
+        assertThat(pom).contains("<groupId>io.github.acme-corp</groupId>");
+        assertThat(pom).contains("<artifactId>my-prompts</artifactId>");
+
+        String artifactsToml = Files.readString(tempDir.resolve(".promptlm/artifacts.toml"), StandardCharsets.UTF_8);
+        assertThat(artifactsToml).contains("group_id = \"io.github.acme-corp\"");
+        assertThat(artifactsToml).contains("artifact_id = \"my-prompts\"");
+        assertThat(artifactsToml).contains("distribution_name = \"my-prompts\"");
+        assertThat(artifactsToml).contains("import_name = \"my_prompts\"");
+        assertThat(artifactsToml).contains("package_name = \"my-prompts\"");
+
+        // No file under the extracted tree should contain a REPLACE_ME_ literal in a place
+        // where downstream tooling would consume it as a real value.
+        //
+        // Known-legitimate references (allow-listed):
+        //   - .promptlm/artifacts.toml: sample deploy-profile URLs (Artifactory /
+        //     GitHub-packages / custom) — P1 follow-up.
+        //   - .github/artifactory-config.yml: REFERENCE ONLY per issue #325 (P1).
+        //   - scripts/package-prompts.sh: documents in a comment that
+        //     REPLACE_ME_* values trigger a fallback — describing the string, not
+        //     using it as a coordinate.
+        Set<String> allowList = Set.of(
+                ".promptlm/artifacts.toml",
+                ".github/artifactory-config.yml",
+                "scripts/package-prompts.sh");
+        try (Stream<Path> walk = Files.walk(tempDir)) {
+            walk.filter(Files::isRegularFile)
+                    .filter(p -> !allowList.contains(
+                            tempDir.relativize(p).toString().replace('\\', '/')))
+                    .forEach(p -> {
+                        try {
+                            String content = Files.readString(p, StandardCharsets.UTF_8);
+                            assertThat(content)
+                                    .as("Unexpected REPLACE_ME_ sentinel left in %s", tempDir.relativize(p))
+                                    .doesNotContain("REPLACE_ME_");
+                        } catch (IOException e) {
+                            // Binary file (e.g. images) — readString would throw MalformedInput.
+                            // Treat as no-op: the substring REPLACE_ME_ in a binary is implausible.
+                        }
+                    });
+        }
+    }
+
+    /**
+     * Regression guard for issue #323: release scripts must be extracted with the
+     * executable bit set so the generated CI workflows can invoke
+     * {@code ./tools/release/build-artifacts} without "Permission denied".
+     */
+    @Test
+    void releaseScriptsAreExecutableOnPosix(@TempDir Path tempDir) throws IOException {
+        Assumptions.assumeTrue(
+                FileSystems.getDefault().supportedFileAttributeViews().contains("posix"),
+                "POSIX permissions are not supported on this filesystem");
+
+        ZipFileRepositoryTemplateExtractor extractor = new ZipFileRepositoryTemplateExtractor();
+        TemplateContext context = new TemplateContext(
+                "my-prompts",
+                "ACME-Corp",
+                "issue-323 exec-bit regression guard",
+                Instant.parse("2026-05-17T01:23:45Z"),
+                "9.9.9");
+
+        extractor.extractTo(tempDir, context);
+
+        Path buildArtifacts = tempDir.resolve("tools/release/build-artifacts");
+        Path publishArtifacts = tempDir.resolve("tools/release/publish-artifacts");
+        assertThat(buildArtifacts).exists();
+        assertThat(publishArtifacts).exists();
+        assertThat(Files.isExecutable(buildArtifacts))
+                .as("tools/release/build-artifacts must be executable after extraction (regression guard for #323)")
+                .isTrue();
+        assertThat(Files.isExecutable(publishArtifacts))
+                .as("tools/release/publish-artifacts must be executable after extraction (regression guard for #323)")
+                .isTrue();
     }
 
     private static List<Path> collectTextFiles(Path root) throws IOException {

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorSubstitutionTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorSubstitutionTest.java
@@ -159,8 +159,12 @@ class ZipFileRepositoryTemplateExtractorSubstitutionTest {
         // where downstream tooling would consume it as a real value.
         //
         // Known-legitimate references (allow-listed):
-        //   - .promptlm/artifacts.toml: sample deploy-profile URLs (Artifactory /
-        //     GitHub-packages / custom) — P1 follow-up.
+        //   - .promptlm/artifacts.toml: Artifactory / custom-profile URLs that genuinely
+        //     require the user to fill in an external service URL we cannot know at
+        //     rollout time (REPLACE_ME_ARTIFACTORY_URL, REPLACE_ME_custom_*,
+        //     REPLACE_ME_pypi_repo_url for the GitHub profile — see comment in the file).
+        //     The GitHub Maven URL is substituted via {{REPO_OWNER}}/{{REPO_NAME}} so it
+        //     does NOT appear in the allow-list.
         //   - .github/artifactory-config.yml: REFERENCE ONLY per issue #325 (P1).
         //   - scripts/package-prompts.sh: documents in a comment that
         //     REPLACE_ME_* values trigger a fallback — describing the string, not
@@ -188,9 +192,13 @@ class ZipFileRepositoryTemplateExtractorSubstitutionTest {
     }
 
     /**
-     * Regression guard for issue #323: release scripts must be extracted with the
-     * executable bit set so the generated CI workflows can invoke
-     * {@code ./tools/release/build-artifacts} without "Permission denied".
+     * Regression guard for issue #323: every extracted file's executable bit must agree
+     * with the extractor's own {@link ZipFileRepositoryTemplateExtractor#isExecutableEntry}
+     * classifier — files the classifier deems executable must have the bit set, and
+     * everything else must not. Walking the whole tree (rather than hardcoding two paths)
+     * means a newly added shell script in the template is caught automatically as long as
+     * it is registered in {@code EXECUTABLE_PATH_PATTERNS} and pinned to {@code 0755} in
+     * the assembly descriptor — the two sources of truth for the shipped archive.
      */
     @Test
     void releaseScriptsAreExecutableOnPosix(@TempDir Path tempDir) throws IOException {
@@ -208,16 +216,31 @@ class ZipFileRepositoryTemplateExtractorSubstitutionTest {
 
         extractor.extractTo(tempDir, context);
 
-        Path buildArtifacts = tempDir.resolve("tools/release/build-artifacts");
-        Path publishArtifacts = tempDir.resolve("tools/release/publish-artifacts");
-        assertThat(buildArtifacts).exists();
-        assertThat(publishArtifacts).exists();
-        assertThat(Files.isExecutable(buildArtifacts))
-                .as("tools/release/build-artifacts must be executable after extraction (regression guard for #323)")
-                .isTrue();
-        assertThat(Files.isExecutable(publishArtifacts))
-                .as("tools/release/publish-artifacts must be executable after extraction (regression guard for #323)")
-                .isTrue();
+        // Spot-check the canonical executables exist so a silent miss (e.g. release-only
+        // gating bug) doesn't pass this test vacuously.
+        List<Path> requiredExecutables = List.of(
+                tempDir.resolve("tools/release/build-artifacts"),
+                tempDir.resolve("tools/release/publish-artifacts"),
+                tempDir.resolve("scripts/validate-prompts.sh"),
+                tempDir.resolve("scripts/package-prompts.sh"));
+        for (Path required : requiredExecutables) {
+            assertThat(required)
+                    .as("expected executable %s to be present after extraction", tempDir.relativize(required))
+                    .exists();
+        }
+
+        // Walk the whole tree: every file's executable bit must match the classifier the
+        // extractor itself uses, so adding a new shell script anywhere in the template
+        // automatically extends coverage.
+        try (Stream<Path> walk = Files.walk(tempDir)) {
+            walk.filter(Files::isRegularFile).forEach(p -> {
+                String relative = tempDir.relativize(p).toString().replace('\\', '/');
+                boolean expectedExecutable = ZipFileRepositoryTemplateExtractor.isExecutableEntry(relative);
+                assertThat(Files.isExecutable(p))
+                        .as("executable bit on %s must match isExecutableEntry classifier (regression guard for #323)", relative)
+                        .isEqualTo(expectedExecutable);
+            });
+        }
     }
 
     private static List<Path> collectTextFiles(Path root) throws IOException {

--- a/components/repository-template/repo-resources/.promptlm/artifacts.toml
+++ b/components/repository-template/repo-resources/.promptlm/artifacts.toml
@@ -31,8 +31,11 @@ npm_repo_url = "https://REPLACE_ME_ARTIFACTORY_URL/api/npm/npm-local"
 
 [deploy.profiles.github]
 type = "github_packages"
-maven_repo_url = "https://maven.pkg.github.com/REPLACE_ME_github_owner/REPLACE_ME_github_repo"
-pypi_repo_url = "https://REPLACE_ME_github_pypi_url"
+maven_repo_url = "https://maven.pkg.github.com/{{REPO_OWNER}}/{{REPO_NAME}}"
+# GitHub Packages does not provide a generic PyPI endpoint. Teams that need
+# PyPI publishing typically point this at a self-hosted index or PyPI itself;
+# leave the placeholder so the misconfiguration is loud rather than silent.
+pypi_repo_url = "https://REPLACE_ME_pypi_repo_url"
 npm_repo_url = "https://npm.pkg.github.com"
 
 [deploy.profiles.custom]

--- a/components/repository-template/repo-resources/.promptlm/artifacts.toml
+++ b/components/repository-template/repo-resources/.promptlm/artifacts.toml
@@ -1,21 +1,21 @@
 [project]
-name = "REPLACE_ME_project_name"
+name = "{{PROJECT_NAME}}"
 version = "1.0.0"
 # Optional: empty or missing => no artifact builds
 # targets = ["java", "python", "js"]
 
 [artifacts.java]
-group_id = "REPLACE_ME_group_id"
-artifact_id = "REPLACE_ME_artifact_id"
+group_id = "{{MAVEN_GROUP_ID}}"
+artifact_id = "{{MAVEN_ARTIFACT_ID}}"
 packaging = "jar"
 
 [artifacts.python]
-distribution_name = "REPLACE_ME_python_distribution_name"
-import_name = "REPLACE_ME_python_import_name"
+distribution_name = "{{PYTHON_DISTRIBUTION_NAME}}"
+import_name = "{{PYTHON_IMPORT_NAME}}"
 build_types = ["wheel", "sdist"]
 
 [artifacts.js]
-package_name = "REPLACE_ME_npm_package_name"
+package_name = "{{NPM_PACKAGE_NAME}}"
 module_type = "commonjs"
 
 [deploy]

--- a/components/repository-template/repo-resources/pom.xml
+++ b/components/repository-template/repo-resources/pom.xml
@@ -5,10 +5,10 @@
          http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Project coordinates - replace REPLACE_ME_* sentinels with your prompt repository's values. -->
-    <!-- Builds intentionally fail with a clear error until these are configured. -->
-    <groupId>REPLACE_ME_group_id</groupId>
-    <artifactId>REPLACE_ME_artifact_id</artifactId>
+    <!-- Project coordinates - filled in at rollout time from the repository owner/name. -->
+    <!-- Override these manually if you want different Maven coordinates. -->
+    <groupId>{{MAVEN_GROUP_ID}}</groupId>
+    <artifactId>{{MAVEN_ARTIFACT_ID}}</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 

--- a/components/repository-template/src/assembly/repo-template.xml
+++ b/components/repository-template/src/assembly/repo-template.xml
@@ -23,7 +23,6 @@
                 <include>.github/workflows/deploy-artifactory.yml</include>
                 <include>.github/workflows/release.yml</include>
                 <include>.github/workflows/validate.yml</include>
-                <include>tools/release/**</include>
             </includes>
         </fileSet>
         <fileSet>
@@ -33,6 +32,7 @@
             <includes>
                 <include>scripts/validate-prompts.sh</include>
                 <include>scripts/package-prompts.sh</include>
+                <include>tools/release/**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/components/repository-template/src/main/java/dev/promptlm/repository/template/ArtifactCoordinateSanitizer.java
+++ b/components/repository-template/src/main/java/dev/promptlm/repository/template/ArtifactCoordinateSanitizer.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.repository.template;
+
+import java.util.Locale;
+
+/**
+ * Sanitizes a repository owner/name into the various artifact-coordinate flavors that a
+ * generated prompt repository ships with — Maven {@code groupId}/{@code artifactId},
+ * PEP 503 Python distribution name, PEP 8 Python import name, and npm package name.
+ *
+ * <p>The defaults produced here are intentionally <em>best-effort but always valid</em>: they
+ * never throw, never return an empty string, and never produce a value that violates the
+ * receiving ecosystem's identifier rules. Users are expected to override these in the
+ * generated {@code pom.xml} / {@code .promptlm/artifacts.toml} when they have specific
+ * coordinates in mind; the job of this class is to ensure the rollout never ships a literal
+ * {@code REPLACE_ME_*} sentinel that would silently break downstream builds.
+ *
+ * <p>None of the produced values are quoted or otherwise context-escaped — callers that
+ * substitute them into JSON/XML/TOML must rely on
+ * {@link TemplateSubstitutionEngine}'s per-format escaping.
+ */
+public final class ArtifactCoordinateSanitizer {
+
+    private static final String FALLBACK = "prompts";
+
+    private ArtifactCoordinateSanitizer() {
+    }
+
+    /**
+     * Derive a Maven {@code groupId} from a repository owner. Produces
+     * {@code io.github.<sanitized-owner>} where {@code <sanitized-owner>} is lowercased and
+     * all characters outside {@code [a-z0-9.]} are collapsed to {@code -}, then trimmed of
+     * leading/trailing punctuation.
+     *
+     * @param ownerName the GitHub owner (login or organization). May be {@code null} or
+     *                  effectively empty.
+     * @return a never-{@code null}, always-valid Maven groupId.
+     */
+    public static String mavenGroupId(String ownerName) {
+        String owner = sanitizeGeneric(ownerName, "[a-z0-9.]", '-');
+        if (owner.isEmpty()) {
+            owner = FALLBACK;
+        }
+        return "io.github." + owner;
+    }
+
+    /**
+     * Derive a Maven {@code artifactId} from a repository name. Lowercased, characters
+     * outside {@code [a-z0-9.-]} collapsed to {@code -}.
+     */
+    public static String mavenArtifactId(String repositoryName) {
+        String out = sanitizeGeneric(repositoryName, "[a-z0-9.-]", '-');
+        return out.isEmpty() ? FALLBACK : out;
+    }
+
+    /**
+     * Derive a PEP 503 (<a href="https://peps.python.org/pep-0503/">PEP 503</a>) normalized
+     * Python distribution name from a repository name: lowercased, runs of
+     * {@code [^a-z0-9]+} collapsed to a single {@code -}, with leading/trailing dashes
+     * trimmed.
+     */
+    public static String pythonDistributionName(String repositoryName) {
+        String out = collapseToSingle(repositoryName, "a-z0-9", '-');
+        return out.isEmpty() ? FALLBACK : out;
+    }
+
+    /**
+     * Derive a PEP 8 Python import name (valid Python module identifier) from a repository
+     * name: lowercased, runs of {@code [^a-z0-9_]+} collapsed to a single {@code _}, with
+     * leading/trailing underscores trimmed. If the result would start with a digit (illegal
+     * in Python identifiers) it is prefixed with {@code _}.
+     */
+    public static String pythonImportName(String repositoryName) {
+        String out = collapseToSingle(repositoryName, "a-z0-9_", '_');
+        if (out.isEmpty()) {
+            return FALLBACK;
+        }
+        if (Character.isDigit(out.charAt(0))) {
+            return "_" + out;
+        }
+        return out;
+    }
+
+    /**
+     * Derive an npm package name from a repository name: lowercased, runs of
+     * {@code [^a-z0-9._-]+} collapsed to a single {@code -}, with leading/trailing dots,
+     * underscores and dashes trimmed.
+     */
+    public static String npmPackageName(String repositoryName) {
+        String out = collapseToSingle(repositoryName, "a-z0-9._-", '-');
+        // npm forbids names starting with '.' or '_'
+        int start = 0;
+        while (start < out.length()) {
+            char c = out.charAt(start);
+            if (c == '.' || c == '_' || c == '-') {
+                start++;
+            } else {
+                break;
+            }
+        }
+        out = out.substring(start);
+        return out.isEmpty() ? FALLBACK : out;
+    }
+
+    /**
+     * Pass-through: returns the repository name as the project name. Callers may want to
+     * keep capitalization for display, so we intentionally do not lowercase here. Falls back
+     * to {@code "prompts"} when {@code repositoryName} is {@code null} or blank.
+     */
+    public static String projectName(String repositoryName) {
+        if (repositoryName == null) {
+            return FALLBACK;
+        }
+        String trimmed = repositoryName.trim();
+        return trimmed.isEmpty() ? FALLBACK : trimmed;
+    }
+
+    /**
+     * Lowercase + replace any char not in {@code allowedClass} (regex char class body, no
+     * brackets) with {@code replacement}; collapse consecutive replacements; trim leading
+     * and trailing replacement chars and dots.
+     */
+    private static String sanitizeGeneric(String input, String allowedClass, char replacement) {
+        if (input == null) {
+            return "";
+        }
+        String lower = input.toLowerCase(Locale.ROOT);
+        StringBuilder out = new StringBuilder(lower.length());
+        boolean lastWasReplacement = false;
+        for (int i = 0; i < lower.length(); i++) {
+            char c = lower.charAt(i);
+            if (String.valueOf(c).matches(allowedClass)) {
+                out.append(c);
+                lastWasReplacement = false;
+            } else {
+                if (!lastWasReplacement && out.length() > 0) {
+                    out.append(replacement);
+                    lastWasReplacement = true;
+                }
+            }
+        }
+        // trim trailing replacement / leading-trailing dots and dashes
+        int end = out.length();
+        while (end > 0) {
+            char c = out.charAt(end - 1);
+            if (c == replacement || c == '.' || c == '-') {
+                end--;
+            } else {
+                break;
+            }
+        }
+        int begin = 0;
+        while (begin < end) {
+            char c = out.charAt(begin);
+            if (c == replacement || c == '.' || c == '-') {
+                begin++;
+            } else {
+                break;
+            }
+        }
+        return out.substring(begin, end);
+    }
+
+    /**
+     * Lowercase + replace runs of {@code [^<allowedClass>]+} with a single {@code separator},
+     * trim leading/trailing separators. Stricter variant of {@link #sanitizeGeneric} used for
+     * PEP 503 / PEP 8 / npm normalization where ecosystem rules forbid runs of separators.
+     */
+    private static String collapseToSingle(String input, String allowedClass, char separator) {
+        if (input == null) {
+            return "";
+        }
+        String lower = input.toLowerCase(Locale.ROOT);
+        StringBuilder out = new StringBuilder(lower.length());
+        boolean lastWasSeparator = true; // suppress leading separators
+        for (int i = 0; i < lower.length(); i++) {
+            char c = lower.charAt(i);
+            if (String.valueOf(c).matches("[" + allowedClass + "]")) {
+                out.append(c);
+                lastWasSeparator = false;
+            } else if (!lastWasSeparator) {
+                out.append(separator);
+                lastWasSeparator = true;
+            }
+        }
+        // trim trailing separator
+        int end = out.length();
+        while (end > 0 && out.charAt(end - 1) == separator) {
+            end--;
+        }
+        return out.substring(0, end);
+    }
+}

--- a/components/repository-template/src/main/java/dev/promptlm/repository/template/TemplateContext.java
+++ b/components/repository-template/src/main/java/dev/promptlm/repository/template/TemplateContext.java
@@ -69,11 +69,15 @@ public record TemplateContext(
     }
 
     /**
-     * Back-compat secondary constructor: takes the 5 original fields and derives the
-     * artifact-coordinate tokens from {@code repositoryName} / {@code ownerName} via
-     * {@link ArtifactCoordinateSanitizer}. New call sites that want explicit control over
-     * the artifact coordinates should use the canonical constructor.
+     * Back-compat secondary constructor. Retained for back-compat; new production call sites
+     * SHOULD use the canonical 11-arg constructor and pass explicit coordinates. The
+     * auto-derivation via {@link ArtifactCoordinateSanitizer} performed here is intended for
+     * tests and migration only — relying on it from production code risks silently shipping
+     * the derived defaults where an explicit override was intended.
+     *
+     * @deprecated Use the canonical 11-arg constructor; see class javadoc.
      */
+    @Deprecated(since = "0.2.0", forRemoval = false)
     public TemplateContext(
             String repositoryName,
             String ownerName,

--- a/components/repository-template/src/main/java/dev/promptlm/repository/template/TemplateContext.java
+++ b/components/repository-template/src/main/java/dev/promptlm/repository/template/TemplateContext.java
@@ -21,21 +21,38 @@ import java.util.Objects;
 
 /**
  * Values that the repository template extractor substitutes into the generated repository at
- * extraction time. Carries the canonical token sources for {@code {{REPO_NAME}}},
- * {@code {{REPO_OWNER}}}, {@code {{PROJECT_DESCRIPTION}}}, {@code {{CREATED_AT}}} and
- * {@code {{GENERATOR_VERSION}}}.
+ * extraction time. Carries the canonical token sources for:
+ *
+ * <ul>
+ *     <li>{@code {{REPO_NAME}}}, {@code {{REPO_OWNER}}}, {@code {{PROJECT_DESCRIPTION}}},
+ *         {@code {{CREATED_AT}}}, {@code {{GENERATOR_VERSION}}} — original P0 tokens.</li>
+ *     <li>{@code {{PROJECT_NAME}}}, {@code {{MAVEN_GROUP_ID}}},
+ *         {@code {{MAVEN_ARTIFACT_ID}}}, {@code {{PYTHON_DISTRIBUTION_NAME}}},
+ *         {@code {{PYTHON_IMPORT_NAME}}}, {@code {{NPM_PACKAGE_NAME}}} — artifact-coordinate
+ *         tokens introduced for issue #323 so rolled-out repositories never ship literal
+ *         {@code REPLACE_ME_*} sentinels.</li>
+ * </ul>
  *
  * <p>{@code createdAt} is rendered as ISO-8601 UTC (e.g. {@code 2026-05-17T01:23:45Z}).
  *
- * <p>This is an immutable, equality-by-value record; callers should construct one per repository
- * generation.
+ * <p>This is an immutable, equality-by-value record; callers should construct one per
+ * repository generation. A 5-arg back-compat secondary constructor derives the artifact
+ * coordinates from {@code repositoryName} / {@code ownerName} via
+ * {@link ArtifactCoordinateSanitizer}, so existing call sites that do not yet know about
+ * the artifact tokens still produce a valid {@code TemplateContext}.
  */
 public record TemplateContext(
         String repositoryName,
         String ownerName,
         String projectDescription,
         Instant createdAt,
-        String generatorVersion) {
+        String generatorVersion,
+        String projectName,
+        String mavenGroupId,
+        String mavenArtifactId,
+        String pythonDistributionName,
+        String pythonImportName,
+        String npmPackageName) {
 
     public TemplateContext {
         Objects.requireNonNull(repositoryName, "repositoryName");
@@ -43,5 +60,38 @@ public record TemplateContext(
         Objects.requireNonNull(projectDescription, "projectDescription");
         Objects.requireNonNull(createdAt, "createdAt");
         Objects.requireNonNull(generatorVersion, "generatorVersion");
+        Objects.requireNonNull(projectName, "projectName");
+        Objects.requireNonNull(mavenGroupId, "mavenGroupId");
+        Objects.requireNonNull(mavenArtifactId, "mavenArtifactId");
+        Objects.requireNonNull(pythonDistributionName, "pythonDistributionName");
+        Objects.requireNonNull(pythonImportName, "pythonImportName");
+        Objects.requireNonNull(npmPackageName, "npmPackageName");
+    }
+
+    /**
+     * Back-compat secondary constructor: takes the 5 original fields and derives the
+     * artifact-coordinate tokens from {@code repositoryName} / {@code ownerName} via
+     * {@link ArtifactCoordinateSanitizer}. New call sites that want explicit control over
+     * the artifact coordinates should use the canonical constructor.
+     */
+    public TemplateContext(
+            String repositoryName,
+            String ownerName,
+            String projectDescription,
+            Instant createdAt,
+            String generatorVersion) {
+        this(
+                repositoryName,
+                ownerName,
+                projectDescription,
+                createdAt,
+                generatorVersion,
+                ArtifactCoordinateSanitizer.projectName(repositoryName),
+                ArtifactCoordinateSanitizer.mavenGroupId(ownerName),
+                ArtifactCoordinateSanitizer.mavenArtifactId(repositoryName),
+                ArtifactCoordinateSanitizer.pythonDistributionName(repositoryName),
+                ArtifactCoordinateSanitizer.pythonImportName(repositoryName),
+                ArtifactCoordinateSanitizer.npmPackageName(repositoryName)
+        );
     }
 }

--- a/components/repository-template/src/main/java/dev/promptlm/repository/template/TemplateSubstitutionEngine.java
+++ b/components/repository-template/src/main/java/dev/promptlm/repository/template/TemplateSubstitutionEngine.java
@@ -38,6 +38,12 @@ import java.util.Set;
  *     <li>{@code {{PROJECT_DESCRIPTION}}}</li>
  *     <li>{@code {{CREATED_AT}}} (ISO-8601 UTC)</li>
  *     <li>{@code {{GENERATOR_VERSION}}}</li>
+ *     <li>{@code {{PROJECT_NAME}}}</li>
+ *     <li>{@code {{MAVEN_GROUP_ID}}}</li>
+ *     <li>{@code {{MAVEN_ARTIFACT_ID}}}</li>
+ *     <li>{@code {{PYTHON_DISTRIBUTION_NAME}}}</li>
+ *     <li>{@code {{PYTHON_IMPORT_NAME}}}</li>
+ *     <li>{@code {{NPM_PACKAGE_NAME}}}</li>
  * </ul>
  *
  * <p>Substitution is single-pass: substituted output is never re-scanned for tokens.
@@ -166,6 +172,12 @@ public final class TemplateSubstitutionEngine {
         tokens.put("PROJECT_DESCRIPTION", maybeJsonEscape(context.projectDescription(), jsonEscape));
         tokens.put("CREATED_AT", maybeJsonEscape(createdAt, jsonEscape));
         tokens.put("GENERATOR_VERSION", maybeJsonEscape(generatorVersion, jsonEscape));
+        tokens.put("PROJECT_NAME", maybeJsonEscape(context.projectName(), jsonEscape));
+        tokens.put("MAVEN_GROUP_ID", maybeJsonEscape(context.mavenGroupId(), jsonEscape));
+        tokens.put("MAVEN_ARTIFACT_ID", maybeJsonEscape(context.mavenArtifactId(), jsonEscape));
+        tokens.put("PYTHON_DISTRIBUTION_NAME", maybeJsonEscape(context.pythonDistributionName(), jsonEscape));
+        tokens.put("PYTHON_IMPORT_NAME", maybeJsonEscape(context.pythonImportName(), jsonEscape));
+        tokens.put("NPM_PACKAGE_NAME", maybeJsonEscape(context.npmPackageName(), jsonEscape));
         return tokens;
     }
 
@@ -219,6 +231,8 @@ public final class TemplateSubstitutionEngine {
      */
     static Set<String> recognizedTokens() {
         return new LinkedHashSet<>(Set.of(
-                "REPO_NAME", "REPO_OWNER", "PROJECT_DESCRIPTION", "CREATED_AT", "GENERATOR_VERSION"));
+                "REPO_NAME", "REPO_OWNER", "PROJECT_DESCRIPTION", "CREATED_AT", "GENERATOR_VERSION",
+                "PROJECT_NAME", "MAVEN_GROUP_ID", "MAVEN_ARTIFACT_ID",
+                "PYTHON_DISTRIBUTION_NAME", "PYTHON_IMPORT_NAME", "NPM_PACKAGE_NAME"));
     }
 }

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/ArtifactCoordinateSanitizerTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/ArtifactCoordinateSanitizerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.repository.template;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArtifactCoordinateSanitizerTest {
+
+    @Test
+    void mavenGroupIdLowercasesOwnerAndPrefixesWithIoGithub() {
+        assertThat(ArtifactCoordinateSanitizer.mavenGroupId("Acme-Corp"))
+                .isEqualTo("io.github.acme-corp");
+    }
+
+    @Test
+    void mavenGroupIdReplacesUnderscoresAndSpecialCharsWithDashes() {
+        assertThat(ArtifactCoordinateSanitizer.mavenGroupId("Org-With.Special_Chars"))
+                .isEqualTo("io.github.org-with.special-chars");
+    }
+
+    @Test
+    void mavenGroupIdFallsBackToPromptsForBlankOrNullOwner() {
+        assertThat(ArtifactCoordinateSanitizer.mavenGroupId(null)).isEqualTo("io.github.prompts");
+        assertThat(ArtifactCoordinateSanitizer.mavenGroupId("")).isEqualTo("io.github.prompts");
+        assertThat(ArtifactCoordinateSanitizer.mavenGroupId("___"))
+                .isEqualTo("io.github.prompts");
+    }
+
+    @Test
+    void mavenArtifactIdLowercasesAndCollapsesNonAllowedToDash() {
+        assertThat(ArtifactCoordinateSanitizer.mavenArtifactId("My-Prompts"))
+                .isEqualTo("my-prompts");
+        assertThat(ArtifactCoordinateSanitizer.mavenArtifactId("My Prompts!"))
+                .isEqualTo("my-prompts");
+    }
+
+    @Test
+    void pythonDistributionNamePep503Normalizes() {
+        // PEP 503: lowercase, runs of non-alphanumeric collapse to single '-'.
+        assertThat(ArtifactCoordinateSanitizer.pythonDistributionName("My_Cool.Prompts"))
+                .isEqualTo("my-cool-prompts");
+        assertThat(ArtifactCoordinateSanitizer.pythonDistributionName("foo___bar"))
+                .isEqualTo("foo-bar");
+        assertThat(ArtifactCoordinateSanitizer.pythonDistributionName("---weird---"))
+                .isEqualTo("weird");
+    }
+
+    @Test
+    void pythonImportNamePep8AndStartsWithLetterOrUnderscore() {
+        assertThat(ArtifactCoordinateSanitizer.pythonImportName("my-prompts"))
+                .isEqualTo("my_prompts");
+        assertThat(ArtifactCoordinateSanitizer.pythonImportName("My.Cool-Prompts"))
+                .isEqualTo("my_cool_prompts");
+        // Leading digit → prefix with underscore to keep a valid Python identifier.
+        assertThat(ArtifactCoordinateSanitizer.pythonImportName("123-go"))
+                .isEqualTo("_123_go");
+    }
+
+    @Test
+    void npmPackageNameLowercasesAndStripsLeadingDotOrUnderscore() {
+        assertThat(ArtifactCoordinateSanitizer.npmPackageName("My-Prompts"))
+                .isEqualTo("my-prompts");
+        assertThat(ArtifactCoordinateSanitizer.npmPackageName("@scoped/pkg"))
+                .isEqualTo("scoped-pkg");
+        assertThat(ArtifactCoordinateSanitizer.npmPackageName("_private"))
+                .isEqualTo("private");
+        assertThat(ArtifactCoordinateSanitizer.npmPackageName(".dotfile"))
+                .isEqualTo("dotfile");
+    }
+
+    @Test
+    void projectNameKeepsOriginalCasing() {
+        assertThat(ArtifactCoordinateSanitizer.projectName("My-Cool-Prompts"))
+                .isEqualTo("My-Cool-Prompts");
+    }
+
+    @Test
+    void projectNameFallsBackForBlankInput() {
+        assertThat(ArtifactCoordinateSanitizer.projectName(null)).isEqualTo("prompts");
+        assertThat(ArtifactCoordinateSanitizer.projectName("")).isEqualTo("prompts");
+        assertThat(ArtifactCoordinateSanitizer.projectName("   ")).isEqualTo("prompts");
+    }
+
+    @Test
+    void allSanitizersTolerateNullInput() {
+        // No NPE — every sanitizer falls back to a sensible default.
+        assertThat(ArtifactCoordinateSanitizer.mavenArtifactId(null)).isEqualTo("prompts");
+        assertThat(ArtifactCoordinateSanitizer.pythonDistributionName(null)).isEqualTo("prompts");
+        assertThat(ArtifactCoordinateSanitizer.pythonImportName(null)).isEqualTo("prompts");
+        assertThat(ArtifactCoordinateSanitizer.npmPackageName(null)).isEqualTo("prompts");
+    }
+
+    @Test
+    void exampleEndToEndAcmeCorpMyPromptsMatchesPrSpec() {
+        // The exact case called out in the issue #325 integration-test contract.
+        assertThat(ArtifactCoordinateSanitizer.mavenGroupId("ACME-Corp"))
+                .isEqualTo("io.github.acme-corp");
+        assertThat(ArtifactCoordinateSanitizer.mavenArtifactId("my-prompts"))
+                .isEqualTo("my-prompts");
+    }
+}

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateActSmokeTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateActSmokeTest.java
@@ -30,11 +30,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -227,6 +229,17 @@ class RepositoryTemplateActSmokeTest {
     }
 
     private static void extractRepositoryTemplate(Path repositoryDir) throws IOException {
+        // Mirror the production extractor's behavior: substitute template tokens
+        // (otherwise the new {{MAVEN_GROUP_ID}} / {{MAVEN_ARTIFACT_ID}} tokens leave a
+        // pom.xml that Maven refuses to parse) and apply +x to the release scripts.
+        TemplateSubstitutionEngine engine = new TemplateSubstitutionEngine();
+        TemplateContext context = new TemplateContext(
+                "template-repo",
+                "promptlm-act-smoke",
+                "act-smoke template repository",
+                Instant.parse("2026-05-17T01:23:45Z"),
+                "smoke");
+
         try (InputStream resource = RepositoryTemplateActSmokeTest.class.getClassLoader()
                 .getResourceAsStream("repo-template.zip")) {
             if (resource == null) {
@@ -240,7 +253,22 @@ class RepositoryTemplateActSmokeTest {
                         Files.createDirectories(target);
                     } else {
                         Files.createDirectories(target.getParent());
-                        Files.copy(zipInputStream, target);
+                        byte[] bytes = zipInputStream.readAllBytes();
+                        if (engine.isTextEntry(entry.getName())) {
+                            bytes = engine.substitute(entry.getName(), bytes, context);
+                        }
+                        Files.write(target, bytes);
+                        // Mark release scripts executable so the workflow can invoke them.
+                        String normalized = entry.getName().replace('\\', '/');
+                        if (normalized.startsWith("tools/release/")
+                                || (normalized.startsWith("scripts/") && normalized.endsWith(".sh"))) {
+                            try {
+                                Files.setPosixFilePermissions(target, Set.copyOf(
+                                        java.nio.file.attribute.PosixFilePermissions.fromString("rwxr-xr-x")));
+                            } catch (UnsupportedOperationException ignored) {
+                                // Non-POSIX filesystem — best effort only.
+                            }
+                        }
                     }
                 }
             }

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/TemplateContextTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/TemplateContextTest.java
@@ -52,4 +52,35 @@ class TemplateContextTest {
         assertThrows(NullPointerException.class,
                 () -> new TemplateContext("r", "o", "d", now, null));
     }
+
+    @Test
+    void backCompatConstructorDerivesArtifactCoordinates() {
+        Instant now = Instant.parse("2026-05-17T01:23:45Z");
+        TemplateContext ctx = new TemplateContext("My-Prompts", "ACME-Corp", "desc", now, "1.0.0");
+
+        assertEquals("My-Prompts", ctx.projectName());
+        assertEquals("io.github.acme-corp", ctx.mavenGroupId());
+        assertEquals("my-prompts", ctx.mavenArtifactId());
+        assertEquals("my-prompts", ctx.pythonDistributionName());
+        assertEquals("my_prompts", ctx.pythonImportName());
+        assertEquals("my-prompts", ctx.npmPackageName());
+    }
+
+    @Test
+    void canonicalConstructorExposesAllElevenFields() {
+        Instant now = Instant.parse("2026-05-17T01:23:45Z");
+        TemplateContext ctx = new TemplateContext(
+                "repo", "owner", "desc", now, "1.0.0",
+                "Display Name", "com.example", "my-artifact",
+                "my-dist", "my_import", "my-npm");
+
+        assertEquals("repo", ctx.repositoryName());
+        assertEquals("owner", ctx.ownerName());
+        assertEquals("Display Name", ctx.projectName());
+        assertEquals("com.example", ctx.mavenGroupId());
+        assertEquals("my-artifact", ctx.mavenArtifactId());
+        assertEquals("my-dist", ctx.pythonDistributionName());
+        assertEquals("my_import", ctx.pythonImportName());
+        assertEquals("my-npm", ctx.npmPackageName());
+    }
 }

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/TemplateSubstitutionEngineTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/TemplateSubstitutionEngineTest.java
@@ -145,4 +145,50 @@ class TemplateSubstitutionEngineTest {
         assertThat(engine.isTextEntry("prompts/.gitignore")).isFalse();
         assertThat(engine.isTextEntry("Makefile")).isFalse();
     }
+
+    @Test
+    void substitutesAllArtifactCoordinateTokens() {
+        // Use the canonical 11-arg constructor so every artifact-coordinate token can be
+        // verified independently of the back-compat derivation rules.
+        TemplateContext ctx = new TemplateContext(
+                "my-prompts",
+                "acme-corp",
+                "desc",
+                Instant.parse("2026-05-17T09:30:00Z"),
+                "1.0.0",
+                "My Prompts",
+                "io.github.acme-corp",
+                "my-prompts",
+                "my-prompts",
+                "my_prompts",
+                "my-prompts");
+        byte[] source = ("project={{PROJECT_NAME}}\n"
+                + "g={{MAVEN_GROUP_ID}}\n"
+                + "a={{MAVEN_ARTIFACT_ID}}\n"
+                + "pyd={{PYTHON_DISTRIBUTION_NAME}}\n"
+                + "pyi={{PYTHON_IMPORT_NAME}}\n"
+                + "npm={{NPM_PACKAGE_NAME}}\n").getBytes(StandardCharsets.UTF_8);
+
+        String result = new String(engine.substitute("artifacts.toml", source, ctx), StandardCharsets.UTF_8);
+
+        assertThat(result).isEqualTo(""
+                + "project=My Prompts\n"
+                + "g=io.github.acme-corp\n"
+                + "a=my-prompts\n"
+                + "pyd=my-prompts\n"
+                + "pyi=my_prompts\n"
+                + "npm=my-prompts\n");
+    }
+
+    @Test
+    void backCompatConstructorDerivesArtifactTokensFromOwnerAndRepo() {
+        TemplateContext ctx = new TemplateContext(
+                "My-Prompts", "ACME-Corp", "desc",
+                Instant.parse("2026-05-17T09:30:00Z"), "1.0.0");
+        byte[] source = "g={{MAVEN_GROUP_ID}} a={{MAVEN_ARTIFACT_ID}}".getBytes(StandardCharsets.UTF_8);
+
+        String result = new String(engine.substitute("artifacts.toml", source, ctx), StandardCharsets.UTF_8);
+
+        assertThat(result).isEqualTo("g=io.github.acme-corp a=my-prompts");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the two CI-breaking flaws in Studio-rolled-out repositories (P0 slice for #325, parent #323):

1. **Literal `REPLACE_ME_*` sentinels in `pom.xml` and `.promptlm/artifacts.toml`** — Maven refuses to parse the pom; downstream tooling silently consumes placeholders. Now substituted via new `{{MAVEN_GROUP_ID}}`, `{{MAVEN_ARTIFACT_ID}}`, `{{PROJECT_NAME}}`, `{{PYTHON_DISTRIBUTION_NAME}}`, `{{PYTHON_IMPORT_NAME}}`, `{{NPM_PACKAGE_NAME}}` tokens derived from owner/repo via a new `ArtifactCoordinateSanitizer` (PEP 503 / PEP 8 / npm / Maven rules).

2. **`tools/release/{build-artifacts,publish-artifacts}` extracted without exec bit** — generated workflows that invoke `./tools/release/build-artifacts` failed with `Permission denied`. The extractor now applies POSIX `0755` to entries under `tools/release/` and `scripts/*.sh`. The assembly descriptor also pins those paths to `0755` in the zip itself (defense in depth).

Parent issue: #323. Slice: #325.

## What changed

- New `ArtifactCoordinateSanitizer` with PEP 503, PEP 8, npm and Maven sanitization rules. Always-valid, never-throws, never-empty.
- `TemplateContext` extended with 6 new fields. Existing 5-arg constructor preserved as a back-compat secondary constructor that derives the artifact tokens, so every existing call site keeps compiling.
- `TemplateSubstitutionEngine` registers the six new tokens.
- `repo-resources/pom.xml` and `repo-resources/.promptlm/artifacts.toml` now use the new tokens. `.github/artifactory-config.yml` and the sample deploy-profile URLs (Artifactory / GitHub-packages / custom) remain `REPLACE_ME_*` — they were called out as P1 follow-up in #325.
- `ZipFileRepositoryTemplateExtractor` applies POSIX mode based on path patterns. We cannot read the zip entry's Unix mode through the JDK 21 `java.util.zip` API (package-private, only populated by `ZipFile` random-access), and Spring Boot 4 BOM does not manage `commons-compress`. Path heuristic mirrors the source-of-truth `fileMode` pinning in `src/assembly/repo-template.xml`.
- `GitProjectService.newProject()` passes the derived coordinates via the canonical 11-arg `TemplateContext` constructor.

## Tests (regression guards)

- `ZipFileRepositoryTemplateExtractorSubstitutionTest.noFileContainsReplaceMeSentinelAndPomHasSubstitutedCoordinates` — extracts the real `repo-template.zip` with `TemplateContext(owner="ACME-Corp", repo="my-prompts")`, asserts `pom.xml` contains `<groupId>io.github.acme-corp</groupId>` and `<artifactId>my-prompts</artifactId>`, and walks the entire extracted tree asserting no file contains the substring `REPLACE_ME_` (allow-list: the three P1-deferred files documented in the test).
- `ZipFileRepositoryTemplateExtractorSubstitutionTest.releaseScriptsAreExecutableOnPosix` — asserts `Files.isExecutable(tools/release/build-artifacts)` and `publish-artifacts` after extraction. Guarded by `Assumptions.assumeTrue` on POSIX-capable filesystems.
- `ArtifactCoordinateSanitizerTest` (10 cases) — uppercase, `Org-With.Special_Chars`, leading digits, null/empty fallbacks, npm scope stripping, the literal ACME-Corp / my-prompts case from the issue contract.
- `TemplateSubstitutionEngineTest` extended with the six new tokens and the back-compat derivation path.
- `TemplateContextTest` covers both the canonical 11-arg and the 5-arg derivation constructor.
- `RepositoryTemplateActSmokeTest` patched to run substitution before invoking act, since the new `{{MAVEN_GROUP_ID}}` token would otherwise block Maven from reading the pom.

## Out of scope (P1 follow-up)

- `.github/artifactory-config.yml` — REFERENCE ONLY per #325.
- Sample Artifactory / GitHub-packages / custom deploy-profile URLs in `.promptlm/artifacts.toml` (they still contain `REPLACE_ME_ARTIFACTORY_URL` etc.) — users edit these before publishing.

## Test plan

- [x] `mvn -pl components/repository-template,components/promptlm-store/promptlm-store-github -am verify` is green (134 tests, including the docker/act smoke).
- [ ] (Reviewer) Sanity check on a fresh Studio rollout once merged: the generated `pom.xml` parses with `mvn validate`, and the build workflow invokes `./tools/release/build-artifacts` without `Permission denied`.

Closes #325 (the P0 slice of #323).

🤖 Generated with [Claude Code](https://claude.com/claude-code)