### PR TITLE
ci: enforce required CI checks on main + workflow_dispatch for oss-checks (#340)

### DIFF
--- a/.github/workflows/oss-checks.yml
+++ b/.github/workflows/oss-checks.yml
@@ -11,6 +11,7 @@ name: oss-checks
 # and surface duplicate failures.
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
Closes #340 (partial — see "Out of scope" below for the cross-repo AC).

## Summary

- **Branch protection on `main`** now requires the full CI gate: `build`, `e2e-mock`, `run / License headers (license-eye)`, `run / Secret scan (gitleaks)`, `Decide whether to run acceptance`. `strict: true` is enabled. Applied via `gh api -X PUT`; rollback snapshot taken before the change.
- **`workflow_dispatch:`** added to `.github/workflows/oss-checks.yml` so release engineers can replay it during dependabot triage without pushing a no-op commit. (The other required-set workflows already had it.)
- **Manual Dependabot trigger** (issue's "manual trigger" ACs) is already satisfied today by GitHub's native "Check for updates" button on each `package-ecosystem:` row — no workflow file needed unless we opt into "Dependabot on Actions" later. Documented in the closeout.

## Why

`main` had **zero required status checks** before this PR — a Dependabot (or any) PR could be merged on a single review with red CI. The 0.1.0 runbook's "Dependabot PRs must build green before merge" gate was unenforced. This PR adds the enforcement.

## What this PR contains
- `.github/workflows/oss-checks.yml`: add `workflow_dispatch:` to `on:`.

## What was changed outside this diff (already applied)
- `PUT /repos/promptLM/promptlm-app/branches/main/protection` — adds `required_status_checks` block, preserves every other setting. Pre-change snapshot kept at `/tmp/main-protection-snapshot.json` on the delivery machine for rollback.

## Out of scope (tracked in the closeout)

- **AC6** (`scripts/deps/auto-merge-deps.sh`) lives in `promptLM/promptlm-release`, not this repo — needs a separate issue/PR there to gate auto-merge on the required checks being declared first.

## Test plan

- [x] BP readback shows 5 contexts + `strict: true`
- [x] Live PR roll-up on an open Dependabot PR (#334) lists all 5 required checks
- [x] PR with failing required checks (#335) → `mergeStateStatus: BLOCKED`
- [ ] After merge: `gh workflow run oss-checks.yml` succeeds (workflow_dispatch becomes API-visible once on default branch)
- [ ] Refresh open Dependabot PRs #334–#339 (rebase / `@dependabot recreate`) to clear "branch is behind"

## Known limitation

Required-check name matching is exact-string. Job renames in the matched workflows silently disable the corresponding required check. Recommended follow-up: migrate to GitHub Rulesets with workflow-id-based "required workflow" conditions.

See `.claude/issue-delivery/sprint-review-demo.md`, `review-report.md`, and `security-report.md` on the agent branch for full evidence.