### PR TITLE
ci(release): fix set -e + ((var++)) trap that breaks patch bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,9 @@ jobs:
             echo "Expected semantic version with optional -SNAPSHOT, got: $current_version" >&2; exit 1
           fi
           case "${{ inputs.release_type }}" in
-            major) ((major++)); minor=0; patch=0 ;;
-            minor) ((minor++)); patch=0 ;;
-            patch) ((patch++)) ;;
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
             *) echo "Unsupported release_type: ${{ inputs.release_type }}" >&2; exit 1 ;;
           esac
           echo "version=${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

PR #315 landed the thin caller, but a shell bug in `calculate_version` kills the workflow whenever the current pom version's patch component is 0.

Under `set -e`, the arithmetic command `((expr))` exits non-zero whenever its final value is 0. So `((patch++))` from patch=0 returns the pre-increment value 0, which errexit treats as failure — the script dies before the implicit assignment lands.

**Repro:** dispatch `release.yml` against current `main` with `release_type=patch`, `dry-run=true` (project.version is `0.1.0-SNAPSHOT`). The `Bump version` step exits in ~12ms with no awk output. `release_type=minor` would have worked (minor=1 → `((minor++))` returns 1).

Discovered while running PR #315's test plan (run 26865297662).

## Fix

`x=$((x + 1))` instead of `((x++))`: plain command-substitution + assignment, no exit-code semantics, immune to `set -e`. 3-line diff.

## Test plan

- [ ] Merge.
- [ ] Dispatch `release.yml` on main with `release_type=patch`, `dry-run=true`. Expect: full pipeline runs, no GH Packages upload, no GH Release.
- [ ] Then `dry-run=false`. Expect: `dev.promptlm:promptlm-parent` 0.1.1 in GH Packages, GH Release `v0.1.1` with jars + 6 native bundles + SHA256SUMS.
- [ ] Re-dispatch with same `release_type`. Expect: idempotency check skips GH Packages deploy, GH Release is updated.