### PR TITLE
chore(release): empty <relativePath/> in apps/*/pom.xml (#317)

### DIFF
--- a/apps/promptlm-cli/pom.xml
+++ b/apps/promptlm-cli/pom.xml
@@ -7,7 +7,7 @@
         <groupId>dev.promptlm</groupId>
         <artifactId>promptlm-app</artifactId>
         <version>0.1.0-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath/>
     </parent>
 
     <artifactId>promptlm-cli</artifactId>

--- a/apps/promptlm-webapp/pom.xml
+++ b/apps/promptlm-webapp/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
         <groupId>dev.promptlm</groupId>
         <artifactId>promptlm-app</artifactId>
         <version>0.1.0-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath/>
     </parent>
 
     <artifactId>promptlm-webapp</artifactId>


### PR DESCRIPTION
## Summary

Empty the `<relativePath/>` element on the `<parent>` block in `apps/promptlm-cli/pom.xml` and `apps/promptlm-webapp/pom.xml` (Step 1 of #317).

The two app modules pointed `relativePath` at `../../pom.xml`. In the new release pipeline (`release.yml` → `promptLM/.github` reusable, see #315), the native build legs run each app module without the aggregator working tree alongside it, so the parent has to resolve from the local m2 cache (reactor build) or from the registry (standalone). Self-closing `<relativePath/>` is the canonical way to tell Maven "do not look on the filesystem" while keeping reactor parent resolution working.

This unblocks the 4-target dry-run dispatch tracked by #317 (linux/x64, linux/arm64, macos/arm64, windows/x64; macos/x64 and windows/arm64 are descoped via #350 and #346).

## Test plan

- [x] `./mvnw -pl apps/promptlm-cli -am install -DskipTests=true -Dlicense.skip=true` succeeds locally
- [x] `./mvnw -pl apps/promptlm-cli help:effective-pom` resolves cleanly
- [ ] CI green on this PR
- [ ] Follow-up: dispatch `Release` with `release_type=patch`, `dry-run=true` and triage 4-cell matrix

Refs #317.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>