### PR TITLE
fix(cli): bound native-image heap + parallelism for macos runners

### DIFF
--- a/apps/promptlm-cli/pom.xml
+++ b/apps/promptlm-cli/pom.xml
@@ -165,6 +165,22 @@
                         <configuration>
                             <mainClass>dev.promptlm.CliApplication</mainClass>
                             <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                            <!--
+                              Bound the native-image hosted JVM heap and parallelism explicitly.
+                              On a 7 GB macos-14 GitHub-hosted runner native-image auto-sized to
+                              ~5.9 GB and the deadlock watchdog killed the build at the
+                              StrengthenGraphs typestate phase (run 27106919036, attempt 1)
+                              with Used=5932/Max=5932 MB. Capping to 5 GB leaves headroom for
+                              the OS + page cache; --parallelism=2 reduces concurrent
+                              point-to-analysis pressure. Slows the build slightly but makes
+                              it deterministic across the GH-hosted matrix.
+                            -->
+                            <jvmArgs>
+                                <arg>-Xmx5g</arg>
+                            </jvmArgs>
+                            <buildArgs>
+                                <arg>--parallelism=2</arg>
+                            </buildArgs>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
## Summary
- macos/arm64 leg of 0.1.0 release dry-run [#27106919036 attempt 1](https://github.com/promptLM/promptlm-app/actions/runs/27106919036) deadlocked during `promptlm-cli` native build at `StrengthenGraphs` typestate phase. Heap stats: `Used=5932 / Max=5932 MB` on a 7 GB macos-14 runner — no headroom, watchdog killed the job after 26:49 min.
- Cap the hosted JVM heap to 5 GB and reduce point-to-analysis parallelism to 2 so the build fits deterministically on the leanest GH-hosted runner class.
- Slows the build slightly; eliminates the deadlock risk across all macos runners.

## Refs
- #317 (0.1.0 release tracking)
- Dry-run #27106919036 attempts: 1 = deadlock, 2 = transient 504 from Oracle CDN, 3 = macos/x64 stuck queued 12h (Intel runner pool exhaustion — separate)

## Test plan
- [ ] Merge → re-run **Release** workflow with `release_type=patch`, `dry-run=true`.
- [ ] macos/arm64 native build completes without watchdog timeout.
- [ ] macos/x64 native build completes (separate capacity concern; if stuck, escalate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)