### PR TITLE
docs(#205): author Prompt specs page (PromptSpec YAML reference)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,11 +5,11 @@ brand-styled HTML pages under `site/docs/` by
 [`scripts/build-docs.mjs`](../scripts/build-docs.mjs). The output is part
 of the static GitHub Pages site served from `site/`.
 
-> **Status:** seven pages are live and verified against the codebase —
+> **Status:** eight pages are live and verified against the codebase —
 > the Get Started flow (Introduction, Install, Your first prompt,
-> Studio, Configuration), CLI reference, and Lifecycle states. The
-> remaining sidebar items (Prompt specs, Releases, Evaluations, the
-> three client SDKs, macOS, JUnit support, LLM providers, REST API,
+> Studio, Configuration), CLI reference, Lifecycle states, and Prompt
+> specs. The remaining sidebar items (Releases, Evaluations, the three
+> client SDKs, macOS, JUnit support, LLM providers, REST API,
 > PromptSpec schema, Config schema) are real product surfaces but
 > haven't been authored yet — they show as greyed placeholders.
 > Tracking issue: [#205](https://github.com/promptLM/promptlm-app/issues/205).

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -25,7 +25,7 @@ groups:
   - heading: CORE
     items:
       - { label: "Lifecycle states",   slug: "lifecycle" }
-      - { label: "Prompt specs" }
+      - { label: "Prompt specs",       slug: "prompt-specs" }
       - { label: "Releases" }
       - { label: "Evaluations" }
 

--- a/docs/pages/core/lifecycle.adoc
+++ b/docs/pages/core/lifecycle.adoc
@@ -4,8 +4,8 @@
 :page-description: The four states a PromptSpec moves through, from in-flight edit to remote-pushed.
 :page-prev-label: Configuration
 :page-prev-href: configuration.html
-:page-next-label: CLI
-:page-next-href: cli.html
+:page-next-label: Prompt specs
+:page-next-href: prompt-specs.html
 
 Every `PromptSpec` carries one of four lifecycle states. The state is
 a function of where the spec's content lives along the persistence

--- a/docs/pages/core/prompt-specs.adoc
+++ b/docs/pages/core/prompt-specs.adoc
@@ -1,0 +1,186 @@
+= Prompt specs
+:page-slug: prompt-specs
+:page-section: CORE
+:page-description: The PromptSpec YAML model — fields, request types, placeholders, and extensions.
+:page-prev-label: Lifecycle states
+:page-prev-href: lifecycle.html
+:page-next-label: CLI
+:page-next-href: cli.html
+
+A `PromptSpec` is the on-disk representation of a single prompt — one
+YAML file persisted in the prompt store. Every prompt the CLI, Studio,
+REST API, and client SDKs work with is one of these specs.
+// source: components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/PromptSpec.java:42
+
+The Java type is `dev.promptlm.domain.promptspec.PromptSpec`. This page
+documents the fields end-users actually author or read; the Builder
+APIs are an implementation detail of the domain module.
+
+== Where they live
+
+Each spec is serialised as YAML on disk under the active repository's
+working tree. The `path` field of the spec captures the relative
+filesystem path within the repo, e.g. `prompts/support/welcome.yaml`.
+// source: PromptSpec.java:153-156
+
+== Fields
+
+[cols="1,1,3"]
+|===
+| Field | Type | Purpose
+
+| `specVersion`    | string                                          | Format version of the spec schema. Stamped by the writer.
+| `uuid`           | UUID                                            | Stable identity of the prompt, independent of name or group.
+| `id`             | string (required)                               | Human-facing identifier. Example: `support_welcome`.
+| `name`           | string (required)                               | Prompt name. Pattern: `^[a-zA-Z0-9\-_]+$` — alphanumerics, dash, underscore only.
+| `group`          | string (required)                               | Logical grouping of related prompts. Same pattern as `name`. Defaults to `default` when not set.
+| `version`        | string                                          | Semantic version of the prompt, e.g. `1.0.0`.
+| `revision`       | integer                                         | Revision counter inside a draft. Defaults to `0` when null.
+| `description`    | string                                          | Human-readable description.
+| `authors`        | list&lt;string&gt;                              | Author identifiers.
+| `purpose`        | string                                          | Business intent of the prompt.
+| `repositoryUrl`  | string                                          | Source repository URL for this prompt.
+| `status`         | enum `ACTIVE` &#124; `RETIRED`                  | Publication status. Defaults to `ACTIVE`.
+| `createdAt`      | timestamp                                       | When the spec was first persisted.
+| `updatedAt`      | timestamp                                       | Last write timestamp.
+| `retiredAt`      | timestamp                                       | When the spec was retired (`null` if `ACTIVE`).
+| `retiredReason`  | string                                          | Optional explanation for retirement.
+| `request`        | xref:prompt-specs.html#_request_types[Request]  | LLM invocation payload — chat, image, or audio.
+| `placeholders`   | xref:prompt-specs.html#_placeholders[Placeholders] | Placeholder metadata and default values.
+| `response`       | Response                                        | Most recent captured response from execution.
+| `extensions`     | map&lt;string, json&gt;                         | Custom payloads keyed by `x-*`. See below.
+| `path`           | string                                          | Filesystem path of the spec within the repo.
+| `executions`     | list&lt;Execution&gt;                           | Recent executions of the prompt.
+| `semanticHash`   | string                                          | SHA-256 over the semantic prompt fields — stable across non-meaningful edits.
+|===
+// source: PromptSpec.java:47-163,484-492
+
+[NOTE]
+====
+`status` defaults to `ACTIVE` when omitted — you don't need to set it
+on every spec. To retire a prompt, set `status: RETIRED` along with
+`retiredAt` and (optionally) `retiredReason`.
+// source: PromptSpec.java:280, isRetired() at PromptSpec.java:662-666
+====
+
+== Request types
+
+The `request` field is polymorphic — Jackson picks a concrete type from
+the `type` discriminator inside the YAML.
+// source: components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/Request.java:26-30
+
+[cols="1,2"]
+|===
+| `type` | Concrete class
+
+| `chat/completion`     | `ChatCompletionRequest`
+| `images/generations`  | `ImagesGenerationsRequest`
+| `audio/speech`        | `AudioSpeechRequest`
+|===
+// source: ChatCompletionRequest.java:30,32; ImagesGenerationsRequest.java:29; AudioSpeechRequest.java:29
+
+When the YAML is written using Jackson's `!<>` tag syntax, the type
+appears as a YAML tag on the `request:` node — for example
+`request: !<chat/completion>`. Both forms round-trip through the
+deserializer.
+
+== Placeholders
+
+`placeholders` declares the template variables a prompt expects.
+
+[cols="1,3"]
+|===
+| Field | Purpose
+
+| `startPattern` | Opening delimiter for placeholders in the prompt body (e.g. `{`).
+| `endPattern`   | Closing delimiter (e.g. `}`).
+| `list`         | Ordered list of `{ name, value }` entries — `value` is the default.
+|===
+// source: PromptSpec.java:1030-1095,1146-1219
+
+`getDefaults()` returns the placeholder name → default map, and rejects
+duplicate names with `IllegalStateException("Duplicate placeholder
+name: …")`. Keep each placeholder unique per spec.
+// source: PromptSpec.java:1041-1064
+
+== Extensions (`x-*`)
+
+The `extensions` map carries arbitrary JSON payloads keyed by names
+that must start with `x-`. This is how evaluation specs, evaluation
+results, and release metadata are attached to a prompt without
+expanding the core schema.
+// source: PromptSpec.java:148-151,683-685
+
+[IMPORTANT]
+====
+Extension keys *must* start with `x-`. Any other key passed in is
+rejected with `IllegalArgumentException("Extension keys must start
+with 'x-': <key>")`.
+// source: PromptSpec.java:668-685
+====
+
+Two extension keys are managed by the core today:
+
+* `x-evaluation` — evaluation spec and results, see `EvaluationExtensions`.
+* `x-release` — release metadata attached when a prompt is released,
+  see `ReleaseExtensions`.
+// source: PromptSpec.java:429-442,562-575
+
+Legacy specs with top-level `evaluationSpec` / `evaluationResults`
+fields are migrated into `x-evaluation` at deserialisation time, so
+older files still load — but newly written specs use the extension
+form.
+// source: PromptSpec.java:687-713
+
+== Example
+
+A minimal chat-completion spec as it appears on disk:
+
+[source,yaml]
+----
+specVersion: null
+uuid: 8d5b6a30-9b3e-4f4c-9b8b-1f3d2a1e5c4f
+id: support_welcome
+name: support_welcome
+group: support
+version: 1.0
+revision: 1
+description: Sample Chat
+authors:
+- fabapp2
+purpose: Test
+repositoryUrl: some-store
+status: ACTIVE
+request: !<chat/completion>
+  vendor: OpenAI
+  model: gpt-3.5-turbo
+  url: https://openai.url
+  messages:
+  - content: You are a happy assistant.
+    role: system
+  - content: How are you?
+    role: user
+placeholders: null
+response: !<chat/completion>
+  content: |
+    I'm happy.
+extensions:
+  x-evaluation:
+    spec:
+      evaluations: []
+    results:
+      evaluations: []
+      status: NOT_CONFIGURED
+path: support/support_welcome.yaml
+----
+// source: components/promptlm-domain/src/test/java/dev/promptlm/domain/promptspec/ChatRequestPromptDeSerializationTests.java:42-83
+
+== Equality and the semantic hash
+
+Two specs compare equal when their `name`, `group`, `version`, and
+`revision` match — that's the identity tuple at the persistence layer.
+For change detection across edits, use `semanticHash`: a SHA-256
+fingerprint of the semantic fields. `hasSemanticChangesComparedTo()`
+returns true when two specs differ in any of those fields, regardless
+of whether timestamps or hashes were rewritten.
+// source: PromptSpec.java:471-481,617-635

--- a/docs/pages/reference/cli.adoc
+++ b/docs/pages/reference/cli.adoc
@@ -2,8 +2,8 @@
 :page-slug: cli
 :page-section: REFERENCE
 :page-description: All promptlm-cli commands and flags, verified against the source.
-:page-prev-label: Lifecycle states
-:page-prev-href: lifecycle.html
+:page-prev-label: Prompt specs
+:page-prev-href: prompt-specs.html
 
 Every command, flag, and default below is taken directly from the
 picocli `@Command` / `@Option` annotations in the CLI module under


### PR DESCRIPTION
## Summary

- New `docs/pages/core/prompt-specs.adoc` documenting the `PromptSpec` YAML model — field reference, `chat/completion` / `images/generations` / `audio/speech` request discriminators, placeholders, `x-*` extensions (`x-evaluation`, `x-release`), equality tuple, and `semanticHash`. Every concrete claim carries a `// source:` citation pointing at `components/promptlm-domain/.../PromptSpec.java` (and friends) so a reviewer can audit the page against code.
- Wired the page into the sidebar: `nav.yml` Prompt specs entry gets `slug: prompt-specs`, so it stops rendering as a greyed placeholder.
- Updated the prev/next chain: Lifecycle → **Prompt specs** → CLI.
- Bumped the status note in `docs/README.md` from seven to eight published pages.

Part of #205.

## Test plan

- [x] `npm run docs:build` — clean, 8 pages rendered, including `site/docs/prompt-specs.html`.
- [x] Locally verified the rendered page in the brand chrome (sidebar entry active, "On this page" rail populated, prev/next links wired).
- [x] Cross-checked field types, request discriminator strings, placeholder error message, and extension key validation against `PromptSpec.java`, `Request.java`, and the de-serialization test fixtures cited in-page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)