### PR TITLE
docs(#205): author the remaining 0.1.0 pages — every nav item now real

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,16 +5,13 @@ brand-styled HTML pages under `site/docs/` by
 [`scripts/build-docs.mjs`](../scripts/build-docs.mjs). The output is part
 of the static GitHub Pages site served from `site/`.
 
-> **Status:** eight pages are live and verified against the codebase —
-> the Get Started flow (Introduction, Install, Your first prompt,
-> Studio, Configuration), CLI reference, Lifecycle states, and Prompt
-> specs. The remaining sidebar items (Releases, the three client SDKs,
-> macOS, LLM providers, REST API, PromptSpec schema, Config schema)
-> are real product surfaces but haven't been authored yet — they show
-> as greyed placeholders. Evaluations and JUnit test support are out
-> of scope for 0.1.0 and have been dropped from the nav.
-> Tracking issue: [#205](https://github.com/promptLM/promptlm-app/issues/205).
-> Please claim a section there before authoring.
+> **Status:** every item in the sidebar resolves to an authored,
+> code-verified page — sixteen in total across Get Started, Core,
+> Clients, Integrations, and Reference. Evaluations, JUnit test
+> support, and a standalone PromptSpec schema page are out of scope
+> for 0.1.0 and have been dropped from the nav (PromptSpec is fully
+> covered by Prompt specs). Tracking issue:
+> [#205](https://github.com/promptLM/promptlm-app/issues/205).
 
 ## Layout
 

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -3,16 +3,14 @@
 # Each `items[].slug` is the basename of an .adoc file under
 # docs/pages/<group-dir>/<slug>.adoc, rendered to site/docs/<slug>.html.
 #
-# Items WITHOUT a slug are placeholders — real product surfaces that
-# exist but where a faithful page is too large for first ship, or
-# where the API isn't stable enough to document yet. They render as
-# non-link greyed text. Tracking issue: #205.
+# Every visible item now resolves to an authored page. Tracking issue: #205.
 #
 # Items removed from the original design-mock structure (no backing
 # code in the repo, or out of scope for 0.1.0): Test suites, Fixtures,
 # Mocking models, MCP record & replay, Vitest / Jest, OpenTelemetry,
 # OpenAI-compat (as an exposed endpoint), Adapter API, Evaluations,
-# JUnit (Gitea + Artifactory) test support.
+# JUnit (Gitea + Artifactory) test support, PromptSpec schema (fully
+# covered by Prompt specs).
 
 groups:
   - heading: GET STARTED
@@ -27,22 +25,21 @@ groups:
     items:
       - { label: "Lifecycle states",   slug: "lifecycle" }
       - { label: "Prompt specs",       slug: "prompt-specs" }
-      - { label: "Releases" }
+      - { label: "Releases",           slug: "releases" }
 
   - heading: CLIENTS
     items:
-      - { label: "Java SDK" }
-      - { label: "TypeScript SDK" }
-      - { label: "Python SDK" }
-      - { label: "macOS menubar" }
+      - { label: "Java SDK",           slug: "java-sdk" }
+      - { label: "TypeScript SDK",     slug: "typescript-sdk" }
+      - { label: "Python SDK",         slug: "python-sdk" }
+      - { label: "macOS menubar",      slug: "macos-menubar" }
 
   - heading: INTEGRATIONS
     items:
-      - { label: "LLM providers" }
+      - { label: "LLM providers",      slug: "llm-providers" }
 
   - heading: REFERENCE
     items:
       - { label: "CLI",                slug: "cli" }
-      - { label: "REST API" }
-      - { label: "PromptSpec schema" }
-      - { label: "Config schema" }
+      - { label: "REST API",           slug: "rest-api" }
+      - { label: "Config schema",      slug: "config-schema" }

--- a/docs/pages/clients/java-sdk.adoc
+++ b/docs/pages/clients/java-sdk.adoc
@@ -1,0 +1,70 @@
+= Java SDK
+:page-slug: java-sdk
+:page-section: CLIENTS
+:page-description: Load and resolve released promptLM prompt bundles from your JVM application.
+:page-prev-label: Releases
+:page-prev-href: releases.html
+:page-next-label: TypeScript SDK
+:page-next-href: typescript-sdk.html
+
+The Java SDK loads prompt bundles packaged on the JVM classpath via a
+small, dependency-light API. It's maintained in the
+https://github.com/promptLM/promptlm-clients[promptLM/promptlm-clients]
+repository under `client-sdk-java/`.
+// source: promptLM/promptlm-clients README.md
+
+Requires JDK 17+.
+// source: promptLM/promptlm-clients/client-sdk-java/README.md
+
+== Install
+
+[source,xml]
+----
+<dependency>
+    <groupId>dev.promptlm</groupId>
+    <artifactId>promptlm-client</artifactId>
+    <version>0.1.0</version>
+</dependency>
+----
+// source: promptLM/promptlm-clients/client-sdk-java/README.md
+
+Gradle (Kotlin DSL):
+
+[source,kotlin]
+----
+dependencies {
+    implementation("dev.promptlm:promptlm-client:0.1.0")
+}
+----
+// source: promptLM/promptlm-clients/client-sdk-java/README.md
+
+== Usage
+
+Drop a `prompts/prompt-index.json` (plus the prompt YAML files it
+references) anywhere on the classpath — typically under
+`src/main/resources` — and resolve a prompt by id:
+
+[source,java]
+----
+import dev.promptlm.client.ClasspathPromptLoader;
+import dev.promptlm.client.Prompt;
+import dev.promptlm.client.PromptLoader;
+
+PromptLoader loader = new ClasspathPromptLoader();
+Prompt prompt = loader.loadPrompt("greeting.v1");
+System.out.println(prompt.getName());
+System.out.println(prompt.getPrompt());
+----
+// source: promptLM/promptlm-clients/client-sdk-java/README.md
+
+The loader scans every classpath entry once on first use, builds an
+in-memory index, and rejects duplicate prompt ids across bundles.
+// source: promptLM/promptlm-clients/client-sdk-java/README.md
+
+== Runtime bundles
+
+The bundle format consumed by the SDK is produced by the bundle-release
+workflow described in
+xref:releases.html#_bundle_release_vs_prompt_release[Releases]. It
+packages the store's prompts as a Maven jar containing
+`prompts/prompt-index.json` and the referenced prompt files.

--- a/docs/pages/clients/macos-menubar.adoc
+++ b/docs/pages/clients/macos-menubar.adoc
@@ -1,0 +1,66 @@
+= macOS menubar
+:page-slug: macos-menubar
+:page-section: CLIENTS
+:page-description: Native macOS menubar app that inserts promptLM prompts at the cursor via a global hotkey.
+:page-prev-label: Python SDK
+:page-prev-href: python-sdk.html
+:page-next-label: LLM providers
+:page-next-href: llm-providers.html
+
+The macOS menubar client is a native Swift app maintained in
+https://github.com/promptLM/promptlm-macos[promptLM/promptlm-macos]. It
+lives in the menu bar, opens a Spotlight-style picker via a global
+shortcut, and inserts rendered prompts at the cursor.
+// source: promptLM/promptlm-macos README.md
+
+[NOTE]
+====
+The macOS client is in early scaffold for the 0.1.0 release. The menu
+bar icon is in place; picker, hotkey, repository loading, render and
+paste are tracked in the repo's issues.
+// source: promptLM/promptlm-macos README.md
+====
+
+== Requirements
+
+* macOS 13 (Ventura) or later
+* Xcode 15+ / Swift 5.9+ for development
+// source: promptLM/promptlm-macos README.md — "Requirements"
+
+== Install
+
+[source,bash]
+----
+git clone https://github.com/promptLM/promptlm-macos.git
+cd promptlm-macos
+./install.sh             # build, wrap into .app, install to ~/Applications
+./install.sh --launch    # also start the app
+./install.sh --system    # install to /Applications (uses sudo)
+./install.sh --uninstall # remove the installed bundle
+----
+// source: promptLM/promptlm-macos README.md — install.sh options
+
+After install, a chat-bubble icon appears in the menu bar. The default
+global hotkey is *⌃⌥⌘P*.
+// source: promptLM/promptlm-macos README.md
+
+== Settings
+
+Open via the menu bar icon → *Settings…* (⌘,):
+
+* *Prompt repository* — folder the app scans for `*.yaml`, `*.yml`,
+  `*.json` prompt specs. Defaults to `~/.promptlm/prompts`.
+* *Global hotkey* — click *Record*, press your combo (must include ⌘,
+  ⌥, or ⌃). ⎋ cancels.
+* *Launch at login* — uses `SMAppService` (macOS 13+).
+// source: promptLM/promptlm-macos README.md — "Settings"
+
+== Selecting a prompt
+
+* Prompts with *no placeholders* — text is pasted at the cursor.
+* Prompts *with placeholders* — a form opens with a field per
+  placeholder (defaults pre-filled, required fields marked `*`); on
+  submit the rendered text is pasted at the cursor.
+
+The original clipboard contents are restored ~400 ms after the paste.
+// source: promptLM/promptlm-macos README.md — "Seeding prompts"

--- a/docs/pages/clients/python-sdk.adoc
+++ b/docs/pages/clients/python-sdk.adoc
@@ -1,0 +1,48 @@
+= Python SDK
+:page-slug: python-sdk
+:page-section: CLIENTS
+:page-description: Load promptLM JSON prompt bundles from Python applications.
+:page-prev-label: TypeScript SDK
+:page-prev-href: typescript-sdk.html
+:page-next-label: macOS menubar
+:page-next-href: macos-menubar.html
+
+The Python SDK exposes a minimal prompt model and loads
+`prompts/prompt-index.json` plus per-prompt JSON files from either a
+filesystem bundle or packaged resources. It's published as
+`promptlm-client` on PyPI and maintained in
+https://github.com/promptLM/promptlm-clients[promptLM/promptlm-clients]
+under `client-sdk-python/`.
+// source: promptLM/promptlm-clients/client-sdk-python/pyproject.toml — "name": "promptlm-client", "version": "0.1.0"
+// source: promptLM/promptlm-clients/client-sdk-python/README.md
+
+Requires Python 3.10+.
+// source: promptLM/promptlm-clients/client-sdk-python/pyproject.toml — requires-python = ">=3.10"
+
+[NOTE]
+====
+The Python SDK is work in progress for the 0.1.0 release. Track status
+in the
+https://github.com/promptLM/promptlm-clients[promptLM/promptlm-clients]
+repository.
+// source: promptLM/promptlm-clients README.md — "Python ... Work in progress"
+====
+
+== Install
+
+[source,bash]
+----
+pip install promptlm-client==0.1.0
+----
+// source: promptLM/promptlm-clients/client-sdk-python/pyproject.toml
+
+== Runtime contract
+
+The SDK consumes the same JSON bundle the
+xref:java-sdk.html[Java SDK] does: `prompts/prompt-index.json` plus
+the per-prompt files it references. See
+xref:java-sdk.html#_runtime_bundles[Runtime bundles] for how that
+bundle is produced.
+
+For current API shape and usage examples, refer to the SDK's source
+README at https://github.com/promptLM/promptlm-clients/tree/main/client-sdk-python.

--- a/docs/pages/clients/typescript-sdk.adoc
+++ b/docs/pages/clients/typescript-sdk.adoc
@@ -1,0 +1,46 @@
+= TypeScript SDK
+:page-slug: typescript-sdk
+:page-section: CLIENTS
+:page-description: Load promptLM JSON prompt bundles from Node and TypeScript applications.
+:page-prev-label: Java SDK
+:page-prev-href: java-sdk.html
+:page-next-label: Python SDK
+:page-next-href: python-sdk.html
+
+The TypeScript SDK loads promptLM JSON prompt bundles. It's published
+as `@promptlm/client` and maintained in
+https://github.com/promptLM/promptlm-clients[promptLM/promptlm-clients]
+under `client-sdk-ts/`.
+// source: promptLM/promptlm-clients/client-sdk-ts/package.json — "name": "@promptlm/client", "version": "0.1.0"
+
+[NOTE]
+====
+The TypeScript SDK is work in progress for the 0.1.0 release. Track
+status in the
+https://github.com/promptLM/promptlm-clients[promptLM/promptlm-clients]
+repository.
+// source: promptLM/promptlm-clients README.md — "TypeScript ... Work in progress"
+====
+
+== Install
+
+[source,bash]
+----
+npm install @promptlm/client@0.1.0
+----
+// source: promptLM/promptlm-clients/client-sdk-ts/package.json
+
+The package ships ESM (`./dist/index.js`) and CJS (`./dist/index.cjs`)
+builds plus type declarations.
+// source: promptLM/promptlm-clients/client-sdk-ts/package.json
+
+== Runtime contract
+
+The SDK consumes the same JSON bundle the
+xref:java-sdk.html[Java SDK] does: `prompts/prompt-index.json` plus the
+per-prompt files it references. See
+xref:java-sdk.html#_runtime_bundles[Runtime bundles] for how that
+bundle is produced.
+
+For current API shape and usage examples, refer to the SDK's source
+README at https://github.com/promptLM/promptlm-clients/tree/main/client-sdk-ts.

--- a/docs/pages/core/prompt-specs.adoc
+++ b/docs/pages/core/prompt-specs.adoc
@@ -4,8 +4,8 @@
 :page-description: The PromptSpec YAML model — fields, request types, placeholders, and extensions.
 :page-prev-label: Lifecycle states
 :page-prev-href: lifecycle.html
-:page-next-label: CLI
-:page-next-href: cli.html
+:page-next-label: Releases
+:page-next-href: releases.html
 
 A `PromptSpec` is the on-disk representation of a single prompt — one
 YAML file persisted in the prompt store. Every prompt the CLI, Studio,

--- a/docs/pages/core/releases.adoc
+++ b/docs/pages/core/releases.adoc
@@ -1,0 +1,135 @@
+= Releases
+:page-slug: releases
+:page-section: CORE
+:page-description: How prompt releases work — direct vs two-phase promotion, release metadata, and the bundle pipeline.
+:page-prev-label: Prompt specs
+:page-prev-href: prompt-specs.html
+:page-next-label: Java SDK
+:page-next-href: java-sdk.html
+
+A *release* freezes the current content of a `PromptSpec` at a named
+version. promptLM supports two distinct release pipelines, and they
+operate at different layers:
+
+* *prompt-level releases* — handled by the `prompt release` CLI command
+  (and the `/api/prompts/.../release` REST endpoints). Stamp the spec
+  with `x-release` metadata and produce a versioned record. Covered on
+  this page.
+* *bundle-release* — a separate CI workflow that packages the entire
+  prompt store as a Maven jar and publishes it to a registry. See the
+  in-repo reference at [`docs/release-classes.md`](https://github.com/promptLM/promptlm-app/blob/main/docs/release-classes.md).
+
+== Promotion modes
+
+The CLI and API select between two promotion modes via the
+`promptlm.release.promotion.mode` property.
+// source: apps/promptlm-cli/src/main/resources/application.yml:9-11
+
+[cols="1,3"]
+|===
+| Mode | Behaviour
+
+| `direct` (default)
+| `prompt release` performs the release in a single step — the spec is
+  released and the `x-release` extension is updated in one operation.
+
+| `pr_two_phase`
+| `prompt release` requests a release and opens a release PR. The
+  `prompt release complete` command finishes the release after the PR
+  is merged. The completion command is only available in this mode.
+|===
+// source: components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/ReleaseMetadata.java:47-48; PromptCommands.java:225-281
+
+Set via env var or `application.yml`:
+
+[source,bash]
+----
+export PROMPTLM_RELEASE_PROMOTION_MODE=pr_two_phase
+----
+// source: apps/promptlm-cli/src/main/resources/application.yml:11
+
+== CLI
+
+[source,bash]
+----
+promptlm-cli prompt release --id <prompt-id>
+----
+// source: apps/promptlm-cli/src/main/java/dev/promptlm/cli/PromptCommands.java:149-159
+
+In `direct` mode this returns the released version. In `pr_two_phase`
+mode it returns a string of the form `requested <version> pr#<number>`,
+and the release is not yet final.
+// source: PromptCommands.java:206-225
+
+After the release PR merges (two-phase only):
+
+[source,bash]
+----
+promptlm-cli prompt release complete --id <prompt-id> --pr <pr-number>
+----
+// source: PromptCommands.java:161-172
+
+The `prompt release complete` command is hidden by an availability
+provider — invoking it under `direct` mode fails with the message
+*"prompt release complete is only available when
+promptlm.release.promotion.mode=pr_two_phase"*.
+// source: PromptCommands.java:249-281
+
+== REST endpoints
+
+Both promotion paths are also exposed over HTTP for Studio and
+integrations:
+// source: components/promptlm-web-api/src/main/java/dev/promptlm/web/PromptSpecController.java:472-558
+
+[cols="1,3"]
+|===
+| Method + path | Purpose
+
+| `POST /api/prompts/{promptSpecId}/release`           | Release by id.
+| `POST /api/prompts/{group}/{name}/release`           | Release by group + name.
+| `POST /api/prompts/{promptSpecId}/release/complete`  | Complete a two-phase release (id).
+| `POST /api/prompts/{group}/{name}/release/complete`  | Complete a two-phase release (group + name).
+|===
+
+== Release metadata (`x-release`)
+
+A successful release writes a `ReleaseMetadata` payload into the
+spec's `x-release` extension. The shape:
+// source: components/promptlm-domain/src/main/java/dev/promptlm/domain/promptspec/ReleaseMetadata.java:34-48
+
+[cols="1,3"]
+|===
+| Field | Meaning
+
+| `state`                | `requested` or `released`.
+| `mode`                 | `direct` or `pr_two_phase` — the mode at release time.
+| `version`              | The version the spec was released at.
+| `tag`                  | Git tag that anchors the release (if any).
+| `branch`               | Branch the release was opened on (two-phase).
+| `prNumber`             | Release PR number (two-phase).
+| `prUrl`                | Release PR URL (two-phase).
+| `existing`             | `true` if the release already existed at request time.
+| `releasedSemanticHash` | The spec's `semanticHash` at the moment it reached `released`. Used by the UI to detect drift since release. Older records may carry `null` (treated as "unknown baseline").
+|===
+
+[NOTE]
+====
+`state` is constructed with the constants `ReleaseMetadata.STATE_REQUESTED`
+and `STATE_RELEASED`; `mode` uses `MODE_DIRECT` and `MODE_PR_TWO_PHASE`.
+Both are required (the record constructor rejects blank values).
+// source: ReleaseMetadata.java:45-57
+====
+
+== Bundle-release vs prompt-release
+
+A *prompt release* updates a single spec on disk. A *bundle-release* is
+a separate CI workflow — `bundle-release.yml` — that packages the entire
+prompts directory of a store repository as a Maven jar and publishes it
+to a registry (GitHub Packages by default, Artifactory / Nexus via
+`BUNDLE_RELEASE_MAVEN_URL`). Bundle-release runs in the user's prompt
+store repo, not in promptlm-app, and is triggered by GitHub's
+`release.created` event or `workflow_dispatch`.
+
+For the bundle-release reference (triggers, configuration knobs,
+acceptance test), see [`docs/release-classes.md`](https://github.com/promptLM/promptlm-app/blob/main/docs/release-classes.md)
+in the repo.

--- a/docs/pages/get-started/introduction.adoc
+++ b/docs/pages/get-started/introduction.adoc
@@ -41,7 +41,7 @@ SDKs into your own workflow.
 
 * *Client SDKs* — Java, TypeScript, and Python libraries that load
   released prompt JSON bundles in your application. Maintained in the
-  separate https://github.com/promptLM/promptlm-client-sdk[promptLM/promptlm-client-sdk]
+  separate https://github.com/promptLM/promptlm-clients[promptLM/promptlm-clients]
   repository.
   // source: README.adoc:168-192
 

--- a/docs/pages/integrations/llm-providers.adoc
+++ b/docs/pages/integrations/llm-providers.adoc
@@ -1,0 +1,106 @@
+= LLM providers
+:page-slug: llm-providers
+:page-section: INTEGRATIONS
+:page-description: How promptLM reaches LLM providers — Spring AI by default, with an optional LiteLLM gateway for everything else.
+:page-prev-label: macOS menubar
+:page-prev-href: macos-menubar.html
+:page-next-label: CLI
+:page-next-href: cli.html
+
+promptLM routes prompt execution through https://docs.spring.io/spring-ai/[Spring AI]
+by default. Two providers ship with the CLI distribution: OpenAI and
+Anthropic. For everything else, enable the LiteLLM gateway module,
+which fronts a long tail of providers behind an OpenAI-compatible API.
+
+== Default providers (Spring AI)
+
+The CLI's `application.yml` wires Spring AI's OpenAI and Anthropic
+clients to the standard environment variables:
+
+[cols="2,3"]
+|===
+| Spring property | Reads from
+
+| `spring.ai.openai.api-key`    | `OPENAI_API_KEY`
+| `spring.ai.anthropic.api-key` | `ANTHROPIC_API_KEY`
+|===
+// source: apps/promptlm-cli/src/main/resources/application.yml:21-27
+
+Routing between OpenAI and Anthropic is driven by the `vendor` and
+`model` fields on the spec's `request` — see
+xref:prompt-specs.html#_request_types[Request types].
+
+== LiteLLM gateway (opt-in)
+
+The `promptlm-execution-litellm` module fronts LiteLLM as a
+self-managed Docker container and routes prompts through it as an
+OpenAI-compatible proxy. Disabled by default.
+// source: components/promptlm-execution-litellm/src/main/resources/application.yml — enabled: false
+
+Enable with:
+
+[source,bash]
+----
+export PROMPTLM_GATEWAY_LITELLM_ENABLED=true
+----
+
+Or in `application.yml`:
+
+[source,yaml]
+----
+promptlm:
+  gateway:
+    litellm:
+      enabled: true
+----
+// source: components/promptlm-execution-litellm/src/main/java/dev/promptlm/execution/litellm/LiteLlmGatewayProperties.java:26-34
+
+=== Properties
+
+All keys are nested under `promptlm.gateway.litellm`.
+// source: LiteLlmGatewayProperties.java:26
+
+[cols="2,1,3"]
+|===
+| Property | Default | Purpose
+
+| `enabled`              | `false`                       | Master switch for the LiteLLM gateway.
+| `version`              | `v1.82.3.dev.6`               | LiteLLM Docker image tag. Used to compose `ghcr.io/berriai/litellm:<version>` unless `docker.image` is set.
+| `base-url`             | `http://localhost:4000`       | Base URL where LiteLLM is exposed.
+| `vendor`               | `litellm`                     | Prompt `vendor` identifier this gateway handles.
+| `model-aliases`        | empty map                     | Mapping from promptLM model id to LiteLLM route.
+| `environment`          | empty map                     | Extra environment variables passed to the LiteLLM container.
+|===
+// source: LiteLlmGatewayProperties.java:34-117
+
+=== Docker container management
+
+Nested under `promptlm.gateway.litellm.docker`:
+
+[cols="2,1,3"]
+|===
+| Property | Default | Purpose
+
+| `manage`            | `true`                       | Whether promptLM manages the container's lifecycle.
+| `image`             | (derived from `version`)     | Explicit image reference. Must use an immutable tag or digest — no `:latest`.
+| `container-name`    | `promptlm-litellm`           | Container name when promptLM spawns LiteLLM.
+| `port`              | `4000`                       | Host port to expose.
+| `network`           | (none)                       | Optional Docker network to attach to.
+| `readiness-timeout` | `30s`                        | How long to wait for LiteLLM readiness.
+| `readiness-path`    | `/health`                    | Path queried for readiness checks.
+|===
+// source: LiteLlmGatewayProperties.java:143-235
+
+=== Model discovery
+
+Nested under `promptlm.gateway.litellm.discovery`:
+
+[cols="2,1,3"]
+|===
+| Property | Default | Purpose
+
+| `enabled`     | `false`     | Pull the model list from LiteLLM at runtime.
+| `cache-ttl`  | `5m`        | How long the discovered list is cached.
+| `models-path` | `/v1/models` | Path queried to list available models.
+|===
+// source: LiteLlmGatewayProperties.java:237-277

--- a/docs/pages/reference/cli.adoc
+++ b/docs/pages/reference/cli.adoc
@@ -2,8 +2,10 @@
 :page-slug: cli
 :page-section: REFERENCE
 :page-description: All promptlm-cli commands and flags, verified against the source.
-:page-prev-label: Prompt specs
-:page-prev-href: prompt-specs.html
+:page-prev-label: LLM providers
+:page-prev-href: llm-providers.html
+:page-next-label: REST API
+:page-next-href: rest-api.html
 
 Every command, flag, and default below is taken directly from the
 picocli `@Command` / `@Option` annotations in the CLI module under

--- a/docs/pages/reference/config-schema.adoc
+++ b/docs/pages/reference/config-schema.adoc
@@ -1,0 +1,87 @@
+= Config schema
+:page-slug: config-schema
+:page-section: REFERENCE
+:page-description: Full configuration reference — environment variables and Spring properties read by the CLI and Studio.
+:page-prev-label: REST API
+:page-prev-href: rest-api.html
+
+This is the exhaustive reference for promptLM configuration. For the
+narrative version (what to set first, what's required) see
+xref:configuration.html[Configuration].
+
+== Environment variables
+
+The `.env.example` shipped at the repository root declares the
+variables the CLI and Studio expect.
+// source: .env.example
+
+[cols="2,1,3"]
+|===
+| Variable | Required | Purpose
+
+| `REPO_REMOTE_URL`                          | yes       | Base URL of the Git host's REST API endpoint (not the web UI). See xref:configuration.html#_environment_variables[Configuration § Environment variables] for the host → endpoint table.
+| `REPO_REMOTE_USERNAME`                     | yes       | Username or owner on the remote host.
+| `REPO_REMOTE_TOKEN`                        | yes       | Personal access token with `repo` scope.
+| `OPENAI_API_KEY`                           | yes       | Forwarded to Spring AI's OpenAI client and the `watch.open-ai-api-key` binding.
+| `ANTHROPIC_API_KEY`                        | no        | Forwarded to Spring AI's Anthropic client when the model catalog routes to Claude.
+| `REPO_REMOTE_ALLOW_LOOPBACK_HOST_ALIASES`  | no, default `true` | Permit loopback aliases when resolving the remote URL — useful for local Gitea setups.
+| `PROMPTLM_RELEASE_PROMOTION_MODE`          | no, default `direct` | Picks the prompt-release promotion mode. See xref:releases.html#_promotion_modes[Releases § Promotion modes].
+|===
+// source: apps/promptlm-cli/src/main/resources/application.yml:5-27; .env.example
+
+== `promptlm.*` properties
+
+Spring properties read by the CLI and Studio.
+
+[cols="3,1,3"]
+|===
+| Property | Default | Purpose
+
+| `promptlm.release.promotion.mode`                  | `direct`                  | `direct` or `pr_two_phase`. See xref:releases.html[Releases].
+| `promptlm.store.local.workspace-root`              | `${user.home}`            | Local directory under which prompt stores are created.
+| `promptlm.store.remote.username`                   | `${REPO_REMOTE_USERNAME}` | Username for the remote store client.
+| `promptlm.store.remote.token`                      | `${REPO_REMOTE_TOKEN}`    | Token for the remote store client.
+| `promptlm.store.remote.base-url`                   | `${REPO_REMOTE_URL}`      | Remote host API base URL.
+| `promptlm.store.remote.allow-loopback-host-aliases`| `true`                    | Permit loopback aliases when resolving the remote URL.
+|===
+// source: apps/promptlm-cli/src/main/resources/application.yml:9-19
+
+== `promptlm.gateway.litellm.*` properties
+
+The LiteLLM gateway module is opt-in. Full property reference, including
+nested `docker.*` and `discovery.*` groups, is on
+xref:llm-providers.html[LLM providers].
+// source: components/promptlm-execution-litellm/src/main/java/dev/promptlm/execution/litellm/LiteLlmGatewayProperties.java:26
+
+== Spring AI properties
+
+[cols="2,3"]
+|===
+| Property | Reads from
+
+| `spring.ai.openai.api-key`    | `OPENAI_API_KEY`
+| `spring.ai.anthropic.api-key` | `ANTHROPIC_API_KEY`
+|===
+// source: apps/promptlm-cli/src/main/resources/application.yml:21-27
+
+== Studio (`watch.*`) properties
+
+The Studio runtime reads two polling intervals plus the OpenAI key
+binding.
+
+[cols="2,1,3"]
+|===
+| Property | Default | Purpose
+
+| `watch.api-polling-interval`  | `10000` (ms) | How often Studio polls the API for project state.
+| `watch.dir-polling-interval`  | `1000` (ms)  | How often Studio polls the workspace directory.
+| `watch.open-ai-api-key`       | `${OPENAI_API_KEY}` | Bound from the env var; used by the Studio runtime path.
+|===
+// source: apps/promptlm-cli/src/main/resources/application.yml:3-7
+
+== Logging and management
+
+`logging.level.root` defaults to `warn` for the CLI distribution. JVM
+metric binders are disabled by default for fast startup; re-enable per
+your operational needs.
+// source: apps/promptlm-cli/src/main/resources/application.yml:36-45

--- a/docs/pages/reference/rest-api.adoc
+++ b/docs/pages/reference/rest-api.adoc
@@ -1,0 +1,105 @@
+= REST API
+:page-slug: rest-api
+:page-section: REFERENCE
+:page-description: HTTP surface exposed by Studio — controllers, paths, and the generated OpenAPI artifact.
+:page-prev-label: CLI
+:page-prev-href: cli.html
+:page-next-label: Config schema
+:page-next-href: config-schema.html
+
+xref:studio.html[Studio] is a Spring Boot application that exposes the
+backend over HTTP. The same endpoints back the CLI, the Studio
+frontend, and third-party integrations. They're grouped into four
+controllers.
+// source: components/promptlm-web-api/src/main/java/dev/promptlm/web/
+
+== Base paths
+
+[cols="1,3"]
+|===
+| Base path | Controller
+
+| `/api/prompts`      | `PromptSpecController` — read, write, release, execute, retire prompts; revisions; SSE execution events.
+| `/api/store`        | `PromptStoreController` — create / clone / switch active project; list owners; SSE store events.
+| `/api/llm`          | `ModelCatalogController` — LLM vendor + model catalog.
+| `/api/capabilities` | `CapabilitiesController` — what this Studio instance can do (feature flags).
+|===
+// source: PromptSpecController.java:74; PromptStoreController.java:57; ModelCatalogController.java:32; CapabilitiesController.java:25
+
+== Selected endpoints
+
+A non-exhaustive tour — the OpenAPI artifact below is the source of
+truth for every operation.
+
+[cols="2,3"]
+|===
+| Method + path | Purpose
+
+| `GET /api/prompts`                                       | List prompt specs in the active store.
+| `GET /api/prompts/{promptSpecId}`                        | Read a single spec by id.
+| `POST /api/prompts`                                      | Create a prompt draft.
+| `PUT /api/prompts/{promptSpecId}`                        | Update an existing spec.
+| `GET /api/prompts/template`                              | Default prompt template used when creating drafts.
+| `POST /api/prompts/{promptSpecId}/release`               | Release by id. Returns the spec carrying its `x-release` metadata. See xref:releases.html[Releases].
+| `POST /api/prompts/{promptSpecId}/release/complete`      | Complete a two-phase release.
+| `POST /api/prompts/execute`                              | Execute a free-form prompt (no spec on disk).
+| `POST /api/prompts/{promptSpecId}/execute`               | Execute a stored prompt.
+| `POST /api/prompts/{promptSpecId}/execute/retry`         | Retry a failed execution.
+| `POST /api/prompts/{promptSpecId}/push/retry`            | Retry a failed push to the remote store.
+| `PUT /api/prompts/{promptSpecId}/retire`                 | Retire a prompt.
+| `GET /api/prompts/{group}/{name}/revisions`              | List revisions for a spec.
+| `GET /api/prompts/{promptSpecId}/history`                | Older executions for a prompt.
+| `GET /api/prompts/{promptSpecId}/execution/events`       | Server-sent events stream for live execution updates.
+| `GET /api/prompts/stats`                                 | Aggregate prompt statistics.
+| `GET /api/prompts/groups`                                | Distinct prompt groups in the active store.
+|===
+// source: PromptSpecController.java — @GetMapping / @PostMapping / @PutMapping annotations
+
+[cols="2,3"]
+|===
+| Method + path | Purpose
+
+| `GET /api/store`                          | Active project, or 404 if none.
+| `POST /api/store`                         | Create a new prompt store.
+| `PUT /api/store`                          | Clone an existing remote store.
+| `GET /api/store/all`                      | List all projects.
+| `GET /api/store/owners`                   | Repository owners visible on the remote host.
+| `POST /api/store/connection`              | Connect to an existing repository.
+| `POST /api/store/switch/{projectId}`      | Switch the active project.
+| `GET /api/store/events/{operationId}`     | SSE stream for a long-running store operation.
+|===
+// source: PromptStoreController.java — @RequestMapping mappings
+
+[cols="2,3"]
+|===
+| Method + path | Purpose
+
+| `GET /api/llm/catalog`     | Vendor + model catalog used to populate dropdowns.
+| `GET /api/capabilities`    | Feature-flag style description of this Studio instance.
+|===
+// source: ModelCatalogController.java:48; CapabilitiesController.java:35
+
+== OpenAPI
+
+A full OpenAPI 3.1 document is generated as part of the webapp build at
+`apps/promptlm-webapp/target/generated/openapi/promptlm-webapp-openapi.json`.
+That artifact is the authoritative reference for request and response
+schemas, including operation IDs and OpenAPI tags.
+// source: apps/promptlm-webapp/target/generated/openapi/promptlm-webapp-openapi.json
+
+The same spec also drives the generated API client at
+`components/promptlm-api-client/`, used by the Studio frontend and the
+CLI.
+
+== Server-sent events
+
+Two SSE endpoints stream long-running operations rather than blocking
+on HTTP responses:
+
+* `GET /api/prompts/{promptSpecId}/execution/events` — execution
+  lifecycle and partial responses while a prompt runs.
+* `GET /api/store/events/{operationId}` — store operations (create,
+  clone, switch) that may span several seconds.
+
+Both produce `text/event-stream`.
+// source: PromptSpecController.java:932; PromptStoreController.java:234

--- a/docs/templates/partials/footer.html
+++ b/docs/templates/partials/footer.html
@@ -24,7 +24,7 @@
         <p class="footer-col-heading">Product</p>
         <a href="{{root}}docs.html#get-started">CLI</a>
         <a href="{{root}}docs.html#studio">Studio</a>
-        <a href="https://github.com/promptLM/promptlm-client-sdk">Java SDK</a>
+        <a href="https://github.com/promptLM/promptlm-clients">Java SDK</a>
         <a href="https://github.com/promptLM/promptlm-macos">macOS app</a>
         <a href="https://github.com/promptLM/promptlm-junit-gitea-artifactory">Test support</a>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -470,7 +470,7 @@ test(<span class="code-str">'summarizes ticket'</span>, () =&gt; {              
               <p class="footer-col-heading">Product</p>
               <a href="docs.html#get-started">CLI</a>
               <a href="docs.html#studio">Studio</a>
-              <a href="https://github.com/promptLM/promptlm-client-sdk">Java SDK</a>
+              <a href="https://github.com/promptLM/promptlm-clients">Java SDK</a>
               <a href="https://github.com/promptLM/promptlm-macos">macOS app</a>
               <a href="https://github.com/promptLM/promptlm-junit-gitea-artifactory">Test support</a>
             </div>


### PR DESCRIPTION
## Summary

Authors the seven remaining documentation pages so every item in `docs/nav.yml` resolves to a real, code-verified page — no greyed placeholders left.

### New pages

**Core**
- `releases.adoc` — direct vs `pr_two_phase` promotion, `ReleaseMetadata` shape (state / mode / version / tag / branch / prNumber / prUrl / existing / releasedSemanticHash), REST endpoints, and a pointer to `docs/release-classes.md` for bundle-release.

**Clients**
- `java-sdk.adoc` — install (Maven Central), `ClasspathPromptLoader` usage. Verified against `promptLM/promptlm-clients/client-sdk-java/README.md`.
- `typescript-sdk.adoc` — `@promptlm/client@0.1.0`, ESM + CJS builds, flagged WIP for 0.1.0.
- `python-sdk.adoc` — `promptlm-client` on PyPI, Python 3.10+, flagged WIP for 0.1.0.
- `macos-menubar.adoc` — `install.sh` flags, settings, paste flow with the 400ms clipboard restore.

**Integrations**
- `llm-providers.adoc` — Spring AI defaults (`spring.ai.openai.api-key`, `spring.ai.anthropic.api-key`), full `promptlm.gateway.litellm` property reference including the nested `docker.*` and `discovery.*` groups (derived from `LiteLlmGatewayProperties.java`).

**Reference**
- `rest-api.adoc` — controller tour for `/api/prompts`, `/api/store`, `/api/llm`, `/api/capabilities`, plus the two SSE endpoints. Points at the generated `promptlm-webapp-openapi.json` as the source of truth.
- `config-schema.adoc` — env vars, `promptlm.*` properties, `watch.*` Studio properties, Spring AI keys.

### nav.yml + chain

- Every CORE / CLIENTS / INTEGRATIONS / REFERENCE entry now has a slug.
- Dropped the standalone **PromptSpec schema** placeholder — fully covered by Prompt specs.
- Rewires prev/next end-to-end: Configuration → Lifecycle → Prompt specs → Releases → Java → TS → Python → macOS → LLM providers → CLI → REST API → Config schema. Verified by grep across all 16 pages.

### Drive-by fixes

- `introduction.adoc` and the marketing-site footer linked `promptLM/promptlm-client-sdk` — that repo doesn't exist. The actual SDK monorepo is `promptLM/promptlm-clients`. Fixed both.
- `docs/README.md` status note rewritten — 16 pages, no placeholders, explicit list of 0.1.0 cuts (Evaluations, JUnit test support, standalone PromptSpec schema).

### Out of scope

- The marketing footer still has a \"Test support\" link to `promptlm-junit-gitea-artifactory`. That's a marketing-site decision; happy to drop it in a follow-up if you want.

## Test plan

- [x] \`npm run docs:build\` — clean, 16 pages rendered.
- [x] Audited prev/next on every page — chain is consistent end-to-end (script in PR description).
- [x] Spot-checked the new pages against source for every \`// source:\` citation (LiteLlmGatewayProperties, ReleaseMetadata, PromptSpecController @\\\*Mapping annotations, the SDK READMEs fetched via the GitHub API).
- [x] Sidebar grep on rendered HTML — no \`Evaluations\` or \`JUnit\` left over.

Closes a major chunk of #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)