### PR TITLE
fix(store): clean worktree before checkout development (#317)

### DIFF
--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/Git.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/Git.java
@@ -522,6 +522,27 @@ class Git {
 
     }
 
+    /**
+     * Discard every uncommitted change in the working tree and index, plus every untracked
+     * file or directory (excluding {@code .git/}). Used by recovery paths that need to leave
+     * the working tree in a known-clean state before switching branches — e.g. the release
+     * flow's {@code finally} block that returns to {@code development} after a release.
+     *
+     * <p>Equivalent to {@code git reset --hard HEAD && git clean -fd}. Do <strong>not</strong>
+     * call this on user-facing write paths (save / commitLocally) where uncommitted edits may
+     * legitimately exist and must not be silently dropped.
+     */
+    public void resetHardAndClean(File repo) {
+        try (org.eclipse.jgit.api.Git git = org.eclipse.jgit.api.Git.open(repo)) {
+            git.reset().setMode(org.eclipse.jgit.api.ResetCommand.ResetType.HARD).call();
+            git.clean().setCleanDirectories(true).setForce(true).call();
+        } catch (IOException e) {
+            throw new GitException("Failed to open store for reset/clean", e);
+        } catch (GitAPIException e) {
+            throw new GitException("Failed to reset/clean working tree", e);
+        }
+    }
+
     public void cherryPick(String devBranch, PromptSpec completed, File repo) {
         try (org.eclipse.jgit.api.Git git = org.eclipse.jgit.api.Git.open(repo)) {
             Repository repository = git.getRepository();

--- a/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubPromptStore.java
+++ b/components/promptlm-store/promptlm-store-github/src/main/java/dev/promptlm/store/github/GitHubPromptStore.java
@@ -465,6 +465,13 @@ public class GitHubPromptStore implements PromptStore {
         } catch (Exception e) {
             throw new GitException("Failed to release prompt %s".formatted(promptSpec.getId()), e);
         } finally {
+            // Recovery: a release that committed in mid-flight can leave the index or working
+            // tree out of sync with HEAD (e.g. stale stat info from `addAllAndCommit`'s file
+            // walk), which makes JGit's checkout treat the branch switch as a conflict and
+            // throws CheckoutConflictException on `prompts/<group>/<name>/promptlm.yml`. Reset
+            // hard + clean before switching guarantees a clean working tree for the checkout.
+            // See #317 (native smoke release failure) and #372 (worktree concurrency).
+            git.resetHardAndClean(repo);
             git.checkoutBranch(DEV_BRANCH, repo);
         }
     }

--- a/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitHubPromptStoreReleaseFlowTest.java
+++ b/components/promptlm-store/promptlm-store-github/src/test/java/dev/promptlm/store/github/GitHubPromptStoreReleaseFlowTest.java
@@ -360,6 +360,10 @@ class GitHubPromptStoreReleaseFlowTest {
         }
 
         @Override
+        public void resetHardAndClean(File repo) {
+        }
+
+        @Override
         public void checkoutOrCreateBranch(String branchName, File repo) {
             createdBranches.add(branchName);
         }


### PR DESCRIPTION
## Summary

Fix the `native smoke (linux/x64)` failure from the v0.1.0 release dry-run (#317).

`GitHubPromptStore.requestDirectRelease`'s `finally` block calls `git.checkoutBranch(DEV_BRANCH, repo)` to return the working tree to `development` after the release flow runs. JGit's `CheckoutCommand` compares the working tree against HEAD via a stat cache, and when `addAllAndCommit`'s file-walk-based staging leaves the index's stat info in a state JGit considers "dirty" — even though we just committed and pushed — the checkout throws `CheckoutConflictException` on `prompts/<group>/<name>/promptlm.yml`.

Stack trace from run [`27373460789`](https://github.com/promptLM/promptlm-app/actions/runs/27373460789):

```
CommandExecutionException: Unable to execute command prompt release
  → InvocationTargetException
    → dev.promptlm.store.github.GitException: Failed to checkout branch development
      → org.eclipse.jgit.api.errors.CheckoutConflictException:
        Checkout conflict with files: prompts/native-smoke/native-cli-prompt/promptlm.yml
        at GitHubPromptStore.requestDirectRelease(GitHubPromptStore.java:468)  // the finally
```

### Fix

Production-side (Fix B per the issue triage):

1. Add `Git.resetHardAndClean(File repo)` — JGit `ResetCommand` HARD + `CleanCommand` (`-fd`). Documented as recovery-only; user-facing save / `commitLocally` paths must NOT call it (they intentionally stage uncommitted edits per #352).
2. Call it in `requestDirectRelease`'s `finally` immediately before the `checkoutBranch(DEV_BRANCH, repo)`.

Scope is deliberately limited to the direct-release recovery path — the PR two-phase flow is not failing and is not touched.

### Why Fix B over Fix A (per-test `@TempDir`)

The test (`NativeCliSmokeTest`) already isolates per-method state via `@BeforeEach` and a fresh `case-<runId>` subdirectory + Gitea repo. There is no cross-test leakage to fix. The defect is in production.

### Cross-reference

This is the same class of bug #372 ("Concurrency on the git working tree") flags: the working tree is a shared mutable resource and the release flow's recovery path assumes a clean state that isn't guaranteed. Once #372 lands its per-project write lock or per-request worktree, this hygiene step becomes belt-and-suspenders; until then it's the suspenders.

Refs #317
Refs #372

## Test plan

- [x] `mvn test` in `components/promptlm-store/promptlm-store-github` — 104/104 pass (`GitHubPromptStoreReleaseFlowTest` is the most directly affected; updated `RecordingGit` to override the new method).
- [ ] CI `verify` (JVM + acceptance) green on this branch.
- [ ] After merge: re-dispatch the Release workflow with `release_type=patch`, `dry_run=true` and confirm `native smoke (linux/x64)` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)