### PR TITLE
fix(store): null-safe id match at remaining 2 sites + remove dead .peek (#227)

### DIFF
--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubPromptStore.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubPromptStore.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -230,7 +231,6 @@ public class GitHubPromptStore implements PromptStore {
                     .filter(this::isPromptSpec)
                     .filter(beforeReading)
                     .map(f -> modelYamlMapper.readValue(f.toFile(), PromptSpec.class))
-                    .peek(spec -> spec.getId())
                     .filter(predicate)
                     .findFirst();
         }
@@ -689,7 +689,7 @@ public class GitHubPromptStore implements PromptStore {
         List<GitRepositoryMetadataFile.Version> versions = metadataFile.getVersions();
 
         GitRepositoryMetadataFile.Version v = versions.stream()
-                .filter(m -> m.getId().equals(picked.getId()) && releaseVersion.equals(m.getVersion()))
+                .filter(m -> Objects.equals(m.getId(), picked.getId()) && releaseVersion.equals(m.getVersion()))
                 .findFirst()
                 .orElse(newVersion(versions));
         v.setName(picked.getName());
@@ -1028,7 +1028,7 @@ public class GitHubPromptStore implements PromptStore {
 
         Path repoDir = appContext.getActiveProject().getRepoDir();
         git.checkoutBranch(DEV_BRANCH, repoDir.toFile());
-        Optional<PromptSpec> dev = searchInPromptSpec(repoDir.toFile(), (p) -> p.getId().equals(id), p -> true);
+        Optional<PromptSpec> dev = searchInPromptSpec(repoDir.toFile(), (p) -> id.equals(p.getId()), p -> true);
         return dev.orElseThrow(() -> new IllegalArgumentException("Could not find PromptSpec with id %s".formatted(id)));
 
     }

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitHubPromptStoreGetDevelopmentVersionTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitHubPromptStoreGetDevelopmentVersionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.store.github;
+
+import dev.promptlm.domain.AppContext;
+import dev.promptlm.domain.BasicAppContext;
+import dev.promptlm.domain.ObjectMapperFactory;
+import dev.promptlm.domain.projectspec.ProjectSpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Regression tests for {@link GitHubPromptStore#getDevelopmentVersion(String)} —
+ * see promptLM/promptlm-app#227: the predicate must not NPE when a spec on
+ * disk has a null id (mirror of the #218 fix for getLatestVersion).
+ */
+class GitHubPromptStoreGetDevelopmentVersionTest {
+
+    @Test
+    void getDevelopmentVersionDoesNotThrowWhenSpecHasNullId(@TempDir Path repoDir) throws Exception {
+        // A malformed spec on disk with no id field — must not NPE the
+        // stream filter while searching for an unrelated id.
+        Path nullIdSpec = repoDir.resolve("prompts/support/broken/promptlm.yml");
+        Files.createDirectories(nullIdSpec.getParent());
+        Files.writeString(nullIdSpec,
+                "name: broken\ngroup: support\nversion: '1.0'\nrevision: 1\n");
+
+        GitHubPromptStore store = newStore(repoDir);
+
+        assertThatThrownBy(() -> store.getDevelopmentVersion("support/something-else"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Could not find PromptSpec");
+    }
+
+    @Test
+    void getDevelopmentVersionThrowsIllegalArgumentForUnknownIdInEmptyRepo(@TempDir Path repoDir) throws Exception {
+        Files.createDirectories(repoDir.resolve("prompts"));
+
+        GitHubPromptStore store = newStore(repoDir);
+
+        assertThatCode(() -> store.getDevelopmentVersion("does-not-exist"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static GitHubPromptStore newStore(Path repoDir) {
+        AppContext appContext = new BasicAppContext();
+        appContext.setActiveProject(ProjectSpec.fromRepo(repoDir));
+        return new GitHubPromptStore(
+                ObjectMapperFactory.createYamlMapper(),
+                new GitFileNameStrategy(),
+                mock(dev.promptlm.store.github.Git.class),
+                appContext,
+                new IntVersioningStrategy(),
+                new GitRepositoryMetadata(ObjectMapperFactory.createJsonMapper())
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #218 / #221 which only fixed one of three instances of the same null-unsafe pattern in `GitHubPromptStore`. Two more sites still NPE if any `PromptSpec` on disk deserialises to a null id; this PR closes the gap and removes a pre-existing dead `.peek`.

- `writeMetadata` (line 692): `m.getId().equals(picked.getId())` → `Objects.equals(m.getId(), picked.getId())`
- `getDevelopmentVersion` (line 1031): `p.getId().equals(id)` → `id.equals(p.getId())` (mirrors #218 style)
- `searchInPromptSpecIncludingRetired` (line 233): dropped `.peek(spec -> spec.getId())` no-op

New test `GitHubPromptStoreGetDevelopmentVersionTest` mirrors the regression coverage style of the existing `GitHubPromptStoreGetLatestVersionTest`.

Closes #227. Refs #218, #221.

## Test plan

- [x] `./mvnw -pl components/promptlm-store/promptlm-store-github test -Dtest='GitHubPromptStoreGetDevelopmentVersionTest,GitHubPromptStoreGetLatestVersionTest' -Dsurefire.failIfNoSpecifiedTests=false` — 4 tests pass locally
- [ ] CI: full reactor build + acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)