### PR TITLE
chore(deps): drop redundant spring-boot-starter-test-classic re-declarations (#303)

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -82,12 +82,6 @@
         </dependency>
 
         <!-- Spring Boot test dependencies -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test-classic</artifactId>
-            <version>4.0.3</version>
-            <scope>test</scope>
-        </dependency>
 
         <!-- JUnit Jupiter API -->
         <dependency>

--- a/components/promptlm-core/pom.xml
+++ b/components/promptlm-core/pom.xml
@@ -53,11 +53,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.22.0</version>

--- a/components/promptlm-execution-litellm/pom.xml
+++ b/components/promptlm-execution-litellm/pom.xml
@@ -43,11 +43,6 @@
             <version>${resilience4j.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/components/promptlm-execution-springai/pom.xml
+++ b/components/promptlm-execution-springai/pom.xml
@@ -43,10 +43,5 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-classic</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/components/promptlm-execution/pom.xml
+++ b/components/promptlm-execution/pom.xml
@@ -33,11 +33,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.modulith</groupId>
             <artifactId>spring-modulith-starter-core</artifactId>
         </dependency>

--- a/components/promptlm-store/promptlm-store-github/pom.xml
+++ b/components/promptlm-store/promptlm-store-github/pom.xml
@@ -23,11 +23,6 @@
             <artifactId>spring-boot-starter-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>dev.promptlm</groupId>
             <artifactId>promptlm-store-api</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
## Summary

Pure deletion sweep — drops the per-component `spring-boot-starter-test-classic` re-declarations now that `promptlm-parent` ships a slim test starter with explicit hamcrest/json-path/awaitility for every consumer.

Removed from 6 poms (31 lines deleted):
- acceptance-tests/pom.xml (also drops the stray hard-coded version 4.0.3)
- components/promptlm-core/pom.xml
- components/promptlm-execution/pom.xml
- components/promptlm-execution-litellm/pom.xml
- components/promptlm-execution-springai/pom.xml
- components/promptlm-store/promptlm-store-github/pom.xml

`grep -rE 'spring-boot-starter-test-classic' --include=pom.xml .` now returns zero matches.

Closes #303. Best landed after #302 (no text overlap, but #303's invariant only holds once `-classic` is gone everywhere).

## Test plan

- [x] grep audit: no remaining `spring-boot-starter-test-classic` entries
- [x] xmllint validates all 6 modified poms
- [ ] CI: per-module test, full reactor build
- [ ] `mvn dependency:tree -Dincludes='*:*-classic'` (CI verifies via standard build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)