### PR TITLE
fix(#361): emit PromptPushFailedEvent + push-failed SSE status + push retry endpoint

### DIFF
--- a/components/promptlm-api-client/spec/asyncapi/store-status.asyncapi.yaml
+++ b/components/promptlm-api-client/spec/asyncapi/store-status.asyncapi.yaml
@@ -56,8 +56,9 @@ components:
 
               The `connected`, `started`, `progress`, `completed`, and `failed`
               values are emitted by the store operation channel. The
-              `executing`, `executed`, and `pushed` values are emitted by the
-              prompt-execution channel (issue #352 deferred-push save flow).
+              `executing`, `executed`, `pushed`, and `push-failed` values are
+              emitted by the prompt-execution channel (issue #352 deferred-push
+              save flow; `push-failed` added in #361).
             enum:
               - connected
               - started
@@ -67,6 +68,7 @@ components:
               - executing
               - executed
               - pushed
+              - push-failed
           message:
             type: string
             description: Human-readable status message.

--- a/components/promptlm-api-client/src/generated/asyncapi.ts
+++ b/components/promptlm-api-client/src/generated/asyncapi.ts
@@ -25,11 +25,12 @@ operation: string
  * 
  * The `connected`, `started`, `progress`, `completed`, and `failed`
  * values are emitted by the store operation channel. The
- * `executing`, `executed`, and `pushed` values are emitted by the
- * prompt-execution channel (issue #352 deferred-push save flow).
+ * `executing`, `executed`, `pushed`, and `push-failed` values are
+ * emitted by the prompt-execution channel (issue #352 deferred-push
+ * save flow; `push-failed` added in #361).
  * 
  */
-status: ("connected" | "started" | "progress" | "completed" | "failed" | "executing" | "executed" | "pushed")
+status: ("connected" | "started" | "progress" | "completed" | "failed" | "executing" | "executed" | "pushed" | "push-failed")
 /**
  * Human-readable status message.
  */

--- a/components/promptlm-api-client/src/generated/mock/example-responses.ts
+++ b/components/promptlm-api-client/src/generated/mock/example-responses.ts
@@ -100,6 +100,10 @@ export const exampleResponses = {
     "202": undefined,
     "404": undefined
   },
+  "retryPush": {
+    "202": undefined,
+    "404": undefined
+  },
   "switchProject": {
     "200": undefined,
     "500": undefined

--- a/components/promptlm-api-client/src/generated/mock/handlers.ts
+++ b/components/promptlm-api-client/src/generated/mock/handlers.ts
@@ -329,6 +329,21 @@ export const retryExecution_default: MockHandler<
 };
 
 /**
+ * POST /api/prompts/{promptSpecId}/push/retry
+ *
+ * Default handler — returns the schema-derived example for status 202.
+ */
+export const retryPush_default: MockHandler<
+  undefined,
+  undefined
+> = (args) => {
+  return {
+    status: 202,
+    body: exampleResponses["retryPush"]["202"] as undefined,
+  };
+};
+
+/**
  * POST /api/store/switch/{projectId}
  *
  * Default handler — delegates to state.handleSwitchProject().
@@ -379,6 +394,7 @@ export const defaultHandlers = {
   releasePrompt: releasePrompt_default,
   retirePrompt: retirePrompt_default,
   retryExecution: retryExecution_default,
+  retryPush: retryPush_default,
   switchProject: switchProject_default,
   updatePromptSpec: updatePromptSpec_default,
 } as const;

--- a/components/promptlm-api-client/src/generated/mock/operation-index.ts
+++ b/components/promptlm-api-client/src/generated/mock/operation-index.ts
@@ -201,6 +201,14 @@ export const operationIndex: readonly OperationDescriptor[] = [
     successStatus: 202,
   },
   {
+    opId: "retryPush",
+    method: "POST",
+    pathTemplate: "/api/prompts/{promptSpecId}/push/retry",
+    pathPattern: "^/api/prompts/(?<promptSpecId>[^/]+)/push/retry$",
+    pathParamNames: ["promptSpecId"],
+    successStatus: 202,
+  },
+  {
     opId: "switchProject",
     method: "POST",
     pathTemplate: "/api/store/switch/{projectId}",

--- a/components/promptlm-domain/src/main/java/dev/promptlm/domain/events/PromptPushFailedEvent.java
+++ b/components/promptlm-domain/src/main/java/dev/promptlm/domain/events/PromptPushFailedEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.domain.events;
+
+import dev.promptlm.domain.promptspec.PromptSpec;
+
+/**
+ * Domain event fired when the deferred amend+push (issue #352) fails after a successful
+ * LLM execution.
+ *
+ * <p>Issue #361: surfacing this as an explicit event lets the SSE listener bridge it to a
+ * {@code push-failed} status so the editor can offer a Retry-push affordance. The local
+ * commit is preserved unchanged — retry republishes {@link PromptExecutedEvent} against the
+ * same in-memory spec to re-fire the amend+push without re-running the LLM.
+ *
+ * <p>{@link #reason()} carries a short human-readable message; {@link #errorClass()}
+ * carries the simple class name of the underlying exception for UI categorisation.
+ */
+public record PromptPushFailedEvent(PromptSpec promptSpec, String reason, String errorClass) {
+
+    public static PromptPushFailedEvent from(PromptSpec promptSpec, Throwable cause) {
+        if (cause == null) {
+            return new PromptPushFailedEvent(promptSpec, "Unknown push failure", null);
+        }
+        String reason = cause.getMessage() != null && !cause.getMessage().isBlank()
+                ? cause.getMessage()
+                : cause.getClass().getSimpleName();
+        return new PromptPushFailedEvent(promptSpec, reason, cause.getClass().getSimpleName());
+    }
+}

--- a/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/PromptPushListener.java
+++ b/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/PromptPushListener.java
@@ -17,6 +17,7 @@
 package dev.promptlm.lifecycle;
 
 import dev.promptlm.domain.events.PromptExecutedEvent;
+import dev.promptlm.domain.events.PromptPushFailedEvent;
 import dev.promptlm.domain.events.PromptPushedEvent;
 import dev.promptlm.domain.promptspec.PromptSpec;
 import dev.promptlm.lifecycle.application.PromptStorePort;
@@ -61,9 +62,11 @@ class PromptPushListener {
         } catch (RuntimeException ex) {
             // The push failure leaves the local commit intact — the user can retry from the
             // UI. Swallowing the exception keeps this async listener from poisoning the
-            // event-publication transaction.
+            // event-publication transaction. Issue #361: emit a domain event so the SSE
+            // bridge can surface a `push-failed` status to the editor.
             log.warn("Failed to amend+push prompt {} after execution; local commit preserved",
                     executed.getId(), ex);
+            eventPublisher.publishEvent(PromptPushFailedEvent.from(executed, ex));
         }
     }
 }

--- a/components/promptlm-lifecycle/src/test/java/dev/promptlm/lifecycle/PromptPushListenerTest.java
+++ b/components/promptlm-lifecycle/src/test/java/dev/promptlm/lifecycle/PromptPushListenerTest.java
@@ -17,6 +17,7 @@
 package dev.promptlm.lifecycle;
 
 import dev.promptlm.domain.events.PromptExecutedEvent;
+import dev.promptlm.domain.events.PromptPushFailedEvent;
 import dev.promptlm.domain.events.PromptPushedEvent;
 import dev.promptlm.domain.promptspec.ChatCompletionRequest;
 import dev.promptlm.domain.promptspec.PromptSpec;
@@ -60,15 +61,27 @@ class PromptPushListenerTest {
     }
 
     @Test
-    void swallowsPushFailureAndEmitsNoPushedEvent() {
+    void emitsPromptPushFailedEventWhenAmendAndPushThrowsAndDoesNotEmitPushedEvent() {
         PromptSpec executed = basePromptSpec();
-        when(repository.amendAndPushHead(executed)).thenThrow(new RuntimeException("push rejected"));
+        RuntimeException pushFailure = new RuntimeException("push rejected");
+        when(repository.amendAndPushHead(executed)).thenThrow(pushFailure);
 
         PromptPushListener listener = new PromptPushListener(repository, eventPublisher);
-        // No throw — the failure is logged + swallowed so the async event chain stays clean.
+        // No throw — the failure is logged + the failure event is published so SSE can
+        // surface a push-failed status without poisoning the async event chain.
         listener.onPromptExecuted(new PromptExecutedEvent(executed));
 
-        verify(eventPublisher, never()).publishEvent(any());
+        // Exactly one event published, and it is the failure event — not PromptPushedEvent.
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        Object published = eventCaptor.getValue();
+        assertThat(published).isInstanceOf(PromptPushFailedEvent.class);
+        PromptPushFailedEvent failedEvent = (PromptPushFailedEvent) published;
+        assertThat(failedEvent.promptSpec()).isSameAs(executed);
+        assertThat(failedEvent.reason()).isEqualTo("push rejected");
+        assertThat(failedEvent.errorClass()).isEqualTo("RuntimeException");
+
+        verify(eventPublisher, never()).publishEvent(any(PromptPushedEvent.class));
     }
 
     private static PromptSpec basePromptSpec() {

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptExecutionSseListener.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptExecutionSseListener.java
@@ -19,6 +19,7 @@ package dev.promptlm.web;
 import dev.promptlm.domain.events.PromptCreatedEvent;
 import dev.promptlm.domain.events.PromptExecutedEvent;
 import dev.promptlm.domain.events.PromptExecutionFailedEvent;
+import dev.promptlm.domain.events.PromptPushFailedEvent;
 import dev.promptlm.domain.events.PromptPushedEvent;
 import dev.promptlm.domain.events.PromptUpdatedEvent;
 import dev.promptlm.domain.promptspec.PromptSpec;
@@ -47,6 +48,7 @@ public class PromptExecutionSseListener {
     public static final String STATUS_EXECUTED = "executed";
     public static final String STATUS_FAILED = "failed";
     public static final String STATUS_PUSHED = "pushed";
+    public static final String STATUS_PUSH_FAILED = "push-failed";
 
     private final SseStatusPublisher publisher;
 
@@ -88,6 +90,18 @@ public class PromptExecutionSseListener {
     @EventListener
     void onPromptPushed(PromptPushedEvent event) {
         emit(event.promptSpec(), STATUS_PUSHED, "Pushed to GitHub");
+    }
+
+    @EventListener
+    void onPromptPushFailed(PromptPushFailedEvent event) {
+        Map<String, Object> details = baseDetails(event.promptSpec());
+        if (StringUtils.hasText(event.reason())) {
+            details.put("reason", event.reason());
+        }
+        if (StringUtils.hasText(event.errorClass())) {
+            details.put("errorClass", event.errorClass());
+        }
+        publish(event.promptSpec(), STATUS_PUSH_FAILED, "Push to GitHub failed", details);
     }
 
     private void emit(PromptSpec spec, String status, String message) {

--- a/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java
@@ -20,6 +20,7 @@ import dev.promptlm.domain.AppContext;
 import dev.promptlm.domain.projectspec.ProjectSpec;
 import dev.promptlm.lifecycle.PromptLifecycleFacade;
 import dev.promptlm.domain.events.PromptCreatedEvent;
+import dev.promptlm.domain.events.PromptExecutedEvent;
 import dev.promptlm.execution.PromptExecutor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -964,6 +965,45 @@ public class PromptSpecController {
         // avoids a parallel "retry" code path.
         applicationEventPublisher.publishEvent(new PromptCreatedEvent(stored.get()));
         return ResponseEntity.accepted().build();
+    }
+
+    /**
+     * Re-fire only the deferred amend+push against the locally-stored spec — used by the
+     * editor's Retry-push affordance after a {@code push-failed} SSE status (issue #361).
+     *
+     * <p>This does NOT re-run the LLM. The stored spec already carries the attached
+     * response from a successful execution; what failed is the remote push. Republishing
+     * {@link PromptExecutedEvent} re-enters the existing {@code PromptPushListener} flow,
+     * which calls {@code amendAndPushHead} again against the preserved local commit.
+     */
+    @Operation(summary = "Retry the deferred push for a stored prompt",
+            description = "Re-fires the amend+push for a prompt whose previous push failed (issue #361). "
+                    + "Does NOT re-run the LLM — only the locally-stored spec's existing response is pushed. "
+                    + "Progress is delivered via the prompt-execution SSE channel.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "202", description = "Push retry accepted"),
+            @ApiResponse(responseCode = "404", description = "Prompt specification not found")
+    })
+    @PostMapping("/{promptSpecId}/push/retry")
+    public ResponseEntity<Void> retryPush(
+            @Parameter(description = "ID of the prompt specification whose push should be retried")
+            @PathVariable("promptSpecId") String promptSpecId) {
+        Optional<PromptSpec> stored = promptStore.getLatestVersion(promptSpecId);
+        if (stored.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        // Re-fire only the push leg: PromptPushListener handles PromptExecutedEvent by
+        // calling amendAndPushHead on the supplied spec. The LLM is not re-invoked.
+        applicationEventPublisher.publishEvent(new PromptExecutedEvent(stored.get()));
+        return ResponseEntity.accepted().build();
+    }
+
+    @Hidden
+    @PostMapping("/{group}/{name}/push/retry")
+    public ResponseEntity<Void> retryPushByGroupAndName(
+            @PathVariable("group") String group,
+            @PathVariable("name") String name) {
+        return retryPush(group + "/" + name);
     }
 
     private PromptExecutionException mapPromptExecutionException(String promptId, RuntimeException exception) {

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptExecutionSseListenerTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptExecutionSseListenerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.web;
+
+import dev.promptlm.domain.events.PromptPushFailedEvent;
+import dev.promptlm.domain.events.PromptPushedEvent;
+import dev.promptlm.domain.promptspec.ChatCompletionRequest;
+import dev.promptlm.domain.promptspec.PromptSpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class PromptExecutionSseListenerTest {
+
+    @Mock
+    private SseStatusPublisher publisher;
+
+    @Test
+    void onPromptPushedEmitsPushedStatus() {
+        PromptExecutionSseListener listener = new PromptExecutionSseListener(publisher);
+        PromptSpec spec = baseSpec();
+
+        listener.onPromptPushed(new PromptPushedEvent(spec));
+
+        verify(publisher).sendStatus(
+                eq(PromptExecutionSseListener.channelKey(spec.getId())),
+                eq(PromptExecutionSseListener.OPERATION),
+                eq(PromptExecutionSseListener.STATUS_PUSHED),
+                eq("Pushed to GitHub"),
+                any());
+    }
+
+    @Test
+    void onPromptPushFailedEmitsPushFailedStatusWithReasonAndErrorClass() {
+        PromptExecutionSseListener listener = new PromptExecutionSseListener(publisher);
+        PromptSpec spec = baseSpec();
+        PromptPushFailedEvent event = PromptPushFailedEvent.from(
+                spec, new IllegalStateException("remote rejected non-fast-forward"));
+
+        listener.onPromptPushFailed(event);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> detailsCaptor =
+                ArgumentCaptor.forClass(Map.class);
+        verify(publisher).sendStatus(
+                eq(PromptExecutionSseListener.channelKey(spec.getId())),
+                eq(PromptExecutionSseListener.OPERATION),
+                eq(PromptExecutionSseListener.STATUS_PUSH_FAILED),
+                eq("Push to GitHub failed"),
+                detailsCaptor.capture());
+
+        Map<String, Object> details = detailsCaptor.getValue();
+        assertThat(details).containsEntry("promptId", spec.getId());
+        assertThat(details).containsEntry("reason", "remote rejected non-fast-forward");
+        assertThat(details).containsEntry("errorClass", "IllegalStateException");
+    }
+
+    @Test
+    void onPromptPushFailedWithBlankPromptIdEmitsNothing() {
+        PromptExecutionSseListener listener = new PromptExecutionSseListener(publisher);
+        PromptSpec specWithoutId = PromptSpec.builder()
+                .withGroup("group")
+                .withName("name")
+                .withVersion("1.0.0-SNAPSHOT")
+                .withRevision(1)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder()
+                        .withVendor("openai")
+                        .withModel("gpt-4")
+                        .withMessages(List.of())
+                        .build())
+                .build();
+
+        listener.onPromptPushFailed(
+                PromptPushFailedEvent.from(specWithoutId, new RuntimeException("nope")));
+
+        verifyNoInteractions(publisher);
+    }
+
+    @Test
+    void onPromptPushFailedConstantMatchesAsyncApiEnum() {
+        // The contract value `push-failed` is shared with the AsyncAPI store-status enum
+        // and the frontend `isTerminalPromptExecutionStatusEvent` helper. Pin it here so
+        // a careless rename in the listener can't desync the wire format.
+        assertThat(PromptExecutionSseListener.STATUS_PUSH_FAILED).isEqualTo("push-failed");
+    }
+
+    private static PromptSpec baseSpec() {
+        return PromptSpec.builder()
+                .withGroup("group")
+                .withName("name")
+                .withVersion("1.0.0-SNAPSHOT")
+                .withRevision(1)
+                .withDescription("desc")
+                .withRequest(ChatCompletionRequest.builder()
+                        .withVendor("openai")
+                        .withModel("gpt-4")
+                        .withMessages(List.of())
+                        .build())
+                .build()
+                .withId("group/name");
+    }
+}

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
@@ -44,6 +44,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.nio.file.Files;
@@ -77,6 +79,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = PromptSpecController.class)
+@RecordApplicationEvents
 class PromptSpecControllerWebMvcTest {
 
     @Autowired
@@ -108,6 +111,9 @@ class PromptSpecControllerWebMvcTest {
 
     @MockitoBean
     private SseStatusPublisher sseStatusPublisher;
+
+    @Autowired(required = false)
+    private ApplicationEvents applicationEvents;
 
     @Test
     void getDefaultTemplateReturnsCanonicalDraftSeed() throws Exception {
@@ -1870,6 +1876,43 @@ class PromptSpecControllerWebMvcTest {
         mockMvc.perform(get("/api/prompts/{promptSpecId}/history", promptId).queryParam("pageSize", "500"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.pageSize").value(RepoHistoryAssembler.MAX_PAGE_SIZE));
+    }
+
+    @Test
+    void retryPushRepublishesPromptExecutedEventAndReturnsAccepted() throws Exception {
+        // Issue #361: the Retry-push endpoint re-fires only the deferred amend+push by
+        // republishing PromptExecutedEvent against the stored spec — the LLM is NOT
+        // re-invoked, so the executor must remain untouched.
+        String promptId = "support/welcome";
+        PromptSpec stored = baseSpec(promptId);
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.of(stored));
+
+        mockMvc.perform(post("/api/prompts/{promptSpecId}/push/retry", promptId))
+                .andExpect(status().isAccepted());
+
+        assertThat(applicationEvents).isNotNull();
+        List<dev.promptlm.domain.events.PromptExecutedEvent> executedEvents =
+                applicationEvents.stream(dev.promptlm.domain.events.PromptExecutedEvent.class).toList();
+        assertThat(executedEvents).hasSize(1);
+        assertThat(executedEvents.get(0).promptSpec()).isSameAs(stored);
+
+        // No LLM re-run on the push-retry path.
+        verifyNoInteractions(promptExecutor);
+    }
+
+    @Test
+    void retryPushReturnsNotFoundWhenPromptIsMissing() throws Exception {
+        String promptId = "support/missing";
+        when(promptStore.getLatestVersion(promptId)).thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/api/prompts/{promptSpecId}/push/retry", promptId))
+                .andExpect(status().isNotFound());
+
+        if (applicationEvents != null) {
+            assertThat(applicationEvents.stream(dev.promptlm.domain.events.PromptExecutedEvent.class))
+                    .isEmpty();
+        }
+        verifyNoInteractions(promptExecutor);
     }
 
     private static PromptSpec repoHistoryFixture(String id, String version, int revision, List<Execution> executions) {

--- a/components/promptlm-web-ui/src/api-common/storeStatusEvents.ts
+++ b/components/promptlm-web-ui/src/api-common/storeStatusEvents.ts
@@ -85,8 +85,11 @@ export type SubscribeToPromptExecutionStatusOptions = {
 
 export const isTerminalPromptExecutionStatusEvent = (event: StoreStatusEvent): boolean => {
   // 'executed' alone is not terminal — 'pushed' may still follow. The UI treats
-  // 'failed' or 'pushed' as terminal states for tearing down the subscription.
-  return event.status === 'failed' || event.status === 'pushed';
+  // 'failed', 'pushed', or 'push-failed' as terminal states for tearing down the
+  // subscription. ('push-failed' added in issue #361.)
+  return (
+    event.status === 'failed' || event.status === 'pushed' || event.status === 'push-failed'
+  );
 };
 
 export const subscribeToPromptExecutionStatus = ({

--- a/components/promptlm-web-ui/src/api/__tests__/storeStatusEvents.test.ts
+++ b/components/promptlm-web-ui/src/api/__tests__/storeStatusEvents.test.ts
@@ -17,6 +17,7 @@ import type { StoreStatusEvent } from '@promptlm/api-client';
 
 import {
   createStoreOperationId,
+  isTerminalPromptExecutionStatusEvent,
   isTerminalStoreStatusEvent,
   subscribeToStoreOperationStatus,
 } from '@api-common/storeStatusEvents';
@@ -149,6 +150,58 @@ describe('storeStatusEvents', () => {
         status: 'progress',
         message: 'Still cloning',
         timestamp: '2026-03-20T10:00:00.000Z',
+      }),
+    ).toBe(false);
+  });
+
+  it('treats failed, pushed, and push-failed as terminal prompt-execution states', () => {
+    // Issue #361: `push-failed` joins `failed` and `pushed` as terminal states so the
+    // editor subscription tears down once the server has reported a definitive outcome.
+    const at = '2026-04-01T10:00:00.000Z';
+
+    expect(
+      isTerminalPromptExecutionStatusEvent({
+        operation: 'prompt-execution',
+        status: 'failed',
+        message: 'Prompt execution failed',
+        timestamp: at,
+      }),
+    ).toBe(true);
+
+    expect(
+      isTerminalPromptExecutionStatusEvent({
+        operation: 'prompt-execution',
+        status: 'pushed',
+        message: 'Pushed to GitHub',
+        timestamp: at,
+      }),
+    ).toBe(true);
+
+    expect(
+      isTerminalPromptExecutionStatusEvent({
+        operation: 'prompt-execution',
+        status: 'push-failed',
+        message: 'Push to GitHub failed',
+        timestamp: at,
+      }),
+    ).toBe(true);
+
+    // Non-terminal intermediate states are still streamed through.
+    expect(
+      isTerminalPromptExecutionStatusEvent({
+        operation: 'prompt-execution',
+        status: 'executed',
+        message: 'Prompt executed',
+        timestamp: at,
+      }),
+    ).toBe(false);
+
+    expect(
+      isTerminalPromptExecutionStatusEvent({
+        operation: 'prompt-execution',
+        status: 'executing',
+        message: 'Executing prompt',
+        timestamp: at,
       }),
     ).toBe(false);
   });

--- a/components/promptlm-web-ui/src/features/prompt-editor/editorActions.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/editorActions.ts
@@ -150,6 +150,10 @@ export type PromptExecutionSubscriptionHandlers = {
   onExecuted?: (event: StoreStatusEvent) => void;
   onFailed?: (event: StoreStatusEvent) => void;
   onPushed?: (event: StoreStatusEvent) => void;
+  // #361: invoked when the deferred amend+push fails. Terminal — the
+  // subscription auto-closes once this fires. The editor wires this to a
+  // Retry-push affordance backed by `POST /api/prompts/{id}/push/retry`.
+  onPushFailed?: (event: StoreStatusEvent) => void;
   onError?: (error: Error) => void;
 };
 
@@ -159,6 +163,7 @@ export const subscribeToPromptExecutionAfterSave = ({
   onExecuted,
   onFailed,
   onPushed,
+  onPushFailed,
   onError,
 }: PromptExecutionSubscriptionHandlers): { close: () => void } => {
   const subscription = subscribeToPromptExecutionStatus({
@@ -176,6 +181,9 @@ export const subscribeToPromptExecutionAfterSave = ({
           break;
         case 'pushed':
           onPushed?.(event);
+          break;
+        case 'push-failed':
+          onPushFailed?.(event);
           break;
         default:
           // `connected` and other shared lifecycle states are ignored here;


### PR DESCRIPTION
Closes #361. Stacks on #359.

## Summary

After a successful LLM execution, a failed `amendAndPushHead` previously logged a warning and silently preserved the local commit — the editor saw `executed` over SSE and assumed the prompt was in the remote repo when it wasn't.

This change surfaces push failures explicitly all the way to the editor:

- New `PromptPushFailedEvent` carries the spec, a short human-readable reason, and the underlying exception's simple class name for UI categorisation.
- `PromptPushListener` publishes the event from its catch block while still preserving the local commit so retry is possible.
- `PromptExecutionSseListener` bridges the event to SSE status `push-failed` with `details.reason` + `details.errorClass`.
- AsyncAPI store-status enum gains `push-failed`; TS regenerated.
- Frontend treats `push-failed` as terminal in `isTerminalPromptExecutionStatusEvent`, and `subscribeToPromptExecutionAfterSave` gains an optional `onPushFailed` callback (declaration-only; the UI wiring lands in #360).
- New `POST /api/prompts/{id}/push/retry` endpoint re-fires only the amend+push by republishing `PromptExecutedEvent` against the locally-stored spec — the LLM is NOT re-invoked.

## Test plan

- [x] `PromptPushListenerTest` — failure path emits `PromptPushFailedEvent` and not `PromptPushedEvent`, local commit preserved
- [x] `PromptExecutionSseListenerTest` (new) — `push-failed` payload shape, blank-id guard, wire-format constant
- [x] `PromptSpecControllerWebMvcTest` — `/push/retry` returns 202 and republishes `PromptExecutedEvent`; missing prompt returns 404; executor is never invoked
- [x] `storeStatusEvents.test.ts` — `isTerminalPromptExecutionStatusEvent` covers the new terminal state
- [x] `npx tsc --noEmit` clean
- [x] `npm test` 216/216 green
- [x] `mvn -pl components/promptlm-{lifecycle,web-api,domain} -am test` 128/128 green