### PR TITLE
fix(#353): add schemaVersion to promptlm.yml and warn/refuse on mismatch

### DIFF
--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractor.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractor.java
@@ -54,6 +54,15 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
     private static final String CONFIG_FILE_NAME = "promptlm.yml";
 
     /**
+     * Schema version this loader knows how to read. A {@code promptlm.yml}
+     * declaring a higher version is rejected; a missing version is treated as
+     * {@value #SUPPORTED_SCHEMA_VERSION} with a deprecation warning so that
+     * the field can be retrofitted to existing files non-disruptively. See
+     * issue #353.
+     */
+    static final String SUPPORTED_SCHEMA_VERSION = "1";
+
+    /**
      * Entries that are only relevant in Mode 2 (release-enabled). When
      * {@code release.enabled} is {@code false} in the generated repository's
      * {@value #CONFIG_FILE_NAME}, these files are skipped during extraction so
@@ -106,7 +115,9 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
         Objects.requireNonNull(context, "context");
 
         Map<String, byte[]> entries = readAllEntries();
-        boolean releaseEnabled = isReleaseEnabled(entries.get(CONFIG_FILE_NAME));
+        byte[] configBytes = entries.get(CONFIG_FILE_NAME);
+        verifySchemaVersion(configBytes);
+        boolean releaseEnabled = isReleaseEnabled(configBytes);
         log.debug("Repository template release.enabled resolved to {}", releaseEnabled);
 
         boolean posixSupported = FileSystems.getDefault()
@@ -214,6 +225,56 @@ public class ZipFileRepositoryTemplateExtractor implements RepositoryTemplateExt
             }
         }
         return false;
+    }
+
+    /**
+     * Verify the {@code schemaVersion} declared in the template's
+     * {@code promptlm.yml}. A missing version is tolerated with a
+     * deprecation warning (treated as {@value #SUPPORTED_SCHEMA_VERSION});
+     * a higher version is rejected with {@link IllegalStateException} so
+     * the rollout fails loudly rather than silently producing a malformed
+     * repository.
+     *
+     * <p>Like {@link #isReleaseEnabled(byte[])} this uses a regex over the
+     * top-level key rather than a full YAML parser to keep the module
+     * dependency-free. See issue #353.
+     *
+     * @param configBytes the raw bytes of {@code promptlm.yml}, or
+     *                    {@code null} / empty if the file is absent (in
+     *                    which case the check is skipped — the caller's
+     *                    fallback path covers that case).
+     */
+    static void verifySchemaVersion(byte[] configBytes) {
+        if (configBytes == null || configBytes.length == 0) {
+            return;
+        }
+        String declared = readSchemaVersion(configBytes);
+        if (declared == null) {
+            log.warn("{} is missing 'schemaVersion'; assuming '{}'. This will become an error in a future release.",
+                    CONFIG_FILE_NAME, SUPPORTED_SCHEMA_VERSION);
+            return;
+        }
+        if (SUPPORTED_SCHEMA_VERSION.equals(declared)) {
+            return;
+        }
+        if (declared.compareTo(SUPPORTED_SCHEMA_VERSION) > 0) {
+            throw new IllegalStateException(
+                    "Unsupported %s schemaVersion '%s'; this build of promptLM only understands schemaVersion '%s'. Upgrade promptLM to consume this template."
+                            .formatted(CONFIG_FILE_NAME, declared, SUPPORTED_SCHEMA_VERSION));
+        }
+        log.warn("{} declares older schemaVersion '{}'; loader expects '{}'. Proceeding on a best-effort basis.",
+                CONFIG_FILE_NAME, declared, SUPPORTED_SCHEMA_VERSION);
+    }
+
+    private static String readSchemaVersion(byte[] configBytes) {
+        String yaml = new String(configBytes, StandardCharsets.UTF_8);
+        Matcher matcher = Pattern
+                .compile("(?m)^schemaVersion:\\s*['\"]?([^'\"#\\s]+)['\"]?\\s*(?:#.*)?$")
+                .matcher(yaml);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
     }
 
     /**

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorSchemaVersionTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorSchemaVersionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Exercises the {@code schemaVersion} gate in
+ * {@link ZipFileRepositoryTemplateExtractor#verifySchemaVersion(byte[])}.
+ * See issue #353.
+ */
+class ZipFileRepositoryTemplateExtractorSchemaVersionTest {
+
+    @Test
+    void supportedSchemaVersionIsAcceptedSilently() {
+        String yaml = """
+                schemaVersion: "1"
+                release:
+                  enabled: true
+                """;
+
+        assertThatCode(() ->
+                ZipFileRepositoryTemplateExtractor.verifySchemaVersion(
+                        yaml.getBytes(StandardCharsets.UTF_8)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void missingSchemaVersionIsTolerated() {
+        // Pre-#353 files have no schemaVersion. The loader must accept them
+        // so existing repositories keep working; the WARN log is enough.
+        String yaml = """
+                release:
+                  enabled: true
+                  provider: github-actions
+                """;
+
+        assertThatCode(() ->
+                ZipFileRepositoryTemplateExtractor.verifySchemaVersion(
+                        yaml.getBytes(StandardCharsets.UTF_8)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void futureSchemaVersionIsRejected() {
+        String yaml = """
+                schemaVersion: "2"
+                release:
+                  enabled: true
+                """;
+
+        assertThatThrownBy(() ->
+                ZipFileRepositoryTemplateExtractor.verifySchemaVersion(
+                        yaml.getBytes(StandardCharsets.UTF_8)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("schemaVersion")
+                .hasMessageContaining("2")
+                .hasMessageContaining("1");
+    }
+}

--- a/components/repository-template/repo-resources/promptlm.yml
+++ b/components/repository-template/repo-resources/promptlm.yml
@@ -5,11 +5,18 @@
 # built and published; see `README.md` and `docs/release-classes.md` in the
 # promptLM app for the bundle-release concept.
 #
+# `schemaVersion` identifies the shape of this file. promptLM loaders refuse
+# to consume a file whose schemaVersion is newer than what they know how to
+# read; a missing schemaVersion is treated as "1" with a deprecation warning.
+# Bump this whenever a backwards-incompatible change is made to the keys
+# below.
+#
 # 0.1.0 ships a single mode: bundle-release (Maven jar → GitHub Packages).
 # A "prompt management only" mode (no CI/CD, no Maven coordinates) is planned
 # for 0.2.0 — when it lands, `release.enabled: false` will skip emitting the
 # release workflows / pom.xml / artifacts.toml at rollout time. Until then
 # the flag is informational; the workflows ship regardless.
+schemaVersion: "1"
 release:
   enabled: true
   provider: github-actions


### PR DESCRIPTION
Closes #353.

## Change
- Added `schemaVersion: "1"` to the template `promptlm.yml`.
- `ZipFileRepositoryTemplateExtractor` now reads `schemaVersion` via regex (same minimal-parse style as the existing `release.enabled` flag — no new YAML parser dependency, since the module's pom doesn't carry one).
- Behaviour:
  - missing → `WARN` and proceed (assumes "1")
  - `"1"` → silent, proceed
  - future version → `IllegalStateException` (matches how `GitProjectService.extractTo` already propagates runtime errors)

## Test
3 new tests in `ZipFileRepositoryTemplateExtractorSchemaVersionTest`: present-and-matches, missing, future-version. Module green: 99 run, 0 failed.

## Scope
Intentionally narrow — only the version field + tolerant load. The larger JSON-Schema work outlined in #353 is deferred (out of 0.1.0 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)