### PR TITLE
fix(pricing): match dated model ids against short-form catalog keys (#229)

### DIFF
--- a/components/promptlm-web-api/src/main/java/dev/promptlm/pricing/ModelPricingService.java
+++ b/components/promptlm-web-api/src/main/java/dev/promptlm/pricing/ModelPricingService.java
@@ -19,6 +19,7 @@ package dev.promptlm.pricing;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import dev.promptlm.pricing.ModelPricingProperties.ModelPrice;
 
@@ -81,6 +82,11 @@ public class ModelPricingService {
         return Optional.of(cost);
     }
 
+    // Trailing dated-revision suffix used by OpenAI / Anthropic SDK exposed ids,
+    // e.g. "gpt-5-2025-08-07", "claude-opus-4-5-20251101", "o3-2025-04-16".
+    // Matches "-YYYY-MM-DD" or "-YYYYMMDD" anchored to end of string.
+    private static final Pattern DATED_SUFFIX = Pattern.compile("-(\\d{4}-\\d{2}-\\d{2}|\\d{8})$");
+
     private ModelPrice lookup(String model) {
 
         Map<String, ModelPrice> table = properties.getModels();
@@ -93,19 +99,37 @@ public class ModelPricingService {
             return direct;
         }
         String normalized = trimmed.toLowerCase(Locale.ROOT);
-        for (Map.Entry<String, ModelPrice> entry : table.entrySet()) {
-            if (entry.getKey().toLowerCase(Locale.ROOT).equals(normalized)) {
-                return entry.getValue();
-            }
+        ModelPrice match = matchCaseInsensitive(table, normalized);
+        if (match != null) {
+            return match;
         }
         // Tolerate vendor-prefixed forms like "openai/gpt-4o".
         int slash = normalized.indexOf('/');
+        String afterVendor = normalized;
         if (slash >= 0 && slash < normalized.length() - 1) {
-            String stripped = normalized.substring(slash + 1);
-            for (Map.Entry<String, ModelPrice> entry : table.entrySet()) {
-                if (entry.getKey().toLowerCase(Locale.ROOT).equals(stripped)) {
-                    return entry.getValue();
-                }
+            afterVendor = normalized.substring(slash + 1);
+            match = matchCaseInsensitive(table, afterVendor);
+            if (match != null) {
+                return match;
+            }
+        }
+        // Tolerate dated SDK ids ("gpt-5-2025-08-07", "claude-opus-4-5-20251101",
+        // "o3-2025-04-16") by stripping a trailing -YYYY-MM-DD or -YYYYMMDD and
+        // retrying against the short-form catalog keys.
+        String undated = DATED_SUFFIX.matcher(afterVendor).replaceFirst("");
+        if (!undated.equals(afterVendor)) {
+            match = matchCaseInsensitive(table, undated);
+            if (match != null) {
+                return match;
+            }
+        }
+        return null;
+    }
+
+    private static ModelPrice matchCaseInsensitive(Map<String, ModelPrice> table, String needle) {
+        for (Map.Entry<String, ModelPrice> entry : table.entrySet()) {
+            if (entry.getKey().toLowerCase(Locale.ROOT).equals(needle)) {
+                return entry.getValue();
             }
         }
         return null;

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/pricing/ModelPricingServiceTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/pricing/ModelPricingServiceTest.java
@@ -109,6 +109,75 @@ class ModelPricingServiceTest {
     }
 
     @Test
+    void computeCost_matchesDatedOpenAiModelIdAgainstShortFormKey() {
+        // promptLM/promptlm-app#229 — SDKs persist dated ids like
+        // "gpt-5-2025-08-07"; the catalog keys are short-form ("gpt-5").
+        ModelPricingService service = serviceWith(Map.of(
+                "gpt-5", price(2.50, 10.00)
+        ));
+
+        Optional<Double> cost = service.computeCost("gpt-5-2025-08-07", 1_000_000, 0);
+
+        assertThat(cost).isPresent();
+        assertThat(cost.get()).isCloseTo(2.50, within(1e-9));
+    }
+
+    @Test
+    void computeCost_matchesDatedAnthropicModelIdAgainstShortFormKey() {
+        // Anthropic's dated form uses YYYYMMDD ("claude-opus-4-5-20251101").
+        ModelPricingService service = serviceWith(Map.of(
+                "claude-opus-4-5", price(15.00, 75.00)
+        ));
+
+        Optional<Double> cost = service.computeCost("claude-opus-4-5-20251101", 1_000_000, 0);
+
+        assertThat(cost).isPresent();
+        assertThat(cost.get()).isCloseTo(15.00, within(1e-9));
+    }
+
+    @Test
+    void computeCost_matchesDatedReasoningModelIdAgainstShortFormKey() {
+        // Regression for the o3-2025-04-16 case previously papered over in #224.
+        ModelPricingService service = serviceWith(Map.of(
+                "o3", price(2.00, 8.00)
+        ));
+
+        Optional<Double> cost = service.computeCost("o3-2025-04-16", 1_000_000, 0);
+
+        assertThat(cost).isPresent();
+        assertThat(cost.get()).isCloseTo(2.00, within(1e-9));
+    }
+
+    @Test
+    void computeCost_matchesVendorPrefixedDatedId() {
+        // Vendor prefix + dated suffix combined.
+        ModelPricingService service = serviceWith(Map.of(
+                "gpt-5", price(2.50, 10.00)
+        ));
+
+        Optional<Double> cost = service.computeCost("openai/gpt-5-2025-08-07", 1_000_000, 0);
+
+        assertThat(cost).isPresent();
+        assertThat(cost.get()).isCloseTo(2.50, within(1e-9));
+    }
+
+    @Test
+    void computeCost_preservesExactMatchOverDatedFallback() {
+        // If both the dated form and the short form are in the catalog,
+        // the dated form must win — never silently shadow a more-specific
+        // price with the short-form fallback.
+        ModelPricingService service = serviceWith(Map.of(
+                "gpt-5", price(2.50, 10.00),
+                "gpt-5-2025-08-07", price(3.00, 12.00)
+        ));
+
+        Optional<Double> cost = service.computeCost("gpt-5-2025-08-07", 1_000_000, 0);
+
+        assertThat(cost).isPresent();
+        assertThat(cost.get()).isCloseTo(3.00, within(1e-9));
+    }
+
+    @Test
     void computeCost_emptyTableReturnsEmpty() {
         ModelPricingService service = serviceWith(Map.of());
 


### PR DESCRIPTION
## Summary

SDKs persist dated model ids (`gpt-5-2025-08-07`, `claude-opus-4-5-20251101`, `o3-2025-04-16`) on `PromptSpec.request.model`, but the pricing catalog keys are short-form (`gpt-5`, `claude-opus-4-5`, `o3`). The previous lookup missed every dated id and the cost chip silently disappeared.

This PR adds a regex-stripping fallback to `ModelPricingService#lookup` per option (1) of #229:
1. exact match
2. case-insensitive scan
3. vendor-prefix strip (existing `openai/gpt-4o` behavior)
4. **new**: dated suffix strip (`-YYYY-MM-DD` or `-YYYYMMDD`) anchored to end of string, retry against the catalog

Exact dated keys still win over the short-form fallback, so operators can override per-revision pricing when they want to (validated by a precedence test).

Closes #229. Refs #216, #221, #224.

## Test plan

- [x] 5 new unit tests for OpenAI dated ids, Anthropic dated ids, the o3-2025-04-16 case previously papered over by #224, vendor-prefixed dated ids, and the precedence guarantee
- [x] `./mvnw -pl components/promptlm-web-api test -Dtest=ModelPricingServiceTest -Dsurefire.failIfNoSpecifiedTests=false` — 13 tests pass locally (5 new + 8 existing)
- [ ] CI: full reactor build

🤖 Generated with [Claude Code](https://claude.com/claude-code)