### PR TITLE
ci(release): patch on a SNAPSHOT pom should release the SNAPSHOT base, not bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,17 @@ jobs:
           if ! [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ && "$patch" =~ ^[0-9]+$ ]]; then
             echo "Expected semantic version with optional -SNAPSHOT, got: $current_version" >&2; exit 1
           fi
+          # SNAPSHOT semantics (Maven convention): pom.xml "X.Y.Z-SNAPSHOT" already
+          # represents the next release as X.Y.Z, so `patch` releases X.Y.Z unchanged.
+          # `minor` / `major` still skip ahead regardless. On a non-SNAPSHOT pom (rare —
+          # only when releasing immediately on top of an already-published version
+          # without manually bumping), `patch` bumps the patch component.
           case "${{ inputs.release_type }}" in
             major) major=$((major + 1)); minor=0; patch=0 ;;
             minor) minor=$((minor + 1)); patch=0 ;;
-            patch) patch=$((patch + 1)) ;;
+            patch)
+              [[ "$current_version" == *-SNAPSHOT ]] || patch=$((patch + 1))
+              ;;
             *) echo "Unsupported release_type: ${{ inputs.release_type }}" >&2; exit 1 ;;
           esac
           echo "version=${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

Maven convention: pom.xml `X.Y.Z-SNAPSHOT` already represents the next release as `X.Y.Z`, so `release_type=patch` on a SNAPSHOT pom should release X.Y.Z — not bump to X.Y.(Z+1).

Today `release.yml` blindly bumps patch in every case. On current main (pom = `0.1.0-SNAPSHOT`), a `release_type=patch` dispatch resolves to `0.1.1` instead of `0.1.0`. Visible in [dry-run #26939872220](https://github.com/promptLM/promptlm-app/actions/runs/26939872220) — the published job is named `publish v0.1.1`. A non-dry dispatch would have locked the wrong tag (`v0.1.1`) and GH Packages version.

## Fix

Only bump the patch component when current pom is a non-SNAPSHOT release. `minor` / `major` unchanged — they reset patch regardless.

```diff
   case "${{ inputs.release_type }}" in
     major) major=$((major + 1)); minor=0; patch=0 ;;
     minor) minor=$((minor + 1)); patch=0 ;;
-    patch) patch=$((patch + 1)) ;;
+    patch)
+      [[ "$current_version" == *-SNAPSHOT ]] || patch=$((patch + 1))
+      ;;
     *) echo "Unsupported release_type: ${{ inputs.release_type }}" >&2; exit 1 ;;
   esac
```

Truth table after this change:

| pom current | patch | minor | major |
|---|---|---|---|
| 0.1.0-SNAPSHOT | 0.1.0 | 0.2.0 | 1.0.0 |
| 0.1.0 | 0.1.1 | 0.2.0 | 1.0.0 |

## Test plan

- [ ] Merge.
- [ ] Re-dispatch with `release_type=patch`, `dry-run=true`. Expect the publish job name to read `publish v0.1.0`.