### PR TITLE
ci(release): switch macos x64 leg to macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,11 +121,17 @@ jobs:
       # default 6-target matrix fails the windows/arm64 leg at `Set up
       # GraalVM`. Scope to 5 targets for 0.1.0; restore windows/arm64
       # in 0.2.0 once upstream ships or we switch distributions (#346).
+      #
+      # macos x64 uses `macos-15-intel` rather than `macos-13`: macos-13
+      # is being retired (Dec 2025) and its GH-hosted runner pool has been
+      # exhausted, leaving the macos/x64 leg stuck queued for hours.
+      # `macos-15-intel` is the documented free Intel x64 successor,
+      # available until August 2027 (the last Intel macOS runner image).
       native-targets: |
         [
           {"os": "ubuntu-latest",    "platform": "linux",   "arch": "x64"},
           {"os": "ubuntu-24.04-arm", "platform": "linux",   "arch": "arm64"},
-          {"os": "macos-13",         "platform": "macos",   "arch": "x64"},
+          {"os": "macos-15-intel",   "platform": "macos",   "arch": "x64"},
           {"os": "macos-14",         "platform": "macos",   "arch": "arm64"},
           {"os": "windows-latest",   "platform": "windows", "arch": "x64"}
         ]


### PR DESCRIPTION
## Summary
- `macos-13` is being retired (Dec 2025) and its GH-hosted runner pool is exhausted: the `macos/x64` leg of release dry-run [27106919036](https://github.com/promptLM/promptlm-app/actions/runs/27106919036) sat `queued` for 12+ hours with no runner assigned, blocking the workflow.
- Switch the matrix entry from `macos-13` to **`macos-15-intel`**, GitHub's documented free Intel x64 successor (macOS 15 on x86_64, available until August 2027 — the last Intel macOS image).
- Apple silicon labels (`macos-14`, `macos-15`) remain arm64-only and would lose x64 coverage, so they are not a drop-in.

## Refs
- #317 (0.1.0 release tracking)
- [GitHub Actions: macOS 13 runner image is closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
- [macOS 15 Sonoma Intel image issue](https://github.com/actions/runner-images/issues/13045)

## Test plan
- [ ] Merge → re-run **Release** workflow with `release_type=patch`, `dry-run=true`.
- [ ] `macos/x64` leg picks up a runner within a reasonable queue time.
- [ ] All 5 native legs complete green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)