### PR TITLE
fix(#354): show 'draft' status for unreleased ACTIVE prompts

### DIFF
--- a/components/promptlm-web-ui/src/api-common/viewModels/promptsV2.ts
+++ b/components/promptlm-web-ui/src/api-common/viewModels/promptsV2.ts
@@ -44,10 +44,24 @@ const formatRelative = (iso?: string): string => {
   return formatDistanceToNow(date, { addSuffix: true });
 };
 
-const toPromptStatus = (raw: PromptSpec['status']): PromptStatus => {
+/**
+ * Map the backend `PromptSpec.status` enum to a UI `PromptStatus`.
+ *
+ * Issue #354: a brand-new prompt was rendered as "production" the moment it
+ * was created, because `ACTIVE` maps to a published lifecycle stage and the
+ * generated client does not yet expose release metadata. Until the backend
+ * surfaces release state on `PromptSpec`, callers must pass an explicit
+ * `released` flag — `undefined` is treated as "not confirmed released" and
+ * downgrades `ACTIVE` to 'draft'. This is a deliberately safer default: better
+ * to under-promise than to label an unreleased prompt as production.
+ */
+const toPromptStatus = (
+  raw: PromptSpec['status'],
+  released?: boolean,
+): PromptStatus => {
   switch (raw) {
     case 'ACTIVE':
-      return 'production';
+      return released ? 'production' : 'draft';
     case 'RETIRED':
       return 'experimental';
     default:
@@ -179,7 +193,8 @@ export const mapPromptSpecToCatalogRowItem = (spec: PromptSpec): CatalogRowItem 
     revision: spec.revision ?? 0,
     vendor,
     model,
-    status: toPromptStatus(spec.status),
+    // TODO(#354): wire release state from backend
+    status: toPromptStatus(spec.status, undefined),
     placeholders,
     messages,
     updatedAt: formatRelative(spec.updatedAt ?? spec.createdAt),
@@ -331,7 +346,8 @@ export const mapPromptSpecToDetailViewModel = (
     rev: `r${spec.revision ?? 0}`,
     vendor: requestVendor,
     model: requestModel,
-    status: toPromptStatus(spec.status),
+    // TODO(#354): wire release state from backend
+    status: toPromptStatus(spec.status, undefined),
     request: {
       vendor: requestVendor,
       model: requestModel,

--- a/components/ui/src/prompts-v2/atoms/StatusDot.tsx
+++ b/components/ui/src/prompts-v2/atoms/StatusDot.tsx
@@ -14,7 +14,12 @@
 
 import * as React from 'react';
 
-export type PromptStatus = 'production' | 'staging' | 'experimental' | 'failing';
+export type PromptStatus =
+  | 'draft'
+  | 'production'
+  | 'staging'
+  | 'experimental'
+  | 'failing';
 
 export interface StatusDotProps extends React.HTMLAttributes<HTMLSpanElement> {
   status: PromptStatus;
@@ -23,6 +28,7 @@ export interface StatusDotProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 const STATUS_MAP: Record<PromptStatus, { color: string; label: string }> = {
+  draft: { color: 'var(--pl-ink-500)', label: 'draft' },
   production: { color: 'var(--pl-ok)', label: 'production' },
   staging: { color: 'var(--pl-warn)', label: 'staging' },
   experimental: { color: 'var(--pl-ink-500)', label: 'experimental' },

--- a/components/ui/src/prompts-v2/detail/PromptDetailHeader.tsx
+++ b/components/ui/src/prompts-v2/detail/PromptDetailHeader.tsx
@@ -85,6 +85,7 @@ const PreReleaseBadge: React.FC<{ badge: PreReleaseExecutionBadge }> = ({ badge 
 );
 
 const STATUS_FG: Record<PromptStatus, string> = {
+  draft: 'var(--pl-ink-600)',
   production: 'oklch(0.40 0.12 155)',
   staging: 'oklch(0.50 0.13 75)',
   experimental: 'var(--pl-ink-600)',
@@ -92,6 +93,7 @@ const STATUS_FG: Record<PromptStatus, string> = {
 };
 
 const STATUS_DOT: Record<PromptStatus, string> = {
+  draft: 'var(--pl-ink-500)',
   production: 'oklch(0.55 0.13 155)',
   staging: 'var(--pl-warn)',
   experimental: 'var(--pl-ink-500)',


### PR DESCRIPTION
Closes #354.

A brand-new prompt was rendering the green "production" status dot because `toPromptStatus` mapped `ACTIVE` → `production` unconditionally. To a human, that reads as "live in production" before any release ever happened.

## Change
- New `'draft'` member added to `PromptStatus` (atoms/`StatusDot.tsx`) with a neutral ink-tone palette in `PromptDetailHeader.tsx`.
- `toPromptStatus(raw, released?)` — `ACTIVE` + no release → `draft`; `ACTIVE` + released → `production`; `RETIRED` → `experimental`.
- Both call sites pass `undefined` for `released` (with `// TODO(#354): wire release state from backend`) since the generated `PromptSpec` client model has no release/`releasedAt` field today. **Effective behaviour: everything renders as `draft`** until the backend exposes release state — safer default than always-`production`.

## Test
`components/ui` green; `components/promptlm-web-ui` 114 tests pass; `tsc --noEmit` clean. (20 pre-existing vitest module-resolution failures verified unrelated via clean-tree round-trip.)

## Follow-up
Wiring `ReleaseMetadata` through to the API view model + generated TS client is the actual fix; this PR caps the visible-bug bleed in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)