### PR TITLE
fix(#302): drop spring-boot-starter-classic; pick narrowest-fit starters

### DIFF
--- a/apps/promptlm-webapp/pom.xml
+++ b/apps/promptlm-webapp/pom.xml
@@ -69,6 +69,13 @@ limitations under the License.
             <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- TestRestTemplate uses RestTemplateBuilder; spring-boot-resttestclient does not
+             transitively bring spring-boot-restclient in 4.0.6, so declare it explicitly here. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/promptlm-core/pom.xml
+++ b/components/promptlm-core/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-classic</artifactId>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>dev.promptlm</groupId>

--- a/components/promptlm-evaluation/pom.xml
+++ b/components/promptlm-evaluation/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-classic</artifactId>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.modulith</groupId>

--- a/components/promptlm-execution-litellm/pom.xml
+++ b/components/promptlm-execution-litellm/pom.xml
@@ -29,7 +29,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-classic</artifactId>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
         <dependency>

--- a/components/promptlm-execution-springai/pom.xml
+++ b/components/promptlm-execution-springai/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-classic</artifactId>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/components/promptlm-rest-docs/pom.xml
+++ b/components/promptlm-rest-docs/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-classic</artifactId>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/components/promptlm-store/promptlm-store-github/pom.xml
+++ b/components/promptlm-store/promptlm-store-github/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-classic</artifactId>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>dev.promptlm</groupId>

--- a/components/promptlm-web-api/pom.xml
+++ b/components/promptlm-web-api/pom.xml
@@ -17,11 +17,11 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-classic</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webmvc</artifactId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
@@ -72,6 +72,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TestRestTemplate uses RestTemplateBuilder; spring-boot-resttestclient does not
+             transitively bring spring-boot-restclient in 4.0.6, so declare it explicitly here. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary

Replace the Spring Boot 4 migration umbrella `spring-boot-starter-classic` in the seven listed component poms. The app has zero JPA/JDBC/H2 usage in source or tests, so classic's ~30 transitive data starters (JPA, Hibernate ORM, H2, Cassandra, MongoDB, Neo4j, Redis, Elasticsearch, Couchbase, ...) are pure noise on the classpath. Each module gets the narrowest fit rather than a blanket swap.

### Per-module table

| Module                                           | classic →                                                                                       |
|--------------------------------------------------|-------------------------------------------------------------------------------------------------|
| `components/promptlm-core`                       | `spring-boot-starter`                                                                           |
| `components/promptlm-evaluation`                 | `spring-boot-starter`                                                                           |
| `components/promptlm-execution-litellm`          | `spring-boot-starter`                                                                           |
| `components/promptlm-execution-springai`         | `spring-boot-starter`                                                                           |
| `components/promptlm-rest-docs`                  | `spring-boot-starter`                                                                           |
| `components/promptlm-store/promptlm-store-github`| `spring-boot-starter`                                                                           |
| `components/promptlm-web-api`                    | dropped (covered by `spring-boot-starter-webmvc` already present) + added `spring-boot-starter-validation` for `@Valid` / `@NotBlank` / `@Validated` |

### Side effect — explicit `spring-boot-restclient` at test scope

In Spring Boot 4.0.6, `spring-boot-resttestclient` does not transitively depend on `spring-boot-restclient`, even though `TestRestTemplate` needs `RestTemplateBuilder` from it. classic used to mask this by hauling `spring-boot-restclient` onto the compile classpath. Declared it explicitly at `test` scope in `components/promptlm-web-api` and `apps/promptlm-webapp` where `TestRestTemplate` is actually used. Reported inline in both poms.

## Verification

- `./mvnw clean install -DskipTests` — green reactor-wide.
- Scoped test run on the seven targets plus `apps/promptlm-webapp` — all green. Per-module test counts (truncated): core 19, evaluation 6, litellm 34, springai 2, rest-docs 4, store-github 102, web-api 127, webapp 3, plus transitives — ~478 tests total, 0 failures, 0 errors.
- `mvn -pl apps/promptlm-webapp dependency:tree -DskipTests | grep -iE 'jpa|hibernate|h2console|h2:jar|cassandra|mongodb|neo4j|redis|elasticsearch|couchbase'` yields:
  - `hibernate-validator` (Bean Validation impl — expected from `spring-boot-starter-validation`, not the ORM)
  - `httpcore5-h2` (Apache HTTP/2, unrelated to H2 the DB)
  - No JPA, H2 console, Cassandra, MongoDB, Neo4j, Redis, Elasticsearch, Couchbase.
- `grep -rE 'spring-boot-starter-classic[<"]' --include=pom.xml .` — empty.
- `./mvnw -pl apps/promptlm-webapp install -DskipTests` — webapp jar still builds.

## Non-obvious calls

- `promptlm-web-api` was the only module where the swap was not a literal artifact rename. It already had `spring-boot-starter-webmvc`, so the narrowest fit was to drop classic entirely (web-mvc transitively brings the slim starter) and add `spring-boot-starter-validation` to keep `jakarta.validation.Valid` / `@NotBlank` / `@Validated` working. Without classic the validation impl is no longer transitively pulled.

## Surprises

- 4.0.6's `spring-boot-resttestclient` pom does not depend on `spring-boot-restclient`. Worth a Spring Boot upstream note — but harmless to handle at our side by declaring it explicitly where `TestRestTemplate` is used.

## Test plan

- [ ] CI green on this PR.
- [ ] Verify `dependency:tree` post-merge shows no `spring-boot-starter-classic` anywhere in the reactor.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)