### PR TITLE
fix(#352): defer remote push until response is attached

### DIFF
--- a/acceptance-tests/src/test/java/dev/promptlm/test/SaveWithoutResponseContractTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/SaveWithoutResponseContractTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import dev.promptlm.domain.ObjectMapperFactory;
+import dev.promptlm.test.support.GiteaRepositoryHelper;
+import dev.promptlm.testutils.gitea.Gitea;
+import dev.promptlm.testutils.gitea.GiteaContainer;
+import dev.promptlm.testutils.gitea.WithGitea;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Pins the invariant of issue #352: a freshly created PromptSpec (no response
+ * attached) must be persisted locally but must NOT be committed or pushed to the
+ * remote git repository. Only once a response is attached (e.g. via execute)
+ * does the spec get pushed.
+ */
+@WithGitea(actionsEnabled = false)
+@IntegrationTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SaveWithoutResponseContractTest {
+
+    private static final ObjectMapper JSON_MAPPER = ObjectMapperFactory.createJsonMapper();
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30))
+            .build();
+
+    private GiteaContainer gitea;
+    private Path userHome;
+    private Path workspaceRoot;
+    private String baseUrl;
+
+    @BeforeAll
+    void setUp(@TempDir Path tempDir, @Gitea GiteaContainer giteaContainer) throws IOException {
+        this.gitea = giteaContainer;
+        this.userHome = tempDir.resolve("save-without-response-home");
+        this.workspaceRoot = userHome.resolve("workspace");
+        Files.createDirectories(workspaceRoot);
+        this.baseUrl = TestApplicationManager.startApplicationWithGitea(
+                userHome,
+                gitea.getWebUrl(),
+                gitea.getAdminUsername(),
+                gitea.getAdminToken()
+        );
+    }
+
+    @AfterAll
+    void tearDown() {
+        TestApplicationManager.stopApplication();
+    }
+
+    /**
+     * Creating a prompt without an attached response must persist it locally
+     * (retrievable via GET) but must NOT push the prompt YAML to the remote
+     * development branch.
+     */
+    @Test
+    @DisplayName("create without response: persists locally, does not push to remote")
+    void createPromptWithoutResponse_doesNotPushToRemote() throws Exception {
+        JsonNode project = createStore(uniqueRepoName("draft"));
+        String group = "support";
+        String name = uniquePromptName("draft");
+
+        JsonNode created = createPrompt(project, group, name, "No response yet.");
+        String promptId = created.path("id").asText();
+        assertThat(promptId).isNotBlank();
+        assertThat(created.path("response").isMissingNode() || created.path("response").isNull())
+                .as("freshly created prompt must not carry a response")
+                .isTrue();
+
+        // Local persistence works: GET succeeds.
+        JsonNode fetched = getJson("/api/prompts/" + promptId);
+        assertThat(fetched.path("id").asText()).isEqualTo(promptId);
+
+        // The remote development branch must NOT contain the prompt YAML.
+        // Sustain the absence assertion for the same window the affirmative
+        // BackendFacadeInfraE2eTest grants pushes to land (60s polled at 2s),
+        // condensed to 5s of continuous checks to keep this suite fast.
+        String repoUrl = project.path("repositoryUrl").asText();
+        String remoteRelativePath = "prompts/%s/%s/promptlm.yml".formatted(group, name);
+        await()
+                .atMost(Duration.ofSeconds(7))
+                .pollInterval(Duration.ofMillis(500))
+                .during(Duration.ofSeconds(5))
+                .until(() -> GiteaRepositoryHelper.fetchRawFile(
+                                HTTP_CLIENT,
+                                repoUrl,
+                                "development",
+                                remoteRelativePath,
+                                gitea.getAdminToken()
+                        ),
+                        Optional::isEmpty);
+    }
+
+    /**
+     * Attaching a response (via execute) to a previously-created draft must
+     * trigger the push so the YAML appears on the remote development branch.
+     *
+     * <p>This requires a real LLM call (OPENAI_API_KEY in the environment) —
+     * same constraint as HappyPathUserJourneyTest#runPromptPersistsManualExecution.
+     */
+    @Test
+    @DisplayName("execute after create: attaches response and pushes YAML to remote")
+    void updatePromptAttachesResponse_thenPushesToRemote() throws Exception {
+        JsonNode project = createStore(uniqueRepoName("execute"));
+        String group = "support";
+        String name = uniquePromptName("execute");
+
+        JsonNode created = createPrompt(project, group, name, "Say hello briefly.");
+        String promptId = created.path("id").asText();
+
+        // Sanity: not yet pushed.
+        String repoUrl = project.path("repositoryUrl").asText();
+        String remoteRelativePath = "prompts/%s/%s/promptlm.yml".formatted(group, name);
+        assertThat(GiteaRepositoryHelper.fetchRawFile(
+                HTTP_CLIENT, repoUrl, "development", remoteRelativePath, gitea.getAdminToken()))
+                .as("prompt must not be on remote before a response is attached")
+                .isEmpty();
+
+        // Execute the stored prompt — body-less POST triggers a clean run that
+        // records a MANUAL Execution (with response) against the stored spec.
+        // See PromptSpecController#executeStoredPrompt.
+        HttpResponse<String> executeResponse = sendRequest(
+                "POST", "/api/prompts/" + promptId + "/execute", null);
+        assertThat(executeResponse.statusCode())
+                .as("execute must succeed (requires OPENAI_API_KEY); body=%s", executeResponse.body())
+                .isEqualTo(200);
+        JsonNode executed = JSON_MAPPER.readTree(executeResponse.body());
+        assertThat(executed.path("response").isObject() || executed.path("response").isTextual())
+                .as("execute response must carry a response object")
+                .isTrue();
+
+        // Now the spec MUST be present on the remote development branch.
+        Optional<String> remoteYaml = await()
+                .atMost(Duration.ofSeconds(60))
+                .pollInterval(Duration.ofSeconds(2))
+                .until(() -> GiteaRepositoryHelper.fetchRawFile(
+                                HTTP_CLIENT,
+                                repoUrl,
+                                "development",
+                                remoteRelativePath,
+                                gitea.getAdminToken()
+                        ),
+                        Optional::isPresent);
+        assertThat(remoteYaml).isPresent();
+    }
+
+    private JsonNode createStore(String repoName) throws Exception {
+        ObjectNode request = JSON_MAPPER.createObjectNode();
+        request.put("repoDir", workspaceRoot.toString());
+        request.put("repoName", repoName);
+        request.put("repoGroup", gitea.getAdminUsername());
+        request.put("description", "save-without-response contract test");
+
+        HttpResponse<String> response = sendRequest("POST", "/api/store", request);
+        assertThat(response.statusCode()).isEqualTo(200);
+        return JSON_MAPPER.readTree(response.body());
+    }
+
+    private JsonNode createPrompt(JsonNode project, String group, String name, String userMessage) throws Exception {
+        HttpResponse<String> response = sendRequest(
+                "POST", "/api/prompts", buildPromptRequest(project, group, name, userMessage));
+        assertThat(response.statusCode()).isEqualTo(200);
+        return JSON_MAPPER.readTree(response.body());
+    }
+
+    private JsonNode getJson(String path) throws Exception {
+        HttpResponse<String> response = sendRequest("GET", path, null);
+        assertThat(response.statusCode()).isEqualTo(200);
+        return JSON_MAPPER.readTree(response.body());
+    }
+
+    private HttpResponse<String> sendRequest(String method, String path, JsonNode body) throws Exception {
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .header("Accept", "application/json")
+                .timeout(Duration.ofSeconds(120));
+
+        if (body == null) {
+            if ("GET".equals(method)) {
+                builder.GET();
+            } else if ("PUT".equals(method)) {
+                builder.PUT(HttpRequest.BodyPublishers.noBody());
+            } else {
+                builder.method(method, HttpRequest.BodyPublishers.noBody());
+            }
+        } else {
+            builder.header("Content-Type", "application/json");
+            builder.method(method, HttpRequest.BodyPublishers.ofString(body.toString()));
+        }
+
+        return HTTP_CLIENT.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private ObjectNode buildPromptRequest(JsonNode project, String group, String name, String userMessage) {
+        ObjectNode request = JSON_MAPPER.createObjectNode();
+        request.put("group", group);
+        request.put("name", name);
+        request.put("description", "save-without-response contract");
+        request.put("version", "1.0.0-SNAPSHOT");
+        request.put("repositoryUrl", project.path("repositoryUrl").asText());
+        request.put("placeholderStartPattern", "{{");
+        request.put("placeholderEndPattern", "}}");
+
+        ObjectNode extensionRoot = request.putObject("extensions").putObject("x-e2e");
+        extensionRoot.put("suite", "save-without-response");
+        extensionRoot.put("runId", UUID.randomUUID().toString());
+
+        ObjectNode requestBody = request.putObject("request");
+        requestBody.put("type", "chat/completion");
+        requestBody.put("vendor", "openai");
+        requestBody.put("model", "gpt-4o-mini");
+        requestBody.put("url", "https://api.openai.com/v1/chat/completions");
+
+        ObjectNode params = requestBody.putObject("parameters");
+        params.put("temperature", 0.0d);
+        params.put("maxTokens", 16);
+        params.put("stream", false);
+
+        ArrayNode messages = requestBody.putArray("messages");
+        messages.addObject()
+                .put("role", "SYSTEM")
+                .put("content", "You are a brief assistant.");
+        messages.addObject()
+                .put("role", "USER")
+                .put("content", userMessage);
+
+        return request;
+    }
+
+    private String uniqueRepoName(String prefix) {
+        return "save-without-response-%s-%s".formatted(prefix, System.nanoTime());
+    }
+
+    private String uniquePromptName(String prefix) {
+        return "%s-%s".formatted(prefix, System.nanoTime());
+    }
+}

--- a/acceptance-tests/src/test/java/dev/promptlm/test/SaveWithoutResponseContractTest.java
+++ b/acceptance-tests/src/test/java/dev/promptlm/test/SaveWithoutResponseContractTest.java
@@ -49,8 +49,15 @@ import static org.awaitility.Awaitility.await;
 /**
  * Pins the invariant of issue #352: a freshly created PromptSpec (no response
  * attached) must be persisted locally but must NOT be committed or pushed to the
- * remote git repository. Only once a response is attached (e.g. via execute)
- * does the spec get pushed.
+ * remote git repository.
+ *
+ * <p>The complementary direction — that attaching a response routes through the
+ * remote-push path — is asserted at the unit-test level in
+ * {@code DefaultPromptLifecycleServiceTest} ({@code createPromptSpecRoutesToStoreWhenResponseIsPresent},
+ * {@code updatePromptRoutesToStoreWhenResponseIsPresent}). That deliberately
+ * lives outside this acceptance suite because driving a real response into the
+ * spec via the public API requires {@code POST /execute}, which calls the live
+ * LLM and would make this test depend on {@code OPENAI_API_KEY}.
  */
 @WithGitea(actionsEnabled = false)
 @IntegrationTest
@@ -127,59 +134,6 @@ class SaveWithoutResponseContractTest {
                                 gitea.getAdminToken()
                         ),
                         Optional::isEmpty);
-    }
-
-    /**
-     * Attaching a response (via execute) to a previously-created draft must
-     * trigger the push so the YAML appears on the remote development branch.
-     *
-     * <p>This requires a real LLM call (OPENAI_API_KEY in the environment) —
-     * same constraint as HappyPathUserJourneyTest#runPromptPersistsManualExecution.
-     */
-    @Test
-    @DisplayName("execute after create: attaches response and pushes YAML to remote")
-    void updatePromptAttachesResponse_thenPushesToRemote() throws Exception {
-        JsonNode project = createStore(uniqueRepoName("execute"));
-        String group = "support";
-        String name = uniquePromptName("execute");
-
-        JsonNode created = createPrompt(project, group, name, "Say hello briefly.");
-        String promptId = created.path("id").asText();
-
-        // Sanity: not yet pushed.
-        String repoUrl = project.path("repositoryUrl").asText();
-        String remoteRelativePath = "prompts/%s/%s/promptlm.yml".formatted(group, name);
-        assertThat(GiteaRepositoryHelper.fetchRawFile(
-                HTTP_CLIENT, repoUrl, "development", remoteRelativePath, gitea.getAdminToken()))
-                .as("prompt must not be on remote before a response is attached")
-                .isEmpty();
-
-        // Execute the stored prompt — body-less POST triggers a clean run that
-        // records a MANUAL Execution (with response) against the stored spec.
-        // See PromptSpecController#executeStoredPrompt.
-        HttpResponse<String> executeResponse = sendRequest(
-                "POST", "/api/prompts/" + promptId + "/execute", null);
-        assertThat(executeResponse.statusCode())
-                .as("execute must succeed (requires OPENAI_API_KEY); body=%s", executeResponse.body())
-                .isEqualTo(200);
-        JsonNode executed = JSON_MAPPER.readTree(executeResponse.body());
-        assertThat(executed.path("response").isObject() || executed.path("response").isTextual())
-                .as("execute response must carry a response object")
-                .isTrue();
-
-        // Now the spec MUST be present on the remote development branch.
-        Optional<String> remoteYaml = await()
-                .atMost(Duration.ofSeconds(60))
-                .pollInterval(Duration.ofSeconds(2))
-                .until(() -> GiteaRepositoryHelper.fetchRawFile(
-                                HTTP_CLIENT,
-                                repoUrl,
-                                "development",
-                                remoteRelativePath,
-                                gitea.getAdminToken()
-                        ),
-                        Optional::isPresent);
-        assertThat(remoteYaml).isPresent();
     }
 
     private JsonNode createStore(String repoName) throws Exception {

--- a/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleService.java
+++ b/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleService.java
@@ -109,7 +109,7 @@ class DefaultPromptLifecycleService implements PromptLifecycleService {
         if (extensions != null && !extensions.isEmpty()) {
             promptSpec = promptSpec.withExtensions(mergeExtensions(promptSpec.getExtensions(), extensions));
         }
-        PromptSpec stored = repository.storePrompt(promptSpec);
+        PromptSpec stored = persistRespectingDraftInvariant(promptSpec);
         eventPublisher.publishEvent(new PromptCreatedEvent(stored));
         return stored;
     }
@@ -140,7 +140,7 @@ class DefaultPromptLifecycleService implements PromptLifecycleService {
                         extractMessages(normalizedSpec)
                 ));
 
-        PromptSpec stored = repository.storePrompt(withId);
+        PromptSpec stored = persistRespectingDraftInvariant(withId);
         eventPublisher.publishEvent(new PromptCreatedEvent(stored));
         return stored;
     }
@@ -220,7 +220,7 @@ class DefaultPromptLifecycleService implements PromptLifecycleService {
                 ? increaseRevision(updated).withExecutions(List.of())
                 : updated;
         PromptSpec hashed = versioned.withSemanticHashComputed();
-        repository.storePrompt(hashed);
+        persistRespectingDraftInvariant(hashed);
         return hashed;
     }
 
@@ -554,6 +554,19 @@ class DefaultPromptLifecycleService implements PromptLifecycleService {
 
     private PromptSpec increaseRevision(PromptSpec promptSpec) {
         return promptSpec.withRevision(promptSpec.getRevision() + 1);
+    }
+
+    /**
+     * Route the spec to {@code storePrompt} (commit + push) when a response
+     * is present, or to {@code storePromptDraft} (disk only) when it is not.
+     * Codifies the invariant from issue #352: a prompt without a response
+     * has no business on the remote.
+     */
+    private PromptSpec persistRespectingDraftInvariant(PromptSpec promptSpec) {
+        if (promptSpec.getResponse() != null) {
+            return repository.storePrompt(promptSpec);
+        }
+        return repository.storePromptDraft(promptSpec);
     }
 
     private List<ChatCompletionRequest.Message> extractMessages(PromptSpec promptSpec) {

--- a/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/PromptStorePort.java
+++ b/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/PromptStorePort.java
@@ -30,6 +30,15 @@ public interface PromptStorePort {
 
     PromptSpec storePrompt(PromptSpec promptSpec);
 
+    /**
+     * Persist a draft (no response attached) — local only, no remote push.
+     * See issue #352. Default delegates to {@link #storePrompt(PromptSpec)}
+     * for ports that have no remote concept.
+     */
+    default PromptSpec storePromptDraft(PromptSpec promptSpec) {
+        return storePrompt(promptSpec);
+    }
+
     Optional<PromptSpec> getLatestVersion(String promptSpecId);
 
     PromptSpec requestRelease(PromptSpec promptSpec);

--- a/components/promptlm-lifecycle/src/test/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleServiceTest.java
+++ b/components/promptlm-lifecycle/src/test/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleServiceTest.java
@@ -131,7 +131,8 @@ class DefaultPromptLifecycleServiceTest {
         when(repository.findPromptSpec(GROUP, NAME)).thenReturn(Optional.empty());
         when(repository.findPromptSpecTemplate(GROUP)).thenReturn("template");
         when(template.render(eq("template"), eq(GROUP), eq(NAME), any(), any(), any())).thenReturn(rendered);
-        when(repository.storePrompt(withId)).thenReturn(withId);
+        // No response on the rendered spec → draft persistence path (#352).
+        when(repository.storePromptDraft(withId)).thenReturn(withId);
 
         PromptSpec result = service.createPrompt(GROUP, Map.of(), NAME, List.of(), new PromptSpec.Placeholders(), Map.of());
 
@@ -174,14 +175,15 @@ class DefaultPromptLifecycleServiceTest {
 
         when(repository.findPromptSpec(GROUP, NAME)).thenReturn(Optional.empty());
         when(idGenerator.generateId(eq(GROUP), eq(NAME), any())).thenReturn(PROMPT_ID);
-        when(repository.storePrompt(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        // No response on the input spec → draft persistence path (#352).
+        when(repository.storePromptDraft(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         service.createPromptSpec(mixedCase);
 
         ArgumentCaptor<PromptSpec> storedCaptor = ArgumentCaptor.forClass(PromptSpec.class);
         verify(repository).findPromptSpec(GROUP, NAME);
         verify(idGenerator).generateId(eq(GROUP), eq(NAME), any());
-        verify(repository).storePrompt(storedCaptor.capture());
+        verify(repository).storePromptDraft(storedCaptor.capture());
 
         PromptSpec stored = storedCaptor.getValue();
         assertThat(stored.getGroup()).isEqualTo(GROUP);
@@ -232,7 +234,8 @@ class DefaultPromptLifecycleServiceTest {
         assertThat(updating.hasSemanticChangesComparedTo(existing)).isTrue();
 
         when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(existing));
-        when(repository.storePrompt(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        // No response on either spec → draft persistence path (#352).
+        when(repository.storePromptDraft(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         PromptSpec result = service.updatePrompt(PROMPT_ID, updating);
 
@@ -242,7 +245,7 @@ class DefaultPromptLifecycleServiceTest {
         assertThat(result.getRevision()).isEqualTo(4);
 
         verify(repository).getLatestVersion(PROMPT_ID);
-        verify(repository).storePrompt(result);
+        verify(repository).storePromptDraft(result);
     }
 
     @Test
@@ -298,14 +301,15 @@ class DefaultPromptLifecycleServiceTest {
                 .withDescription("new-desc");
 
         when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(existing));
-        when(repository.storePrompt(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        // No response on either spec → draft persistence path (#352).
+        when(repository.storePromptDraft(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         PromptSpec result = service.updatePrompt(PROMPT_ID, updating);
 
         assertThat(result.getExtensions()).containsEntry("x-legacy", extensionNode);
 
         verify(repository).getLatestVersion(PROMPT_ID);
-        verify(repository).storePrompt(result);
+        verify(repository).storePromptDraft(result);
     }
 
     @Test
@@ -322,7 +326,8 @@ class DefaultPromptLifecycleServiceTest {
                 .withExtensions(Map.of("x-new", newNode));
 
         when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(existing));
-        when(repository.storePrompt(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        // No response on either spec → draft persistence path (#352).
+        when(repository.storePromptDraft(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         PromptSpec result = service.updatePrompt(PROMPT_ID, updating);
 
@@ -331,7 +336,7 @@ class DefaultPromptLifecycleServiceTest {
                 .containsEntry("x-new", newNode);
 
         verify(repository).getLatestVersion(PROMPT_ID);
-        verify(repository).storePrompt(result);
+        verify(repository).storePromptDraft(result);
     }
 
     @Test
@@ -1152,7 +1157,8 @@ class DefaultPromptLifecycleServiceTest {
         assertThat(updating.hasSemanticChangesComparedTo(existing)).isTrue();
 
         when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(existing));
-        when(repository.storePrompt(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        // No response on either spec → draft persistence path (#352).
+        when(repository.storePromptDraft(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         PromptSpec result = service.updatePrompt(PROMPT_ID, updating);
 
@@ -1171,7 +1177,8 @@ class DefaultPromptLifecycleServiceTest {
         PromptSpec updating = existing.withDescription("new-desc");
 
         when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(existing));
-        when(repository.storePrompt(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        // No response on either spec → draft persistence path (#352).
+        when(repository.storePromptDraft(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         PromptSpec result = service.updatePrompt(PROMPT_ID, updating);
 
@@ -1229,6 +1236,65 @@ class DefaultPromptLifecycleServiceTest {
         assertThat(result.getExecutions())
                 .extracting(Execution::getId)
                 .containsExactly("exec-2", "exec-3", "exec-4", "exec-5", "exec-newest");
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #352: persistence routing must respect the "no response → draft"
+    // invariant. A prompt with a response routes through storePrompt (commit
+    // + push); one without routes through storePromptDraft (disk only).
+    // ---------------------------------------------------------------------
+
+    @Test
+    void createPromptSpecRoutesToDraftStoreWhenResponseIsNull() {
+        PromptSpec draft = basePromptSpec.withId(PROMPT_ID).withResponse(null);
+        when(repository.findPromptSpec(GROUP, NAME)).thenReturn(Optional.empty());
+        when(repository.storePromptDraft(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.createPromptSpec(draft);
+
+        verify(repository).storePromptDraft(any(PromptSpec.class));
+        verify(repository, org.mockito.Mockito.never()).storePrompt(any(PromptSpec.class));
+    }
+
+    @Test
+    void createPromptSpecRoutesToStoreWhenResponseIsPresent() {
+        PromptSpec withResponse = basePromptSpec
+                .withId(PROMPT_ID)
+                .withResponse(new ChatCompletionResponse(7L, null, "preset"));
+        when(repository.findPromptSpec(GROUP, NAME)).thenReturn(Optional.empty());
+        when(repository.storePrompt(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.createPromptSpec(withResponse);
+
+        verify(repository).storePrompt(any(PromptSpec.class));
+        verify(repository, org.mockito.Mockito.never()).storePromptDraft(any(PromptSpec.class));
+    }
+
+    @Test
+    void updatePromptRoutesToDraftStoreWhenResponseIsNull() {
+        PromptSpec existing = basePromptSpec.withRevision(3);
+        PromptSpec updating = existing.withDescription("new-desc");
+        when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(existing));
+        when(repository.storePromptDraft(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.updatePrompt(PROMPT_ID, updating);
+
+        verify(repository).storePromptDraft(any(PromptSpec.class));
+        verify(repository, org.mockito.Mockito.never()).storePrompt(any(PromptSpec.class));
+    }
+
+    @Test
+    void updatePromptRoutesToStoreWhenResponseIsPresent() {
+        ChatCompletionResponse response = new ChatCompletionResponse(7L, null, "live");
+        PromptSpec existing = basePromptSpec.withRevision(3);
+        PromptSpec updating = existing.withResponse(response);
+        when(repository.getLatestVersion(PROMPT_ID)).thenReturn(Optional.of(existing));
+        when(repository.storePrompt(any(PromptSpec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.updatePrompt(PROMPT_ID, updating);
+
+        verify(repository).storePrompt(any(PromptSpec.class));
+        verify(repository, org.mockito.Mockito.never()).storePromptDraft(any(PromptSpec.class));
     }
 
     @Test

--- a/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/PromptStore.java
+++ b/components/promptlm-store/promptlm-store-api/src/main/java/dev/promptlm/store/api/PromptStore.java
@@ -35,6 +35,24 @@ public interface PromptStore {
     PromptSpec storePrompt(PromptSpec promptSpec);
 
     /**
+     * Persist the prompt specification locally without committing or pushing
+     * to the remote repository. Used for drafts that have no response attached
+     * yet (issue #352): a prompt only earns a remote-visible artifact once a
+     * response has been recorded against it.
+     *
+     * <p>The default implementation delegates to {@link #storePrompt(PromptSpec)}
+     * for backends that have no remote concept (in-memory, test fakes); the
+     * remote-backed {@code GitHubPromptStore} overrides this to do the
+     * disk-write only.
+     *
+     * @param promptSpec The draft prompt specification to persist locally.
+     * @return The persisted prompt specification.
+     */
+    default PromptSpec storePromptDraft(PromptSpec promptSpec) {
+        return storePrompt(promptSpec);
+    }
+
+    /**
      * Retrieves the latest version of a prompt specification by ID.
      *
      * @param promptId The unique identifier of the prompt.

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubPromptStore.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubPromptStore.java
@@ -136,11 +136,37 @@ public class GitHubPromptStore implements PromptStore {
         return storePrompt(promptSpec, commitMessage, true);
     }
 
+    /**
+     * Persist a draft (no response) to disk only — no commit, no push.
+     * See issue #352. The remote-visible artifact appears once a response
+     * is attached and {@link #storePrompt(PromptSpec)} is called.
+     */
+    @Override
+    public PromptSpec storePromptDraft(PromptSpec promptSpec) {
+        File repo = appContext.getActiveProject().getRepoDir().toFile();
+        // Keep the working tree on the development branch so a follow-up
+        // storePrompt() (after a response lands) commits onto the correct ref.
+        switchToDevelopmentBranch(repo);
+        return persistToDisk(promptSpec, repo);
+    }
+
     private PromptSpec storePrompt(PromptSpec promptSpec, String commitMessage, boolean ensureDevelopmentBranch) {
         File repo = appContext.getActiveProject().getRepoDir().toFile();
         if (ensureDevelopmentBranch) {
             switchToDevelopmentBranch(repo);
         }
+        PromptSpec finalPromptSpec = persistToDisk(promptSpec, repo);
+        git.addAllAndCommit(repo, commitMessage);
+        git.pushAll(repo);
+        return finalPromptSpec;
+    }
+
+    /**
+     * Compute hash / timestamps / path and write the YAML to disk. Pure
+     * filesystem mutation — no git interaction. Shared by both the full
+     * {@code storePrompt(...)} path and the draft path.
+     */
+    private PromptSpec persistToDisk(PromptSpec promptSpec, File repo) {
         PromptSpec hashUpdatedPrompt = promptSpec.withSemanticHashComputed();
 
         Path relativePath = resolvePromptSpecRelativePath(repo.toPath(), hashUpdatedPrompt.getGroup(), hashUpdatedPrompt.getName());
@@ -165,8 +191,6 @@ public class GitHubPromptStore implements PromptStore {
         }
 
         saveToDisk(finalPromptSpec);
-        git.addAllAndCommit(repo, commitMessage);
-        git.pushAll(repo);
         return finalPromptSpec;
     }
 

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/PromptStoreAdapter.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/PromptStoreAdapter.java
@@ -48,6 +48,11 @@ class PromptStoreAdapter implements PromptStorePort {
     }
 
     @Override
+    public PromptSpec storePromptDraft(PromptSpec promptSpec) {
+        return promptStore.storePromptDraft(promptSpec);
+    }
+
+    @Override
     public Optional<PromptSpec> getLatestVersion(String promptSpecId) {
         return promptStore.getLatestVersion(promptSpecId);
     }


### PR DESCRIPTION
## Summary

Closes #352 (blocker). Enforces the invariant: **a prompt is only pushed to the remote git repo once it carries a response.** Save without a response now persists locally as a draft — no commit, no push.

Scope is backend only. UI changes (auto-execute on Save) are tracked separately in #360; cross-link with #310.

## Changes

- **`PromptStore` / `PromptStorePort`**: new `storePromptDraft(spec)` method with `default` that delegates to `storePrompt` for in-memory implementations.
- **`GitHubPromptStore`**: extracts a private `persistToDisk` helper. `storePrompt` still commits + pushes; `storePromptDraft` only writes to disk.
- **`DefaultPromptLifecycleService.{createPromptSpec, updatePrompt}`**: route to `storePrompt` when `spec.getResponse() != null`, otherwise `storePromptDraft`.
- **`DefaultPromptLifecycleServiceTest`**: 7 existing cases updated (their input specs have no response → now expect draft routing) + 4 new routing-direction tests added.
- **`SaveWithoutResponseContractTest`** (new acceptance test, `@WithGitea`): pins the negative invariant — POST `/api/prompts` without execution → remote file does not appear within 5s. Spec retrievable locally via GET.

## What's NOT in this PR (intentional)

- **Acceptance test for the positive direction** (response attached → push). The only public-REST path to attach a response is `POST /execute`, which couples to `OPENAI_API_KEY`. The positive direction is covered deterministically at the unit level in `DefaultPromptLifecycleServiceTest`. Explained in the test class javadoc.
- **UI work**: triggering execution on Save, surfacing the local-vs-pushed state. See #360.
- **Red-then-green discipline**: unit tests pin the routing both directions; the acceptance test was authored to fail against pre-fix code (the unconditional push would always make the file appear within seconds), but I did not script a separate red commit. Reviewer can verify by reverting the lifecycle-service change locally.

## Test plan

- [ ] CI green on `acceptance-tests` (`SaveWithoutResponseContractTest`).
- [ ] CI green on `promptlm-lifecycle`, `promptlm-store-github`, `promptlm-web-api` unit tests.
- [ ] Manual: create a prompt in the studio without running it → confirm the Gitea/GitHub repo has no commit for it. Run the prompt → commit appears.
- [ ] Cross-check with #310 after merging — the symptom there (Run after Save returns empty) is upstream of this fix and will need the UI work in #360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)