### PR TITLE
fix(webapp): use ${basedir} so web-ui-workspace profile actually activates

### DIFF
--- a/apps/promptlm-webapp/pom.xml
+++ b/apps/promptlm-webapp/pom.xml
@@ -266,7 +266,7 @@ limitations under the License.
             <id>web-ui-workspace</id>
             <activation>
                 <file>
-                    <exists>${project.basedir}/../../components/promptlm-web-ui/package.json</exists>
+                    <exists>${basedir}/../../components/promptlm-web-ui/package.json</exists>
                 </file>
             </activation>
             <properties>


### PR DESCRIPTION
## Summary

- Replace `${project.basedir}` with `${basedir}` inside `<activation><file><exists>` in `apps/promptlm-webapp/pom.xml`. Maven does not interpolate `${project.basedir}` during profile activation (it runs before the project model is built), so the `web-ui-workspace` profile was silently failing to activate.
- With the profile inactive, `promptlm.webapp.ui.skip` stayed `true`, all three `frontend-maven-plugin` executions logged `Skipping execution.`, and the webapp was packaged with the placeholder `index.html`.

## Trigger

Hetzner acceptance trial run [27362380053](https://github.com/promptLM/promptlm-app/actions/runs/27362380053) failed with:

```
UI bundle is missing: received placeholder HTML instead of built frontend assets.
Ensure promptlm-webapp is built with promptlm.webapp.ui.skip=false and the web UI workspace is available.
```

at `BackendFacadeInfraE2eTest.setUp:72` and `HappyPathUserJourneyTest.beforeAll:118`.

Maven's own warning prescribed the fix:

```
'profiles.profile[web-ui-workspace].activation.file.exists' Failed to interpolate file location
${project.basedir}/../../components/promptlm-web-ui/package.json for profile web-ui-workspace:
${project.basedir} expression not supported during profile activation, use ${basedir} instead
```

## Test plan

- [ ] Re-run the Acceptance Tests workflow against this branch and confirm `frontend-maven-plugin:install-node-and-npm`, `npm-install`, and `npm-build` actually run (no `Skipping execution.`).
- [ ] Confirm `BackendFacadeInfraE2eTest` and `HappyPathUserJourneyTest` reach their assertions instead of failing in setUp.
- [ ] Sanity-check that local `./build-full.sh` still builds the UI (it should — the profile now activates correctly in every flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)