### PR TITLE
ci(release): drop windows/arm64 from native matrix for 0.1.0 (#346)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,4 +117,16 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       maven-package-name: dev.promptlm.promptlm-parent
       cli-binary: promptlm-cli
+      # GraalVM CE 25.0.2 does not ship a windows-aarch64 binary, so the
+      # default 6-target matrix fails the windows/arm64 leg at `Set up
+      # GraalVM`. Scope to 5 targets for 0.1.0; restore windows/arm64
+      # in 0.2.0 once upstream ships or we switch distributions (#346).
+      native-targets: |
+        [
+          {"os": "ubuntu-latest",    "platform": "linux",   "arch": "x64"},
+          {"os": "ubuntu-24.04-arm", "platform": "linux",   "arch": "arm64"},
+          {"os": "macos-13",         "platform": "macos",   "arch": "x64"},
+          {"os": "macos-14",         "platform": "macos",   "arch": "arm64"},
+          {"os": "windows-latest",   "platform": "windows", "arch": "x64"}
+        ]
     secrets: inherit


### PR DESCRIPTION
## Summary
- GraalVM CE 25.0.2 does not publish a `windows-aarch64` binary, failing the `windows/arm64` leg of the default 6-target matrix at `Set up GraalVM`. Observed in release dry-run [run 27106314200](https://github.com/promptLM/promptlm-app/actions/runs/27106314200).
- Override `native-targets` to the 5 targets that have CE binaries today so `0.1.0` can ship.
- [#346](https://github.com/promptLM/promptlm-app/issues/346) tracks restoring the 6th target in `0.2.0`.

## Test plan
- [ ] Merge → re-run **Release** workflow with `release_type=patch`, `dry-run=true`.
- [ ] All 5 native legs (`linux/{x64,arm64}`, `macos/{x64,arm64}`, `windows/x64`) green; `mvn deploy` skipped; no GH Release created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)