### PR TITLE
fix(#309): blank new repos and New-prompt view (remove demo seed)

### DIFF
--- a/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleService.java
+++ b/components/promptlm-lifecycle/src/main/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleService.java
@@ -160,6 +160,15 @@ class DefaultPromptLifecycleService implements PromptLifecycleService {
 
     @Override
     public PromptSpec createDefaultPromptSpec() {
+        // Issue #309 — the New-prompt editor must open blank. Previously this method
+        // returned a demo "support-prompt" seed (name/group/description/messages/
+        // placeholders all pre-filled), which both (a) pre-populated the form in the
+        // web UI and (b) made it trivially easy for users to save the demo content
+        // into their own repo (e.g. as prompts/support/support-prompt/promptlm.yml)
+        // by accepting the defaults. We now return an empty draft with only the
+        // structural defaults (placeholder delimiters, sane parameter defaults,
+        // a `chat/completion` request shape with empty system/user message slots)
+        // so the editor presents truly blank fields.
         Map<String, Object> defaultParams = new HashMap<>();
         defaultParams.put("temperature", 0.7);
         defaultParams.put("maxTokens", 1024);
@@ -171,30 +180,30 @@ class DefaultPromptLifecycleService implements PromptLifecycleService {
         PromptSpec.Placeholders placeholders = new PromptSpec.Placeholders();
         placeholders.setStartPattern("{{");
         placeholders.setEndPattern("}}");
-        placeholders.setList(List.of(new PromptSpec.Placeholder("customer_name", "Taylor")));
+        placeholders.setList(List.of());
 
         Request request = ChatCompletionRequest.builder()
-                .withVendor("openai")
-                .withModel("gpt-4o")
+                .withVendor("")
+                .withModel("")
                 .withMessages(List.of(
                         ChatCompletionRequest.Message.builder()
                                 .withRole("system")
-                                .withContent("You are a helpful assistant.")
+                                .withContent("")
                                 .build(),
                         ChatCompletionRequest.Message.builder()
                                 .withRole("user")
-                                .withContent("Help the customer.")
+                                .withContent("")
                                 .build()
                 ))
                 .withParameters(defaultParams)
                 .build();
 
         return PromptSpec.builder()
-                .withGroup("support")
-                .withName("support-prompt")
+                .withGroup("")
+                .withName("")
                 .withVersion("1.0.0-SNAPSHOT")
                 .withRevision(1)
-                .withDescription("Assist support agents")
+                .withDescription("")
                 .withRequest(request)
                 .withPlaceholders(placeholders)
                 .build();

--- a/components/promptlm-lifecycle/src/test/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleServiceTest.java
+++ b/components/promptlm-lifecycle/src/test/java/dev/promptlm/lifecycle/application/DefaultPromptLifecycleServiceTest.java
@@ -189,21 +189,25 @@ class DefaultPromptLifecycleServiceTest {
     }
 
     @Test
-    void createDefaultPromptSpecReturnsCanonicalDraftTemplate() {
+    void createDefaultPromptSpecReturnsBlankDraftTemplate() {
+        // Issue #309 — the New-prompt editor must open blank. The template carries
+        // structural defaults (placeholder delimiters, parameter defaults, empty
+        // system/user message slots) but no demo content the user would have to
+        // overwrite (and could accidentally save into their repo verbatim).
         PromptSpec templateSpec = service.createDefaultPromptSpec();
 
-        assertThat(templateSpec.getGroup()).isEqualTo("support");
-        assertThat(templateSpec.getName()).isEqualTo("support-prompt");
-        assertThat(templateSpec.getDescription()).isEqualTo("Assist support agents");
+        assertThat(templateSpec.getGroup()).isEmpty();
+        assertThat(templateSpec.getName()).isEmpty();
+        assertThat(templateSpec.getDescription()).isEmpty();
 
         ChatCompletionRequest request = (ChatCompletionRequest) templateSpec.getRequest();
-        assertThat(request.getVendor()).isEqualTo("openai");
-        assertThat(request.getModel()).isEqualTo("gpt-4o");
+        assertThat(request.getVendor()).isEmpty();
+        assertThat(request.getModel()).isEmpty();
         assertThat(request.getMessages())
                 .extracting(ChatCompletionRequest.Message::getRole, ChatCompletionRequest.Message::getContent)
                 .containsExactly(
-                        tuple("system", "You are a helpful assistant."),
-                        tuple("user", "Help the customer.")
+                        tuple("system", ""),
+                        tuple("user", "")
                 );
         assertThat(request.getParameters()).containsEntry("maxTokens", 1024);
         assertThat(request.getParameters()).containsEntry("stream", false);
@@ -211,9 +215,7 @@ class DefaultPromptLifecycleServiceTest {
         assertThat(templateSpec.getPlaceholders()).isNotNull();
         assertThat(templateSpec.getPlaceholders().getStartPattern()).isEqualTo("{{");
         assertThat(templateSpec.getPlaceholders().getEndPattern()).isEqualTo("}}");
-        assertThat(templateSpec.getPlaceholders().getList())
-                .extracting(PromptSpec.Placeholder::getName, PromptSpec.Placeholder::getValue)
-                .containsExactly(tuple("customer_name", "Taylor"));
+        assertThat(templateSpec.getPlaceholders().getList()).isEmpty();
     }
 
     @Test

--- a/components/promptlm-openapi-examples/src/main/resources/openapi/examples/prompt-template.json
+++ b/components/promptlm-openapi-examples/src/main/resources/openapi/examples/prompt-template.json
@@ -1,26 +1,19 @@
 {
-  "name": "support-prompt",
-  "group": "support",
-  "description": "Assist support agents",
+  "name": "",
+  "group": "",
+  "description": "",
   "version": "1.0.0-SNAPSHOT",
   "revision": 1,
   "placeholders": {
     "startPattern": "{{",
     "endPattern": "}}",
-    "list": [
-      {
-        "name": "customer_name",
-        "value": "Taylor"
-      }
-    ],
-    "defaults": {
-      "customer_name": "Taylor"
-    }
+    "list": [],
+    "defaults": {}
   },
   "request": {
     "type": "chat/completion",
-    "vendor": "openai",
-    "model": "gpt-4o",
+    "vendor": "",
+    "model": "",
     "parameters": {
       "temperature": 0.7,
       "maxTokens": 1024,
@@ -32,11 +25,11 @@
     "messages": [
       {
         "role": "system",
-        "content": "You are a helpful assistant."
+        "content": ""
       },
       {
         "role": "user",
-        "content": "Help the customer."
+        "content": ""
       }
     ]
   }

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorReleaseToggleTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/ZipFileRepositoryTemplateExtractorReleaseToggleTest.java
@@ -60,7 +60,10 @@ class ZipFileRepositoryTemplateExtractorReleaseToggleTest {
         assertThat(tempDir.resolve("promptlm.yml")).exists();
         assertThat(tempDir.resolve(".promptlm/metadata.json")).exists();
         assertThat(tempDir.resolve(".promptlm/prompts-meta.json")).exists();
-        assertThat(tempDir.resolve("prompts/examples/hello.md")).exists();
+        // Issue #309 — the live template no longer seeds prompts/examples/hello.md;
+        // the only prompts/ entry now is the .gitignore placeholder that keeps the
+        // empty directory in the zip. We assert on that to stay aligned with reality.
+        assertThat(tempDir.resolve("prompts/.gitignore")).exists();
         assertThat(tempDir.resolve("README.md")).exists();
 
         // Mode 2 release infrastructure must be absent.
@@ -143,7 +146,7 @@ class ZipFileRepositoryTemplateExtractorReleaseToggleTest {
             builder.write(".promptlm/metadata.json", "{}");
             builder.write(".promptlm/prompts-meta.json", "{}");
             builder.write(".promptlm/artifacts.toml", "[project]");
-            builder.write("prompts/examples/hello.md", "hello");
+            builder.write("prompts/.gitignore", "");
             builder.write(".github/workflows/build-artifacts.yml", "name: build");
             builder.write(".github/workflows/bundle-release.yml", "name: bundle-release");
             builder.write("tools/release/build-artifacts", "#!/bin/sh");

--- a/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
+++ b/components/promptlm-web-api/src/test/java/dev/promptlm/web/PromptSpecControllerWebMvcTest.java
@@ -116,29 +116,33 @@ class PromptSpecControllerWebMvcTest {
     private ApplicationEvents applicationEvents;
 
     @Test
-    void getDefaultTemplateReturnsCanonicalDraftSeed() throws Exception {
+    void getDefaultTemplateReturnsBlankDraftSeed() throws Exception {
+        // Issue #309 — the New-prompt editor must open blank. The /template endpoint
+        // hands the UI a draft with structural defaults only (placeholder delimiters,
+        // empty system/user message slots) and no demo strings that would either
+        // pre-fill the form or get saved verbatim into the user's repo.
         PromptSpec.Placeholders placeholders = new PromptSpec.Placeholders();
         placeholders.setStartPattern("{{");
         placeholders.setEndPattern("}}");
-        placeholders.setList(List.of(new PromptSpec.Placeholder("customer_name", "Taylor")));
+        placeholders.setList(List.of());
 
         PromptSpec template = PromptSpec.builder()
-                .withGroup("support")
-                .withName("support-prompt")
+                .withGroup("")
+                .withName("")
                 .withVersion("1.0.0-SNAPSHOT")
                 .withRevision(1)
-                .withDescription("Assist support agents")
+                .withDescription("")
                 .withRequest(ChatCompletionRequest.builder()
-                        .withVendor("openai")
-                        .withModel("gpt-4o")
+                        .withVendor("")
+                        .withModel("")
                         .withMessages(List.of(
                                 ChatCompletionRequest.Message.builder()
                                         .withRole("system")
-                                        .withContent("You are a helpful assistant.")
+                                        .withContent("")
                                         .build(),
                                 ChatCompletionRequest.Message.builder()
                                         .withRole("user")
-                                        .withContent("Help the customer.")
+                                        .withContent("")
                                         .build()))
                         .build())
                 .withPlaceholders(placeholders)
@@ -148,19 +152,18 @@ class PromptSpecControllerWebMvcTest {
         mockMvc.perform(get("/api/prompts/template"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.name").value("support-prompt"))
-                .andExpect(jsonPath("$.group").value("support"))
-                .andExpect(jsonPath("$.description").value("Assist support agents"))
-                .andExpect(jsonPath("$.request.vendor").value("openai"))
-                .andExpect(jsonPath("$.request.model").value("gpt-4o"))
+                .andExpect(jsonPath("$.name").value(""))
+                .andExpect(jsonPath("$.group").value(""))
+                .andExpect(jsonPath("$.description").value(""))
+                .andExpect(jsonPath("$.request.vendor").value(""))
+                .andExpect(jsonPath("$.request.model").value(""))
                 .andExpect(jsonPath("$.request.messages[0].role").value("system"))
-                .andExpect(jsonPath("$.request.messages[0].content").value("You are a helpful assistant."))
+                .andExpect(jsonPath("$.request.messages[0].content").value(""))
                 .andExpect(jsonPath("$.request.messages[1].role").value("user"))
-                .andExpect(jsonPath("$.request.messages[1].content").value("Help the customer."))
+                .andExpect(jsonPath("$.request.messages[1].content").value(""))
                 .andExpect(jsonPath("$.placeholders.startPattern").value("{{"))
                 .andExpect(jsonPath("$.placeholders.endPattern").value("}}"))
-                .andExpect(jsonPath("$.placeholders.list[0].name").value("customer_name"))
-                .andExpect(jsonPath("$.placeholders.list[0].value").value("Taylor"));
+                .andExpect(jsonPath("$.placeholders.list").isEmpty());
     }
 
     @Test

--- a/components/promptlm-web-ui/src/features/prompt-editor/__tests__/draftState.test.ts
+++ b/components/promptlm-web-ui/src/features/prompt-editor/__tests__/draftState.test.ts
@@ -70,7 +70,72 @@ describe('promptEditorReducer', () => {
   });
 });
 
+describe('createEmptyPromptDraft', () => {
+  // Issue #309 — the New-prompt view must open blank. The empty draft is what
+  // the editor falls back to before the backend template lands and what it
+  // also lands on once the backend returns the blank /api/prompts/template
+  // payload (see DefaultPromptLifecycleService#createDefaultPromptSpec).
+  it('starts with blank name, group, description, messages and placeholders', () => {
+    const state = createEmptyPromptDraft();
+
+    expect(state.draft.name).toBe('');
+    expect(state.draft.group).toBe('');
+    expect(state.draft.description).toBe('');
+    expect(state.draft.request.vendor).toBe('');
+    expect(state.draft.request.model).toBe('');
+    expect(state.draft.request.messages).toHaveLength(2);
+    expect(state.draft.request.messages[0]?.role).toBe('system');
+    expect(state.draft.request.messages[0]?.content).toBe('');
+    expect(state.draft.request.messages[1]?.role).toBe('user');
+    expect(state.draft.request.messages[1]?.content).toBe('');
+    expect(state.draft.placeholders.list).toEqual([]);
+    expect(state.draft.placeholders.startPattern).toBe('{{');
+    expect(state.draft.placeholders.endPattern).toBe('}}');
+    expect(state.evaluationEnabled).toBe(false);
+  });
+});
+
 describe('createPromptDraftFromPrompt', () => {
+  // Issue #309 — the New-prompt editor hydrates from the backend `/template`
+  // payload. That payload is now blank by design, and the hydration must not
+  // re-introduce demo content (name/group/messages/placeholders).
+  it('keeps all fields blank when the backend template is blank', () => {
+    const blankTemplate: PromptSpec = {
+      name: '',
+      group: '',
+      description: '',
+      version: '1.0.0-SNAPSHOT',
+      revision: 1,
+      request: {
+        type: 'chat/completion',
+        vendor: '',
+        model: '',
+        messages: [
+          { role: 'system', content: '' },
+          { role: 'user', content: '' },
+        ],
+      } as PromptSpec['request'],
+      placeholders: {
+        startPattern: '{{',
+        endPattern: '}}',
+        list: [],
+      },
+    } as PromptSpec;
+
+    const state = createPromptDraftFromPrompt(blankTemplate);
+
+    expect(state.draft.name).toBe('');
+    expect(state.draft.group).toBe('');
+    expect(state.draft.description).toBe('');
+    expect(state.draft.request.vendor).toBe('');
+    expect(state.draft.request.model).toBe('');
+    expect(state.draft.request.messages).toHaveLength(2);
+    expect(state.draft.request.messages[0]?.content).toBe('');
+    expect(state.draft.request.messages[1]?.content).toBe('');
+    expect(state.draft.placeholders.list).toEqual([]);
+    expect(state.evaluationEnabled).toBe(false);
+  });
+
   it('hydrates evaluation definitions from prompt extensions', () => {
     const prompt: PromptSpec = {
       id: 'prompt-1',

--- a/components/repository-template/repo-resources/.promptlm/metadata.json
+++ b/components/repository-template/repo-resources/.promptlm/metadata.json
@@ -6,16 +6,7 @@
     "created": "{{CREATED_AT}}",
     "updated": "{{CREATED_AT}}"
   },
-  "prompts": [
-    {
-      "id": "hello",
-      "name": "hello",
-      "group": "examples",
-      "version": "1.0.0",
-      "file": "prompts/examples/hello.md",
-      "status": "active"
-    }
-  ],
+  "prompts": [],
   "metadata": {
     "format_version": "1.0",
     "generator": "promptLM",

--- a/components/repository-template/repo-resources/prompts/examples/hello.md
+++ b/components/repository-template/repo-resources/prompts/examples/hello.md
@@ -1,9 +1,0 @@
-# Hello
-
-A minimal placeholder prompt shipped with the promptLM repository template so the
-release-artifact contract is satisfied out of the box. Replace this file with your
-own prompts under `prompts/` and update `.promptlm/metadata.json` accordingly.
-
-## Prompt
-
-You are a helpful assistant. Greet the user warmly and ask how you can help today.

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateActSmokeTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateActSmokeTest.java
@@ -60,6 +60,13 @@ class RepositoryTemplateActSmokeTest {
             Path repositoryDir = tempDir.resolve("template-repo").toAbsolutePath();
             Files.createDirectories(repositoryDir);
             extractRepositoryTemplate(repositoryDir);
+            // Issue #309 — the repository template now ships with an empty prompts/
+            // directory (only `.gitignore` survives the zip round-trip). The
+            // validate-prompts.sh job is designed to fail on empty prompts/ so
+            // releases cannot ship a content-free bundle. Seed a synthetic prompt
+            // here so the smoke test still exercises the workflow without
+            // re-introducing demo content into the shipped template.
+            seedSmokePrompt(repositoryDir);
 
             initializeGitRepository(repositoryDir, tempDir);
             Path bareRemoteRepository = createBareRemote(repositoryDir, tempDir);
@@ -273,6 +280,33 @@ class RepositoryTemplateActSmokeTest {
                 }
             }
         }
+    }
+
+    /**
+     * Drop a minimal, valid {@code promptlm.yml} prompt manifest into the
+     * extracted template so {@code validate-prompts.sh} has something to validate.
+     * Mirrors the smallest shape the script will accept (id/name/group/version/
+     * request top-level fields). Issue #309 removed the demo {@code hello.md}
+     * seed from the shipped template; this fixture is test-only and must not
+     * leak into anything the user ever sees.
+     */
+    private static void seedSmokePrompt(Path repositoryDir) throws IOException {
+        Path promptFile = repositoryDir.resolve("prompts").resolve("smoke").resolve("smoke-prompt").resolve("promptlm.yml");
+        Files.createDirectories(promptFile.getParent());
+        String content = """
+                id: smoke/smoke-prompt
+                name: smoke-prompt
+                group: smoke
+                version: 1.0.0-SNAPSHOT
+                request:
+                  type: chat/completion
+                  vendor: openai
+                  model: gpt-4o-mini
+                  messages:
+                    - role: user
+                      content: smoke
+                """;
+        Files.writeString(promptFile, content, StandardCharsets.UTF_8);
     }
 
     private static void initializeGitRepository(Path repositoryDir, Path tempDir) throws Exception {

--- a/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateZipContentsTest.java
+++ b/components/repository-template/src/test/java/dev/promptlm/repository/template/RepositoryTemplateZipContentsTest.java
@@ -44,6 +44,9 @@ class RepositoryTemplateZipContentsTest {
                 }
             }
 
+            // Issue #309 — a freshly provisioned repo must start blank: no demo
+            // prompt files under prompts/. Only the `.gitignore` placeholder is
+            // shipped so the empty directory survives the zip round-trip.
             Set<String> expectedEntries = new TreeSet<>(List.of(
                     ".github/workflows/build-artifacts.yml",
                     ".github/workflows/bundle-release.yml",
@@ -56,7 +59,6 @@ class RepositoryTemplateZipContentsTest {
                     "pom.xml",
                     "promptlm.yml",
                     "prompts/.gitignore",
-                    "prompts/examples/hello.md",
                     "scripts/package-prompts.sh",
                     "scripts/validate-prompts.sh",
                     "tools/release/build-artifacts",
@@ -64,6 +66,14 @@ class RepositoryTemplateZipContentsTest {
             ));
 
             assertEquals(expectedEntries, actualEntries);
+
+            // Defensive guard: nothing under prompts/ may ship as a seeded example.
+            for (String entry : actualEntries) {
+                if (entry.startsWith("prompts/") && !entry.equals("prompts/.gitignore")) {
+                    throw new AssertionError(
+                            "Repository template must not seed example prompts (#309), found: " + entry);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #309.

Both surfaces that pre-populated demo content now start blank:

- **Repository template** (`components/repository-template/repo-resources/`): the `prompts/examples/hello.md` seed and its matching entry in `.promptlm/metadata.json` are removed. A freshly provisioned repo ships with an empty `prompts/` directory — only the `.gitignore` placeholder survives the zip round-trip so the empty directory is preserved.
- **`/api/prompts/template`** (`DefaultPromptLifecycleService#createDefaultPromptSpec`): returns a blank draft — empty name/group/description/messages/placeholders — instead of the "support-prompt" / "Help the customer." demo. Structural defaults (placeholder delimiters, sane parameter defaults, `chat/completion` request shape with empty system/user message slots) are preserved so the web-ui editor renders a valid empty form.

The web-ui `/prompts/new` view consumes the template via `usePromptDraftTemplate` and hydrates the editor through `createPromptDraftFromPrompt` — with a blank template payload, every field opens empty without any UI-side change.

### Backwards compatibility

Existing repositories are **not** touched. Only freshly provisioned repos see the change. Users who already have a `support-prompt` from earlier seeding keep it.

## Investigation notes

The issue's pointer (`prompts/examples/hello.md`) and observed symptom (`prompts/support/support-prompt.toml`) initially looked contradictory — there is no `support-prompt.toml` in the template. They turned out to describe two independent seeds:

- `hello.md` is the literal seed file in the repo template zip.
- `support-prompt` came from `DefaultPromptLifecycleService.createDefaultPromptSpec()` pre-filling the New-prompt form, which a user can then save verbatim to their repo (producing the `support-prompt/promptlm.yml` they observed in `~/dev/rpmptlm/repos/test10`).

Both are fixed here.

## Changes

- `components/promptlm-lifecycle/.../DefaultPromptLifecycleService.java` — `createDefaultPromptSpec` returns blank fields with structural defaults.
- `components/repository-template/repo-resources/prompts/examples/hello.md` — deleted.
- `components/repository-template/repo-resources/.promptlm/metadata.json` — `prompts` array emptied.
- `components/promptlm-openapi-examples/.../prompt-template.json` — mirrors the new blank shape.

## Test plan

- [x] `DefaultPromptLifecycleServiceTest` updated to assert the blank template.
- [x] `PromptSpecControllerWebMvcTest` updated to assert the `/api/prompts/template` returns blank fields.
- [x] `RepositoryTemplateZipContentsTest` no longer expects `prompts/examples/hello.md`, plus a defensive guard that fails if anything other than `prompts/.gitignore` ever ships under `prompts/`.
- [x] `ZipFileRepositoryTemplateExtractorReleaseToggleTest` synthetic archive uses `prompts/.gitignore` (the marker that actually ships) instead of a fake hello.md.
- [x] `RepositoryTemplateActSmokeTest` seeds a test-only `smoke-prompt/promptlm.yml` after extraction so `validate-prompts.sh` has something to validate — the script's "empty `prompts/` is a release-time error" contract is preserved.
- [x] `draftState.test.ts` (web-ui) — new regression tests assert (1) `createEmptyPromptDraft` starts blank, (2) `createPromptDraftFromPrompt` keeps every field blank when fed a blank backend template.
- [x] Local Maven runs of the affected modules (lifecycle, web-api, repository-template, store-github, cli, webapp) all green.
- [x] Local web-ui prompt-editor vitest suite (158 tests across 21 files) all green.

## Decisions

- **Empty system/user message slots are kept in the blank template.** The editor's `createEmptyPromptDraft` does the same; this matches the existing UI behavior of always showing a `system` and `user` row in the messages section.
- **`validate-prompts.sh` is unchanged.** Failing on empty `prompts/` at release time is the right contract — users releasing a content-free bundle is a bug, not a feature. The act smoke test seeds a fixture so it can still exercise the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)